### PR TITLE
feat(ingestion): parser + section schema (EPIC 2)

### DIFF
--- a/docs/process/git_workflow.md
+++ b/docs/process/git_workflow.md
@@ -281,7 +281,26 @@ Example for issue `#10`:
 git switch -c feat/10-repo-skeleton
 ```
 
-### Step 3: make changes locally and commit
+### Step 3: make changes locally
+
+Before committing, run the local quality gates so your branch matches the repository workflow and GitHub Actions behavior as closely as possible.
+
+Recommended commands:
+
+```bash
+uv sync
+uv run pre-commit run --all-files
+uv run pytest -q
+```
+
+Notes:
+
+- `uv sync` ensures the local environment matches the project lockfile.
+- `uv run pre-commit run --all-files` runs the configured formatting and lint hooks consistently.
+- `uv run pytest -q` runs the test suite inside the project environment.
+- If `pre-commit` modifies files, stage them again with `git add ...` before committing.
+
+### Step 4: commit
 
 Example commit message:
 
@@ -291,7 +310,7 @@ feat: create repo skeleton and development conventions
 
 This matches a clean Conventional Commits style.
 
-### Step 4: push the branch
+### Step 5: push the branch
 
 ```bash
 git push -u origin feat/10-repo-skeleton
@@ -340,6 +359,8 @@ This lets GitHub automatically close the linked issue when the PR is merged.
 - no accidental junk files are committed
 - file structure is correct
 - package/module naming is correct
+- `uv run pre-commit run --all-files` passes locally
+- `uv run pytest -q` passes locally
 - issue reference is present in the PR description
 
 ---
@@ -360,7 +381,15 @@ git pull origin main
 git switch -c feat/10-repo-skeleton
 ```
 
-Work locally, then:
+Work locally, then run the repository checks:
+
+```bash
+uv sync
+uv run pre-commit run --all-files
+uv run pytest -q
+```
+
+If hooks modify files, stage them again and continue:
 
 ```bash
 git add .
@@ -425,6 +454,7 @@ git fetch --prune
 A task issue is done when:
 
 - implementation is committed,
+- local quality checks pass (`uv run pre-commit run --all-files` and `uv run pytest -q`),
 - branch is pushed,
 - PR is opened,
 - PR includes `Closes #<issue-number>`,
@@ -441,6 +471,8 @@ A task issue is done when:
 - Keep branches short-lived.
 - Keep PRs focused.
 - Prefer clean history over large mixed commits.
+- Run `uv run pre-commit run --all-files` before committing.
+- Run `uv run pytest -q` before opening or updating a PR.
 - Implement sub-issues, not the Epic directly.
 - When creating a sub-issue from an Epic, choose **TASK — Work item**.
 - Use `git switch` instead of `git checkout` for branch changes.

--- a/src/supportdoc_rag_chatbot/ingestion/__init__.py
+++ b/src/supportdoc_rag_chatbot/ingestion/__init__.py
@@ -1,0 +1,19 @@
+"""Ingestion pipeline building blocks for SupportDoc RAG Chatbot."""
+
+from .chunker import chunk_section, chunk_sections, estimate_token_count
+from .parser import parse_document, parse_manifest
+from .schemas import ChunkRecord, IngestReport, ManifestRecord, SectionRecord
+from .validator import validate_corpus
+
+__all__ = [
+    "ChunkRecord",
+    "IngestReport",
+    "ManifestRecord",
+    "SectionRecord",
+    "chunk_section",
+    "chunk_sections",
+    "estimate_token_count",
+    "parse_document",
+    "parse_manifest",
+    "validate_corpus",
+]

--- a/src/supportdoc_rag_chatbot/ingestion/chunk_docs.py
+++ b/src/supportdoc_rag_chatbot/ingestion/chunk_docs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .chunker import chunk_sections
+from .jsonl import read_jsonl, write_jsonl
+from .schemas import SectionRecord
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Chunk sections.jsonl into chunks.jsonl")
+    parser.add_argument("--input", required=True, type=Path, help="Path to sections.jsonl")
+    parser.add_argument("--output", required=True, type=Path, help="Path to chunks.jsonl")
+    parser.add_argument("--max-tokens", type=int, default=350)
+    parser.add_argument("--overlap-tokens", type=int, default=50)
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    sections = [SectionRecord.from_dict(payload) for payload in read_jsonl(args.input)]
+    chunks = list(
+        chunk_sections(
+            sections,
+            max_tokens=args.max_tokens,
+            overlap_tokens=args.overlap_tokens,
+        )
+    )
+    count = write_jsonl(args.output, chunks)
+    print(f"Wrote {count} chunks to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/supportdoc_rag_chatbot/ingestion/chunker.py
+++ b/src/supportdoc_rag_chatbot/ingestion/chunker.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Iterable, Iterator
+
+from .schemas import ChunkRecord, SectionRecord
+
+TOKEN_RE = re.compile(r"\w+|[^\w\s]", re.UNICODE)
+
+
+def estimate_token_count(text: str) -> int:
+    return len(list(TOKEN_RE.finditer(text)))
+
+
+def _token_spans(text: str) -> list[tuple[int, int]]:
+    return [(match.start(), match.end()) for match in TOKEN_RE.finditer(text)]
+
+
+def _stable_chunk_id(section: SectionRecord, *, chunk_index: int, start: int, end: int) -> str:
+    digest = hashlib.sha1(
+        f"{section.snapshot_id}|{section.doc_id}|{section.section_id}|{chunk_index}|{start}|{end}".encode(
+            "utf-8"
+        )
+    ).hexdigest()[:12]
+    return f"{section.doc_id}-chk-{chunk_index:04d}-{digest}"
+
+
+def chunk_section(
+    section: SectionRecord,
+    *,
+    max_tokens: int = 350,
+    overlap_tokens: int = 50,
+) -> list[ChunkRecord]:
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be > 0")
+    if overlap_tokens < 0:
+        raise ValueError("overlap_tokens must be >= 0")
+    if overlap_tokens >= max_tokens:
+        raise ValueError("overlap_tokens must be smaller than max_tokens")
+
+    spans = _token_spans(section.text)
+    if not spans:
+        return []
+
+    chunks: list[ChunkRecord] = []
+    start_index = 0
+    chunk_index = 0
+
+    while start_index < len(spans):
+        end_index = min(start_index + max_tokens, len(spans))
+        start_char = spans[start_index][0]
+        end_char = spans[end_index - 1][1]
+        chunk_text = section.text[start_char:end_char].strip()
+
+        if chunk_text:
+            chunks.append(
+                ChunkRecord(
+                    snapshot_id=section.snapshot_id,
+                    doc_id=section.doc_id,
+                    chunk_id=_stable_chunk_id(
+                        section,
+                        chunk_index=chunk_index,
+                        start=section.start_offset + start_char,
+                        end=section.start_offset + end_char,
+                    ),
+                    section_id=section.section_id,
+                    section_index=section.section_index,
+                    chunk_index=chunk_index,
+                    doc_title=section.doc_title,
+                    section_path=section.section_path,
+                    source_path=section.source_path,
+                    source_url=section.source_url,
+                    license=section.license,
+                    attribution=section.attribution,
+                    language=section.language,
+                    start_offset=section.start_offset + start_char,
+                    end_offset=section.start_offset + end_char,
+                    token_count=end_index - start_index,
+                    text=chunk_text,
+                )
+            )
+            chunk_index += 1
+
+        if end_index >= len(spans):
+            break
+
+        next_start = end_index - overlap_tokens
+        if next_start <= start_index:
+            next_start = start_index + 1
+        start_index = next_start
+
+    return chunks
+
+
+def chunk_sections(
+    sections: Iterable[SectionRecord],
+    *,
+    max_tokens: int = 350,
+    overlap_tokens: int = 50,
+) -> Iterator[ChunkRecord]:
+    for section in sections:
+        yield from chunk_section(section, max_tokens=max_tokens, overlap_tokens=overlap_tokens)

--- a/src/supportdoc_rag_chatbot/ingestion/fetch_snapshot.py
+++ b/src/supportdoc_rag_chatbot/ingestion/fetch_snapshot.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Stub for future snapshot acquisition automation.")
+    parser.add_argument("--repo-url", default="https://github.com/kubernetes/website.git")
+    parser.add_argument("--ref", required=True, help="Pinned git commit, tag, or branch")
+    parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    raise SystemExit(
+        "fetch_snapshot is intentionally left as a stub for the separate downloader/fetcher task. "
+        f"Requested ref={args.ref!r}, output_dir={str(args.output_dir)!r}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/supportdoc_rag_chatbot/ingestion/jsonl.py
+++ b/src/supportdoc_rag_chatbot/ingestion/jsonl.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from dataclasses import is_dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+def _normalize_record(record: Any) -> dict[str, Any]:
+    if hasattr(record, "to_dict"):
+        return record.to_dict()
+    if is_dataclass(record):
+        from dataclasses import asdict
+
+        return asdict(record)
+    if isinstance(record, dict):
+        return record
+    raise TypeError(f"Unsupported JSONL record type: {type(record)!r}")
+
+
+def read_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            payload = line.strip()
+            if not payload:
+                continue
+            try:
+                yield json.loads(payload)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSONL in {path} on line {line_number}") from exc
+
+
+def write_jsonl(path: Path, records: Iterable[Any]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(_normalize_record(record), ensure_ascii=False) + "\n")
+            count += 1
+    return count

--- a/src/supportdoc_rag_chatbot/ingestion/parse_docs.py
+++ b/src/supportdoc_rag_chatbot/ingestion/parse_docs.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .jsonl import write_jsonl
+from .parser import parse_manifest
+from .schemas import SectionRecord
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Parse Markdown/HTML docs into sections.jsonl")
+    parser.add_argument("--snapshot-root", required=True, type=Path)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser
+
+
+def build_sections_artifact(
+    *,
+    manifest_path: Path,
+    snapshot_root: Path,
+    output_path: Path,
+) -> list[SectionRecord]:
+    sections = list(parse_manifest(manifest_path, snapshot_root=snapshot_root))
+    write_jsonl(output_path, sections)
+    return sections
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    sections = build_sections_artifact(
+        manifest_path=args.manifest,
+        snapshot_root=args.snapshot_root,
+        output_path=args.output,
+    )
+    print(f"Wrote {len(sections)} parsed sections to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/supportdoc_rag_chatbot/ingestion/parser.py
+++ b/src/supportdoc_rag_chatbot/ingestion/parser.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import html as htmllib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from bs4 import BeautifulSoup, Tag
+
+from .jsonl import read_jsonl
+from .schemas import ManifestRecord, SectionRecord
+
+MARKDOWN_SUFFIXES = {".md", ".mdx"}
+HTML_SUFFIXES = {".html", ".htm"}
+
+FRONT_MATTER_BOUNDARY_RE = re.compile(r"^---\s*$")
+FRONT_MATTER_FIELD_RE = re.compile(r'^\s*([A-Za-z0-9_-]+)\s*:\s*["\']?(.*?)["\']?\s*$')
+HEADING_RE = re.compile(r"^(?P<level>#{1,6})\s+(?P<text>.+?)\s*$")
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+LINK_RE = re.compile(r"!\[(.*?)\]\([^\)]*\)|\[(.*?)\]\([^\)]*\)")
+INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+EMPHASIS_RE = re.compile(r"(?<!\*)\*\*(.*?)\*\*|__(.*?)__|(?<!\*)\*(.*?)\*|_(.*?)_")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+ORDERED_LIST_RE = re.compile(r"^\s*\d+\.\s+")
+UNORDERED_LIST_RE = re.compile(r"^\s*[-+*]\s+")
+MULTI_BLANK_RE = re.compile(r"\n{3,}")
+
+HTML_HEADING_LEVELS = {f"h{level}": level for level in range(1, 7)}
+HTML_SKIP_TAGS = {"script", "style", "nav", "footer", "header", "aside"}
+HTML_BLOCK_TAGS = {"p", "li", "pre", "blockquote", "code"}
+
+
+@dataclass(slots=True)
+class _SectionSeed:
+    heading: str | None
+    section_path: list[str]
+    text: str
+
+
+def strip_front_matter(text: str) -> str:
+    body, _ = split_front_matter(text)
+    return body
+
+
+def split_front_matter(text: str) -> tuple[str, dict[str, str]]:
+    normalized = _normalize_newlines(text)
+    lines = normalized.split("\n")
+    if not lines or not FRONT_MATTER_BOUNDARY_RE.match(lines[0]):
+        return normalized, {}
+
+    closing_index: int | None = None
+    for index, line in enumerate(lines[1:], start=1):
+        if FRONT_MATTER_BOUNDARY_RE.match(line) or line.strip() == "...":
+            closing_index = index
+            break
+
+    if closing_index is None:
+        return normalized, {}
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:closing_index]:
+        match = FRONT_MATTER_FIELD_RE.match(line)
+        if match is not None:
+            metadata[match.group(1).lower()] = match.group(2).strip()
+
+    body = "\n".join(lines[closing_index + 1 :])
+    return body, metadata
+
+
+def _strip_markdown_markup(text: str) -> str:
+    text = LINK_RE.sub(lambda match: match.group(1) or match.group(2) or "", text)
+    text = INLINE_CODE_RE.sub(lambda match: match.group(1), text)
+    text = EMPHASIS_RE.sub(
+        lambda match: next(group for group in match.groups() if group is not None),
+        text,
+    )
+    text = HTML_TAG_RE.sub("", text)
+    text = text.replace("\\", "")
+    return text
+
+
+def _normalize_plain_text(text: str, *, preserve_line_breaks: bool = False) -> str:
+    normalized = htmllib.unescape(_normalize_newlines(text)).replace("\xa0", " ")
+    cleaned_lines: list[str] = []
+
+    for raw_line in normalized.split("\n"):
+        line = re.sub(
+            r"[ \t]+", " ", raw_line.rstrip() if preserve_line_breaks else raw_line.strip()
+        )
+        if not preserve_line_breaks:
+            line = re.sub(r"\s+([,.;:!?])", r"\1", line)
+            line = line.strip()
+        cleaned_lines.append(line)
+
+    collapsed_lines: list[str] = []
+    previous_blank = False
+    for line in cleaned_lines:
+        is_blank = not line.strip()
+        if is_blank and previous_blank:
+            continue
+        collapsed_lines.append(line if preserve_line_breaks else line.strip())
+        previous_blank = is_blank
+
+    return "\n".join(collapsed_lines).strip()
+
+
+def normalize_markdown(markdown_text: str) -> str:
+    lines: list[str] = []
+    for raw_line in _normalize_newlines(markdown_text).split("\n"):
+        stripped = raw_line.strip()
+        if not stripped:
+            lines.append("")
+            continue
+        if FENCE_RE.match(stripped):
+            continue
+
+        heading_match = HEADING_RE.match(stripped)
+        line = heading_match.group("text") if heading_match is not None else raw_line
+        line = ORDERED_LIST_RE.sub("", line)
+        line = UNORDERED_LIST_RE.sub("", line)
+        if line.lstrip().startswith(">"):
+            line = line.lstrip()[1:].lstrip()
+        lines.append(_strip_markdown_markup(line))
+
+    text = "\n".join(lines).strip()
+    return MULTI_BLANK_RE.sub("\n\n", _normalize_plain_text(text))
+
+
+def _normalize_html_text(html_text: str) -> str:
+    if not html_text.strip():
+        return ""
+
+    soup = BeautifulSoup(html_text, "lxml")
+    for tag in soup.find_all(HTML_SKIP_TAGS):
+        tag.decompose()
+
+    blocks: list[str] = []
+    for tag in soup.find_all(list(HTML_HEADING_LEVELS) + sorted(HTML_BLOCK_TAGS)):
+        if not _is_top_level_content_tag(tag):
+            continue
+        if tag.name == "pre":
+            raw_text = tag.get_text("\n", strip=False)
+            normalized = _normalize_plain_text(raw_text, preserve_line_breaks=True)
+        else:
+            raw_text = tag.get_text(" ", strip=True)
+            normalized = _normalize_plain_text(raw_text)
+        if normalized:
+            blocks.append(normalized)
+
+    if blocks:
+        return "\n\n".join(blocks)
+
+    return _normalize_plain_text(soup.get_text(" ", strip=True))
+
+
+def _fallback_title(source_path: str) -> str:
+    stem = Path(source_path).stem
+    parts = [part for part in re.split(r"[-_]+", stem) if part]
+    return " ".join(part.capitalize() for part in parts) or stem
+
+
+def _compose_section_path(title_prefix: list[str], heading_stack: list[str]) -> list[str]:
+    path: list[str] = []
+    for part in [*title_prefix, *heading_stack]:
+        normalized = _normalize_plain_text(part)
+        if not normalized:
+            continue
+        if not path or path[-1] != normalized:
+            path.append(normalized)
+    return path
+
+
+def _append_seed(
+    seeds: list[_SectionSeed],
+    *,
+    heading: str | None,
+    section_path: list[str],
+    text: str,
+) -> None:
+    normalized = _normalize_plain_text(text, preserve_line_breaks="\n" in text)
+    if not normalized:
+        return
+    seeds.append(
+        _SectionSeed(
+            heading=_normalize_plain_text(heading) if heading is not None else None,
+            section_path=section_path,
+            text=normalized,
+        )
+    )
+
+
+def _extract_markdown_title(body: str, metadata: dict[str, str], fallback_title: str) -> str:
+    title = _normalize_plain_text(metadata.get("title", ""))
+    if title:
+        return title
+
+    in_code_fence = False
+    active_fence = ""
+    for raw_line in _normalize_newlines(body).split("\n"):
+        stripped = raw_line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            fence_token = stripped[:3]
+            if in_code_fence and stripped.startswith(active_fence):
+                in_code_fence = False
+                active_fence = ""
+            else:
+                in_code_fence = True
+                active_fence = fence_token
+            continue
+        if in_code_fence:
+            continue
+
+        match = HEADING_RE.match(stripped)
+        if match is not None and len(match.group("level")) == 1:
+            return _normalize_plain_text(_strip_markdown_markup(match.group("text")))
+
+    return _normalize_plain_text(fallback_title) or "Untitled Document"
+
+
+def _parse_markdown_document(text: str, *, record: ManifestRecord) -> list[_SectionSeed]:
+    body, metadata = split_front_matter(text)
+    doc_title = _extract_markdown_title(body, metadata, _fallback_title(record.source_path))
+    title_prefix = [doc_title] if doc_title else []
+
+    heading_stack: list[str] = []
+    buffer: list[str] = []
+    seeds: list[_SectionSeed] = []
+    in_code_fence = False
+    active_fence = ""
+
+    def flush() -> None:
+        normalized = normalize_markdown("\n".join(buffer))
+        if normalized:
+            _append_seed(
+                seeds,
+                heading=heading_stack[-1] if heading_stack else None,
+                section_path=_compose_section_path(title_prefix, heading_stack),
+                text=normalized,
+            )
+
+    for raw_line in _normalize_newlines(body).split("\n"):
+        stripped = raw_line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            fence_token = stripped[:3]
+            if in_code_fence and stripped.startswith(active_fence):
+                in_code_fence = False
+                active_fence = ""
+            else:
+                in_code_fence = True
+                active_fence = fence_token
+            buffer.append(raw_line)
+            continue
+
+        if not in_code_fence:
+            match = HEADING_RE.match(stripped)
+            if match is not None:
+                flush()
+                heading_text = _normalize_plain_text(_strip_markdown_markup(match.group("text")))
+                if heading_text:
+                    level = len(match.group("level"))
+                    heading_stack[:] = heading_stack[: level - 1] + [heading_text]
+                buffer = []
+                continue
+
+        buffer.append(raw_line)
+
+    flush()
+
+    if seeds:
+        return seeds
+
+    fallback_text = normalize_markdown(body)
+    if not fallback_text:
+        return []
+
+    return [
+        _SectionSeed(
+            heading=None,
+            section_path=[doc_title],
+            text=fallback_text,
+        )
+    ]
+
+
+def _parse_html_document(text: str, *, record: ManifestRecord) -> list[_SectionSeed]:
+    soup = BeautifulSoup(text, "lxml")
+    for tag in soup.find_all(HTML_SKIP_TAGS):
+        tag.decompose()
+
+    body = soup.body or soup
+    title = _normalize_plain_text(
+        soup.title.get_text(" ", strip=True) if soup.title is not None else ""
+    )
+    if not title:
+        first_heading = body.find(["h1", "h2"])
+        title = _normalize_plain_text(
+            first_heading.get_text(" ", strip=True) if first_heading is not None else ""
+        )
+    if not title:
+        title = _fallback_title(record.source_path)
+
+    title_prefix = [title] if title else []
+    heading_stack: list[str] = []
+    buffer: list[str] = []
+    seeds: list[_SectionSeed] = []
+
+    def flush() -> None:
+        normalized = _normalize_html_text("".join(buffer))
+        if normalized:
+            _append_seed(
+                seeds,
+                heading=heading_stack[-1] if heading_stack else None,
+                section_path=_compose_section_path(title_prefix, heading_stack),
+                text=normalized,
+            )
+
+    ordered_tags = body.find_all(list(HTML_HEADING_LEVELS) + sorted(HTML_BLOCK_TAGS))
+    for tag in ordered_tags:
+        if not _is_top_level_content_tag(tag):
+            continue
+
+        if tag.name in HTML_HEADING_LEVELS:
+            flush()
+            level = HTML_HEADING_LEVELS[tag.name]
+            heading_text = _normalize_plain_text(tag.get_text(" ", strip=True))
+            if heading_text:
+                heading_stack[:] = heading_stack[: level - 1] + [heading_text]
+            buffer = []
+            continue
+
+        buffer.append(str(tag))
+
+    flush()
+
+    if seeds:
+        return seeds
+
+    fallback_text = _normalize_html_text(str(body))
+    if not fallback_text:
+        return []
+
+    return [
+        _SectionSeed(
+            heading=None,
+            section_path=[title],
+            text=fallback_text,
+        )
+    ]
+
+
+def parse_document(record: ManifestRecord, *, snapshot_root: Path) -> list[SectionRecord]:
+    source_file = snapshot_root / record.source_path
+    if not source_file.exists():
+        raise FileNotFoundError(f"Missing source file for manifest entry: {source_file}")
+
+    raw_text = source_file.read_text(encoding="utf-8")
+    suffix = source_file.suffix.lower()
+    if suffix in HTML_SUFFIXES:
+        seeds = _parse_html_document(raw_text, record=record)
+    else:
+        seeds = _parse_markdown_document(raw_text, record=record)
+
+    if not seeds:
+        raise ValueError(f"Document {record.doc_id} produced no non-empty sections")
+
+    doc_title = (
+        seeds[0].section_path[0] if seeds[0].section_path else _fallback_title(record.source_path)
+    )
+    sections: list[SectionRecord] = []
+    cursor = 0
+
+    for section_index, seed in enumerate(seeds):
+        text = seed.text.strip()
+        if not text:
+            continue
+
+        start_offset = cursor
+        end_offset = start_offset + len(text)
+        cursor = end_offset + 2
+
+        sections.append(
+            SectionRecord(
+                snapshot_id=record.snapshot_id,
+                doc_id=record.doc_id,
+                section_id=f"{record.doc_id}-sec-{section_index:04d}",
+                section_index=section_index,
+                doc_title=doc_title,
+                heading=seed.heading,
+                section_path=seed.section_path or [doc_title],
+                source_path=record.source_path,
+                source_url=record.source_url,
+                license=record.license,
+                attribution=record.attribution,
+                language=record.language,
+                start_offset=start_offset,
+                end_offset=end_offset,
+                text=text,
+            )
+        )
+
+    if not sections:
+        raise ValueError(f"Document {record.doc_id} produced no non-empty sections")
+
+    return sections
+
+
+def parse_manifest(manifest_path: Path, *, snapshot_root: Path) -> Iterator[SectionRecord]:
+    records = sorted(
+        (ManifestRecord.from_dict(payload) for payload in read_jsonl(manifest_path)),
+        key=lambda record: (record.source_path, record.doc_id),
+    )
+
+    for record in records:
+        if not record.allowed:
+            continue
+        yield from parse_document(record, snapshot_root=snapshot_root)
+
+
+def _normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _is_top_level_content_tag(tag: Tag) -> bool:
+    parent = tag.parent
+    while isinstance(parent, Tag):
+        if parent.name in HTML_BLOCK_TAGS or parent.name in HTML_HEADING_LEVELS:
+            return False
+        parent = parent.parent
+    return True

--- a/src/supportdoc_rag_chatbot/ingestion/schemas.py
+++ b/src/supportdoc_rag_chatbot/ingestion/schemas.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ManifestRecord:
+    snapshot_id: str
+    source_path: str
+    source_url: str
+    doc_id: str
+    language: str
+    license: str
+    attribution: str
+    allowed: bool = True
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ManifestRecord":
+        return cls(
+            snapshot_id=str(payload["snapshot_id"]),
+            source_path=str(payload["source_path"]),
+            source_url=str(payload["source_url"]),
+            doc_id=str(payload["doc_id"]),
+            language=str(payload.get("language", "en")),
+            license=str(payload["license"]),
+            attribution=str(payload["attribution"]),
+            allowed=bool(payload.get("allowed", True)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class SectionRecord:
+    snapshot_id: str
+    doc_id: str
+    section_id: str
+    section_index: int
+    doc_title: str
+    heading: str | None
+    section_path: list[str]
+    source_path: str
+    source_url: str
+    license: str
+    attribution: str
+    language: str
+    start_offset: int
+    end_offset: int
+    text: str
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SectionRecord":
+        return cls(
+            snapshot_id=str(payload["snapshot_id"]),
+            doc_id=str(payload["doc_id"]),
+            section_id=str(payload["section_id"]),
+            section_index=int(payload["section_index"]),
+            doc_title=str(payload["doc_title"]),
+            heading=str(payload["heading"]) if payload.get("heading") is not None else None,
+            section_path=[str(part) for part in payload.get("section_path", [])],
+            source_path=str(payload["source_path"]),
+            source_url=str(payload["source_url"]),
+            license=str(payload["license"]),
+            attribution=str(payload["attribution"]),
+            language=str(payload.get("language", "en")),
+            start_offset=int(payload["start_offset"]),
+            end_offset=int(payload["end_offset"]),
+            text=str(payload["text"]),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ChunkRecord:
+    snapshot_id: str
+    doc_id: str
+    chunk_id: str
+    section_id: str
+    section_index: int
+    chunk_index: int
+    doc_title: str
+    section_path: list[str]
+    source_path: str
+    source_url: str
+    license: str
+    attribution: str
+    language: str
+    start_offset: int
+    end_offset: int
+    token_count: int
+    text: str
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ChunkRecord":
+        return cls(
+            snapshot_id=str(payload["snapshot_id"]),
+            doc_id=str(payload["doc_id"]),
+            chunk_id=str(payload["chunk_id"]),
+            section_id=str(payload["section_id"]),
+            section_index=int(payload["section_index"]),
+            chunk_index=int(payload["chunk_index"]),
+            doc_title=str(payload["doc_title"]),
+            section_path=[str(part) for part in payload.get("section_path", [])],
+            source_path=str(payload["source_path"]),
+            source_url=str(payload["source_url"]),
+            license=str(payload["license"]),
+            attribution=str(payload["attribution"]),
+            language=str(payload.get("language", "en")),
+            start_offset=int(payload["start_offset"]),
+            end_offset=int(payload["end_offset"]),
+            token_count=int(payload["token_count"]),
+            text=str(payload["text"]),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class IngestReport:
+    snapshot_id: str | None
+    manifest_path: str
+    sections_path: str
+    chunks_path: str
+    document_count: int = 0
+    section_count: int = 0
+    chunk_count: int = 0
+    estimated_token_count: int = 0
+    empty_section_count: int = 0
+    empty_chunk_count: int = 0
+    duplicate_section_ids: int = 0
+    duplicate_chunk_ids: int = 0
+    missing_metadata_count: int = 0
+    warning_count: int = 0
+    error_count: int = 0
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["warning_count"] = len(self.warnings)
+        payload["error_count"] = len(self.errors)
+        return payload

--- a/src/supportdoc_rag_chatbot/ingestion/validate_corpus.py
+++ b/src/supportdoc_rag_chatbot/ingestion/validate_corpus.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .validator import (
+    load_chunk_records,
+    load_manifest_records,
+    load_section_records,
+    validate_corpus,
+    write_report,
+)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate ingestion artifacts and emit ingest_report.json"
+    )
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--sections", required=True, type=Path)
+    parser.add_argument("--chunks", required=True, type=Path)
+    parser.add_argument("--report-out", required=True, type=Path)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when validation errors are present.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    manifest_records = load_manifest_records(args.manifest)
+    sections = load_section_records(args.sections)
+    chunks = load_chunk_records(args.chunks)
+    report = validate_corpus(
+        manifest_records,
+        sections,
+        chunks,
+        manifest_path=args.manifest,
+        sections_path=args.sections,
+        chunks_path=args.chunks,
+    )
+    write_report(report, args.report_out)
+
+    if report.errors:
+        print(f"Validation finished with {len(report.errors)} error(s). Report: {args.report_out}")
+        if args.strict:
+            raise SystemExit(1)
+    else:
+        print(f"Validation passed. Report: {args.report_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/supportdoc_rag_chatbot/ingestion/validator.py
+++ b/src/supportdoc_rag_chatbot/ingestion/validator.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .jsonl import read_jsonl
+from .schemas import ChunkRecord, IngestReport, ManifestRecord, SectionRecord
+
+REQUIRED_CHUNK_FIELDS = (
+    "source_url",
+    "license",
+    "attribution",
+    "snapshot_id",
+    "doc_id",
+    "chunk_id",
+    "section_path",
+    "start_offset",
+    "end_offset",
+    "token_count",
+    "text",
+)
+
+
+def _is_missing(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, list):
+        return len(value) == 0
+    return False
+
+
+def validate_corpus(
+    manifest_records: Iterable[ManifestRecord],
+    sections: Iterable[SectionRecord],
+    chunks: Iterable[ChunkRecord],
+    *,
+    manifest_path: Path,
+    sections_path: Path,
+    chunks_path: Path,
+) -> IngestReport:
+    manifest_list = list(manifest_records)
+    section_list = list(sections)
+    chunk_list = list(chunks)
+
+    snapshot_id = manifest_list[0].snapshot_id if manifest_list else None
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    section_ids_seen: set[str] = set()
+    chunk_ids_seen: set[str] = set()
+    duplicate_section_ids = 0
+    duplicate_chunk_ids = 0
+    empty_section_count = 0
+    empty_chunk_count = 0
+    missing_metadata_count = 0
+
+    for section in section_list:
+        if not section.text.strip():
+            empty_section_count += 1
+            errors.append(f"Empty section text: {section.section_id}")
+        if section.section_id in section_ids_seen:
+            duplicate_section_ids += 1
+            errors.append(f"Duplicate section_id: {section.section_id}")
+        section_ids_seen.add(section.section_id)
+
+    for chunk in chunk_list:
+        if not chunk.text.strip():
+            empty_chunk_count += 1
+            errors.append(f"Empty chunk text: {chunk.chunk_id}")
+        if chunk.chunk_id in chunk_ids_seen:
+            duplicate_chunk_ids += 1
+            errors.append(f"Duplicate chunk_id: {chunk.chunk_id}")
+        chunk_ids_seen.add(chunk.chunk_id)
+
+        for field_name in REQUIRED_CHUNK_FIELDS:
+            value = getattr(chunk, field_name)
+            if _is_missing(value):
+                missing_metadata_count += 1
+                errors.append(f"Missing required metadata '{field_name}' on chunk {chunk.chunk_id}")
+
+        if chunk.start_offset >= chunk.end_offset:
+            errors.append(f"Invalid chunk offsets: {chunk.chunk_id}")
+
+    if not manifest_list:
+        warnings.append("Manifest was empty.")
+    if not section_list:
+        warnings.append("No sections were produced.")
+    if not chunk_list:
+        warnings.append("No chunks were produced.")
+
+    manifest_doc_ids = {record.doc_id for record in manifest_list}
+    section_doc_ids = {section.doc_id for section in section_list}
+    chunk_doc_ids = {chunk.doc_id for chunk in chunk_list}
+    if section_doc_ids - manifest_doc_ids:
+        warnings.append("Parsed sections contain doc_ids that were not present in the manifest.")
+    if chunk_doc_ids - section_doc_ids:
+        warnings.append("Chunks contain doc_ids that were not present in parsed sections.")
+
+    report = IngestReport(
+        snapshot_id=snapshot_id,
+        manifest_path=str(manifest_path),
+        sections_path=str(sections_path),
+        chunks_path=str(chunks_path),
+        document_count=len(manifest_doc_ids),
+        section_count=len(section_list),
+        chunk_count=len(chunk_list),
+        estimated_token_count=sum(chunk.token_count for chunk in chunk_list),
+        empty_section_count=empty_section_count,
+        empty_chunk_count=empty_chunk_count,
+        duplicate_section_ids=duplicate_section_ids,
+        duplicate_chunk_ids=duplicate_chunk_ids,
+        missing_metadata_count=missing_metadata_count,
+        warnings=warnings,
+        errors=errors,
+    )
+    report.warning_count = len(warnings)
+    report.error_count = len(errors)
+    return report
+
+
+def load_manifest_records(path: Path) -> list[ManifestRecord]:
+    return [ManifestRecord.from_dict(payload) for payload in read_jsonl(path)]
+
+
+def load_section_records(path: Path) -> list[SectionRecord]:
+    return [SectionRecord.from_dict(payload) for payload in read_jsonl(path)]
+
+
+def load_chunk_records(path: Path) -> list[ChunkRecord]:
+    return [ChunkRecord.from_dict(payload) for payload in read_jsonl(path)]
+
+
+def write_report(report: IngestReport, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(report.to_dict(), handle, ensure_ascii=False, indent=2)
+        handle.write("\n")

--- a/src/supportdoc_rag_chatbot/resources/default_config.yaml
+++ b/src/supportdoc_rag_chatbot/resources/default_config.yaml
@@ -1,0 +1,9 @@
+ingestion:
+  artifacts:
+    manifest_path: data/manifests/source_manifest.jsonl
+    sections_path: data/parsed/sections.jsonl
+    chunks_path: data/processed/chunks.jsonl
+    ingest_report_path: data/processed/ingest_report.json
+  chunking:
+    max_tokens: 350
+    overlap_tokens: 50

--- a/tests/test_parser_issue1.py
+++ b/tests/test_parser_issue1.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from supportdoc_rag_chatbot.ingestion.parse_docs import build_sections_artifact
+from supportdoc_rag_chatbot.ingestion.parser import parse_document
+from supportdoc_rag_chatbot.ingestion.schemas import ManifestRecord
+
+
+def _write_manifest(path: Path, records: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_parse_markdown_document_builds_section_paths_and_offsets(tmp_path: Path) -> None:
+    snapshot_root = tmp_path / "snapshot"
+    source_path = snapshot_root / "content/en/docs/concepts/pods.md"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(
+        """---
+title: Pods
+---
+Intro with **bold** text and a [link](https://example.com).
+
+## Lifecycle
+Pods move through phases.
+
+### Restart Policy
+Containers can restart.
+
+```python
+print('hello')
+```
+""",
+        encoding="utf-8",
+    )
+
+    record = ManifestRecord(
+        snapshot_id="snapshot-001",
+        source_path="content/en/docs/concepts/pods.md",
+        source_url="https://kubernetes.io/docs/concepts/pods/",
+        doc_id="k8s_001",
+        language="en",
+        license="CC BY 4.0",
+        attribution="Kubernetes Documentation © The Kubernetes Authors",
+        allowed=True,
+    )
+
+    sections = parse_document(record, snapshot_root=snapshot_root)
+
+    assert len(sections) == 3
+    assert [section.section_path for section in sections] == [
+        ["Pods"],
+        ["Pods", "Lifecycle"],
+        ["Pods", "Lifecycle", "Restart Policy"],
+    ]
+    assert sections[0].text == "Intro with bold text and a link."
+    assert sections[1].text == "Pods move through phases."
+    assert "print('hello')" in sections[2].text
+    assert sections[0].start_offset == 0
+    assert sections[0].end_offset == len(sections[0].text)
+    assert sections[1].start_offset == sections[0].end_offset + 2
+    assert sections[2].start_offset == sections[1].end_offset + 2
+    assert all(section.text.strip() for section in sections)
+
+
+def test_parse_html_document_normalizes_text_and_skips_empty_sections(tmp_path: Path) -> None:
+    snapshot_root = tmp_path / "snapshot"
+    source_path = snapshot_root / "content/en/docs/tasks/demo.html"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(
+        """
+<html>
+  <head><title>Demo Page</title></head>
+  <body>
+    <p>Overview paragraph.</p>
+    <h2>Install</h2>
+    <p>Install <strong>kubectl</strong>.</p>
+    <h3>Notes</h3>
+    <pre><code>kubectl get pods</code></pre>
+  </body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+    record = ManifestRecord(
+        snapshot_id="snapshot-001",
+        source_path="content/en/docs/tasks/demo.html",
+        source_url="https://example.invalid/demo",
+        doc_id="html_001",
+        language="en",
+        license="CC BY 4.0",
+        attribution="Kubernetes Documentation © The Kubernetes Authors",
+        allowed=True,
+    )
+
+    sections = parse_document(record, snapshot_root=snapshot_root)
+
+    assert [section.section_path for section in sections] == [
+        ["Demo Page"],
+        ["Demo Page", "Install"],
+        ["Demo Page", "Install", "Notes"],
+    ]
+    assert sections[0].text == "Overview paragraph."
+    assert sections[1].text == "Install kubectl."
+    assert sections[2].text == "kubectl get pods"
+
+
+def test_build_sections_artifact_sorts_manifest_for_deterministic_output(tmp_path: Path) -> None:
+    snapshot_root = tmp_path / "snapshot"
+    (snapshot_root / "content/en/docs/tasks").mkdir(parents=True, exist_ok=True)
+    file_a = snapshot_root / "content/en/docs/tasks/a.md"
+    file_b = snapshot_root / "content/en/docs/tasks/b.md"
+    file_a.write_text("# Alpha\nA body.\n", encoding="utf-8")
+    file_b.write_text("# Beta\nB body.\n", encoding="utf-8")
+
+    manifest_path = tmp_path / "source_manifest.jsonl"
+    _write_manifest(
+        manifest_path,
+        [
+            {
+                "snapshot_id": "snapshot-001",
+                "source_path": "content/en/docs/tasks/b.md",
+                "source_url": "https://example.invalid/b",
+                "doc_id": "doc_b",
+                "language": "en",
+                "license": "CC BY 4.0",
+                "attribution": "Kubernetes Documentation © The Kubernetes Authors",
+                "allowed": True,
+            },
+            {
+                "snapshot_id": "snapshot-001",
+                "source_path": "content/en/docs/tasks/a.md",
+                "source_url": "https://example.invalid/a",
+                "doc_id": "doc_a",
+                "language": "en",
+                "license": "CC BY 4.0",
+                "attribution": "Kubernetes Documentation © The Kubernetes Authors",
+                "allowed": True,
+            },
+        ],
+    )
+
+    output_path = tmp_path / "sections.jsonl"
+    sections = build_sections_artifact(
+        manifest_path=manifest_path,
+        snapshot_root=snapshot_root,
+        output_path=output_path,
+    )
+
+    assert [section.doc_id for section in sections] == ["doc_a", "doc_b"]
+    written = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert [entry["doc_id"] for entry in written] == ["doc_a", "doc_b"]
+
+    rerun_output = tmp_path / "sections-second.jsonl"
+    rerun_sections = build_sections_artifact(
+        manifest_path=manifest_path,
+        snapshot_root=snapshot_root,
+        output_path=rerun_output,
+    )
+    assert [section.to_dict() for section in rerun_sections] == [
+        section.to_dict() for section in sections
+    ]
+    assert rerun_output.read_text(encoding="utf-8") == output_path.read_text(encoding="utf-8")
+
+
+def test_parse_document_raises_when_no_non_empty_sections(tmp_path: Path) -> None:
+    snapshot_root = tmp_path / "snapshot"
+    source_path = snapshot_root / "content/en/docs/tasks/empty.md"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text("---\ntitle: Empty\n---\n", encoding="utf-8")
+
+    record = ManifestRecord(
+        snapshot_id="snapshot-001",
+        source_path="content/en/docs/tasks/empty.md",
+        source_url="https://example.invalid/empty",
+        doc_id="empty_001",
+        language="en",
+        license="CC BY 4.0",
+        attribution="Kubernetes Documentation © The Kubernetes Authors",
+        allowed=True,
+    )
+
+    with pytest.raises(ValueError, match="no non-empty sections"):
+        parse_document(record, snapshot_root=snapshot_root)


### PR DESCRIPTION
- parse markdown/html into sections
- deterministic section ids + offsets
- sections.jsonl output
- tests for parser
- git_workflow.md was modified to add CI/CD integration on Local repo

Closes #3

Changes to be committed:
	modified:   docs/process/git_workflow.md
	modified:   src/supportdoc_rag_chatbot/ingestion/__init__.py
	new file:   src/supportdoc_rag_chatbot/ingestion/chunk_docs.py
	new file:   src/supportdoc_rag_chatbot/ingestion/chunker.py
	new file:   src/supportdoc_rag_chatbot/ingestion/fetch_snapshot.py
	new file:   src/supportdoc_rag_chatbot/ingestion/jsonl.py
	new file:   src/supportdoc_rag_chatbot/ingestion/parse_docs.py
	new file:   src/supportdoc_rag_chatbot/ingestion/parser.py
	new file:   src/supportdoc_rag_chatbot/ingestion/schemas.py
	new file:   src/supportdoc_rag_chatbot/ingestion/validate_corpus.py
	new file:   src/supportdoc_rag_chatbot/ingestion/validator.py
	modified:   src/supportdoc_rag_chatbot/resources/default_config.yaml
	new file:   tests/test_parser_issue1.py