### PR TITLE
On branch feat/33-add-retrieval-smoke-test-cli-for-local-dense-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Local dense retrieval baseline.
 - Stable `chunks.jsonl` artifact with chunk-level provenance metadata.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
 - Local FAISS backend that builds, persists, reloads, and searches a dense index over saved embedding artifacts.
+- Developer-facing retrieval smoke CLI for local dense search over a saved FAISS index.
 
 ### In Progress
-- Retrieval smoke test CLI.
 - Citation contract and refusal behavior integration.
 
 ### Next Up
@@ -143,6 +143,7 @@ src/supportdoc_rag_chatbot/
   retrieval/
     embeddings/           # Local embedding job + artifact I/O
     indexes/              # Dense index interfaces + local FAISS backend
+    smoke.py              # Developer-facing dense retrieval smoke helpers
   app/                    # Backend orchestration entrypoints (to grow over time)
   resources/              # Default config and packaged resources
 
@@ -240,6 +241,33 @@ backend = load_faiss_index_backend(
     metadata_path=Path("data/processed/indexes/faiss/chunk_index.metadata.json"),
 )
 ```
+
+### Run a local dense-retrieval smoke test
+
+After the FAISS index exists, run a query end to end:
+
+```bash
+uv run python -m supportdoc_rag_chatbot smoke-dense-retrieval \
+  --query "what is a pod" \
+  --top-k 3 \
+  --index data/processed/indexes/faiss/chunk_index.faiss \
+  --index-metadata data/processed/indexes/faiss/chunk_index.metadata.json
+```
+
+By default, the smoke command:
+
+- loads the embedding model recorded in the FAISS index metadata,
+- uses the row-mapping path recorded in the index metadata,
+- uses the source `chunks.jsonl` path recorded in the index metadata, and
+- prints rank, score, chunk ID, section path, source URL, and a short text preview.
+
+Useful options:
+
+- `--row-mapping data/processed/indexes/faiss/chunk_index.row_mapping.json`
+- `--chunks data/processed/chunks.jsonl`
+- `--model-name sentence-transformers/all-MiniLM-L6-v2`
+- `--device cpu|cuda|mps`
+- `--preview-chars 200`
 
 ### Local verification
 

--- a/src/supportdoc_rag_chatbot/cli.py
+++ b/src/supportdoc_rag_chatbot/cli.py
@@ -21,6 +21,12 @@ from supportdoc_rag_chatbot.retrieval.indexes import (
     DEFAULT_FAISS_ROW_MAPPING_PATH,
     build_faiss_index_artifacts,
 )
+from supportdoc_rag_chatbot.retrieval.smoke import (
+    DEFAULT_PREVIEW_CHARS,
+    DEFAULT_RETRIEVAL_TOP_K,
+    render_dense_retrieval_smoke_report,
+    run_dense_retrieval_smoke,
+)
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -102,6 +108,71 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     index_parser.set_defaults(handler=_run_build_faiss_index)
 
+    smoke_parser = subparsers.add_parser(
+        "smoke-dense-retrieval",
+        help="Run a local dense-retrieval smoke test over the saved FAISS index",
+    )
+    smoke_parser.add_argument(
+        "--query",
+        required=True,
+        help="Query text to embed and search",
+    )
+    smoke_parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_RETRIEVAL_TOP_K,
+        help="Number of top matches to print",
+    )
+    smoke_parser.add_argument(
+        "--index",
+        type=Path,
+        default=DEFAULT_FAISS_INDEX_PATH,
+        help="Path to the persisted FAISS index file",
+    )
+    smoke_parser.add_argument(
+        "--index-metadata",
+        type=Path,
+        default=DEFAULT_FAISS_METADATA_PATH,
+        help="Path to the FAISS index metadata JSON",
+    )
+    smoke_parser.add_argument(
+        "--row-mapping",
+        type=Path,
+        default=None,
+        help="Optional path to the row-to-chunk-id mapping JSON (defaults to the metadata sidecar)",
+    )
+    smoke_parser.add_argument(
+        "--chunks",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to chunks.jsonl (defaults to the source path recorded in index metadata)"
+        ),
+    )
+    smoke_parser.add_argument(
+        "--model-name",
+        default=None,
+        help="Optional embedding model override (defaults to the model recorded in index metadata)",
+    )
+    smoke_parser.add_argument(
+        "--device",
+        default=DEFAULT_DEVICE,
+        help="Embedding device, for example cpu, cuda, or mps",
+    )
+    smoke_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Embedding batch size for the single-query embedder",
+    )
+    smoke_parser.add_argument(
+        "--preview-chars",
+        type=int,
+        default=DEFAULT_PREVIEW_CHARS,
+        help="Maximum number of characters to print from each chunk preview",
+    )
+    smoke_parser.set_defaults(handler=_run_smoke_dense_retrieval)
+
     return parser
 
 
@@ -140,6 +211,23 @@ def _run_build_faiss_index(args: argparse.Namespace) -> int:
         f"index={args.index_output}, metadata={args.index_metadata_output}, "
         f"row-mapping={args.row_mapping_output}"
     )
+    return 0
+
+
+def _run_smoke_dense_retrieval(args: argparse.Namespace) -> int:
+    report = run_dense_retrieval_smoke(
+        query_text=args.query,
+        top_k=args.top_k,
+        index_path=args.index,
+        index_metadata_path=args.index_metadata,
+        row_mapping_path=args.row_mapping,
+        chunks_path=args.chunks,
+        model_name=args.model_name,
+        device=args.device,
+        batch_size=args.batch_size,
+        preview_chars=args.preview_chars,
+    )
+    print(render_dense_retrieval_smoke_report(report))
     return 0
 
 

--- a/src/supportdoc_rag_chatbot/retrieval/__init__.py
+++ b/src/supportdoc_rag_chatbot/retrieval/__init__.py
@@ -27,6 +27,14 @@ from .indexes import (
     read_chunk_row_mapping,
     read_index_metadata,
 )
+from .smoke import (
+    DEFAULT_PREVIEW_CHARS,
+    DEFAULT_RETRIEVAL_TOP_K,
+    DenseRetrievalSmokeMatch,
+    DenseRetrievalSmokeReport,
+    render_dense_retrieval_smoke_report,
+    run_dense_retrieval_smoke,
+)
 
 __all__ = [
     "DEFAULT_BATCH_SIZE",
@@ -38,10 +46,14 @@ __all__ = [
     "DEFAULT_FAISS_ROW_MAPPING_PATH",
     "DEFAULT_LOCAL_EMBEDDING_MODEL",
     "DEFAULT_METADATA_PATH",
+    "DEFAULT_PREVIEW_CHARS",
+    "DEFAULT_RETRIEVAL_TOP_K",
     "DEFAULT_VECTORS_PATH",
     "ChunkRowMapping",
     "DenseIndexMetadata",
     "DenseRetrievalBackend",
+    "DenseRetrievalSmokeMatch",
+    "DenseRetrievalSmokeReport",
     "DenseSearchResult",
     "EmbeddingMetadata",
     "FaissDenseIndexBackend",
@@ -54,4 +66,6 @@ __all__ = [
     "read_embedding_metadata",
     "read_index_metadata",
     "read_vector_rows",
+    "render_dense_retrieval_smoke_report",
+    "run_dense_retrieval_smoke",
 ]

--- a/src/supportdoc_rag_chatbot/retrieval/smoke.py
+++ b/src/supportdoc_rag_chatbot/retrieval/smoke.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_DEVICE,
+    create_local_embedder,
+    load_chunk_records,
+)
+from supportdoc_rag_chatbot.retrieval.indexes import (
+    DEFAULT_FAISS_INDEX_PATH,
+    DEFAULT_FAISS_METADATA_PATH,
+    DenseSearchResult,
+    load_faiss_index_backend,
+    read_index_metadata,
+)
+
+DEFAULT_RETRIEVAL_TOP_K = 5
+DEFAULT_PREVIEW_CHARS = 200
+
+
+@dataclass(slots=True)
+class DenseRetrievalSmokeMatch:
+    rank: int
+    score: float
+    chunk_id: str
+    row_index: int
+    doc_title: str
+    section_path: str
+    source_url: str
+    source_path: str
+    text_preview: str
+
+
+@dataclass(slots=True)
+class DenseRetrievalSmokeReport:
+    query_text: str
+    model_name: str
+    top_k: int
+    index_path: str
+    index_metadata_path: str
+    row_mapping_path: str
+    chunks_path: str
+    matches: list[DenseRetrievalSmokeMatch]
+
+
+def run_dense_retrieval_smoke(
+    *,
+    query_text: str,
+    top_k: int = DEFAULT_RETRIEVAL_TOP_K,
+    index_path: Path = DEFAULT_FAISS_INDEX_PATH,
+    index_metadata_path: Path = DEFAULT_FAISS_METADATA_PATH,
+    row_mapping_path: Path | None = None,
+    chunks_path: Path | None = None,
+    model_name: str | None = None,
+    device: str = DEFAULT_DEVICE,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    preview_chars: int = DEFAULT_PREVIEW_CHARS,
+) -> DenseRetrievalSmokeReport:
+    normalized_query = " ".join(query_text.split())
+    if not normalized_query:
+        raise ValueError("query text must not be empty")
+    if top_k <= 0:
+        raise ValueError("top_k must be > 0")
+    if preview_chars <= 0:
+        raise ValueError("preview_chars must be > 0")
+
+    _require_path(index_metadata_path, label="Index metadata artifact")
+    _require_path(index_path, label="FAISS index artifact")
+
+    index_metadata = read_index_metadata(index_metadata_path)
+    resolved_row_mapping_path = row_mapping_path or _metadata_path(
+        index_metadata.row_mapping_path,
+        label="row_mapping_path",
+        source_path=index_metadata_path,
+    )
+    _require_path(resolved_row_mapping_path, label="Index row mapping artifact")
+
+    resolved_chunks_path = chunks_path or _metadata_path(
+        index_metadata.source_chunks_path,
+        label="source_chunks_path",
+        source_path=index_metadata_path,
+    )
+    _require_path(resolved_chunks_path, label="Chunks artifact")
+
+    backend = load_faiss_index_backend(
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=resolved_row_mapping_path,
+    )
+    chunks = load_chunk_records(resolved_chunks_path)
+    if len(chunks) != backend.metadata.row_count:
+        raise ValueError(
+            "Chunk artifact row count does not match index metadata row count: "
+            f"expected {backend.metadata.row_count}, got {len(chunks)}"
+        )
+
+    resolved_model_name = model_name or index_metadata.embedding_model_name
+    embedder = create_local_embedder(
+        model_name=resolved_model_name,
+        device=device,
+        batch_size=batch_size,
+        normalize_embeddings=True,
+    )
+    query_vectors = embedder.embed_texts([normalized_query])
+    if len(query_vectors) != 1:
+        raise ValueError(f"Embedding backend returned {len(query_vectors)} rows for a single query")
+
+    results = backend.search(query_vectors[0], top_k=top_k)
+    matches = [
+        _join_search_result(result=result, chunks=chunks, preview_chars=preview_chars)
+        for result in results
+    ]
+    return DenseRetrievalSmokeReport(
+        query_text=normalized_query,
+        model_name=resolved_model_name,
+        top_k=top_k,
+        index_path=str(index_path),
+        index_metadata_path=str(index_metadata_path),
+        row_mapping_path=str(resolved_row_mapping_path),
+        chunks_path=str(resolved_chunks_path),
+        matches=matches,
+    )
+
+
+def render_dense_retrieval_smoke_report(report: DenseRetrievalSmokeReport) -> str:
+    lines = [
+        "Dense retrieval smoke test",
+        f'query: "{report.query_text}"',
+        f"model: {report.model_name}",
+        f"top_k: {report.top_k}",
+        f"index: {report.index_path}",
+        f"index_metadata: {report.index_metadata_path}",
+        f"row_mapping: {report.row_mapping_path}",
+        f"chunks: {report.chunks_path}",
+        "",
+    ]
+
+    if not report.matches:
+        lines.append("No matches returned.")
+        return "\n".join(lines)
+
+    for match in report.matches:
+        lines.extend(
+            [
+                f"[{match.rank}] score={match.score:.6f} chunk_id={match.chunk_id}",
+                f"    title: {match.doc_title}",
+                f"    section_path: {match.section_path}",
+                f"    source_url: {match.source_url}",
+                f"    preview: {match.text_preview}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines).rstrip()
+
+
+def _join_search_result(
+    *,
+    result: DenseSearchResult,
+    chunks: list[ChunkRecord],
+    preview_chars: int,
+) -> DenseRetrievalSmokeMatch:
+    if result.row_index < 0 or result.row_index >= len(chunks):
+        raise ValueError(
+            f"Search result row index is out of range for chunks artifact: {result.row_index}"
+        )
+
+    chunk = chunks[result.row_index]
+    if chunk.chunk_id != result.chunk_id:
+        raise ValueError(
+            "Search result chunk_id does not match the chunk artifact row mapping: "
+            f"row {result.row_index} has {chunk.chunk_id!r}, result reported {result.chunk_id!r}"
+        )
+
+    return DenseRetrievalSmokeMatch(
+        rank=result.rank,
+        score=result.score,
+        chunk_id=result.chunk_id,
+        row_index=result.row_index,
+        doc_title=chunk.doc_title,
+        section_path=_format_section_path(chunk.section_path),
+        source_url=chunk.source_url,
+        source_path=chunk.source_path,
+        text_preview=_preview_text(chunk.text, preview_chars=preview_chars),
+    )
+
+
+def _format_section_path(section_path: list[str]) -> str:
+    if not section_path:
+        return "(root)"
+    return " > ".join(section_path)
+
+
+def _preview_text(text: str, *, preview_chars: int) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= preview_chars:
+        return normalized
+    return normalized[: max(1, preview_chars - 1)].rstrip() + "…"
+
+
+def _metadata_path(raw_path: str | None, *, label: str, source_path: Path) -> Path:
+    if not raw_path:
+        raise ValueError(f"Missing {label} in artifact metadata: {source_path}")
+    return Path(raw_path)
+
+
+def _require_path(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} not found: {path}")

--- a/tests/test_retrieval_smoke_cli.py
+++ b/tests/test_retrieval_smoke_cli.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import pickle
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from supportdoc_rag_chatbot.cli import main
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import build_embedding_artifacts
+from supportdoc_rag_chatbot.retrieval.indexes import build_faiss_index_artifacts
+
+
+class MappingTestEmbedder:
+    model_name = "test-map-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self.mapping = mapping
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[float(value) for value in self.mapping[text]] for text in texts]
+
+
+class FakeFaissIndexFlatIP:
+    def __init__(self, dimension: int) -> None:
+        self.d = int(dimension)
+        self.ntotal = 0
+        self._vectors = _numpy().empty((0, self.d), dtype=_numpy().float32)
+
+    def add(self, vectors) -> None:
+        vectors_array = _numpy().asarray(vectors, dtype=_numpy().float32)
+        if vectors_array.ndim != 2 or vectors_array.shape[1] != self.d:
+            raise ValueError("FakeFaissIndexFlatIP.add received vectors with the wrong shape")
+        self._vectors = _numpy().vstack([self._vectors, vectors_array])
+        self.ntotal = int(self._vectors.shape[0])
+
+    def search(self, queries, top_k: int):
+        queries_array = _numpy().asarray(queries, dtype=_numpy().float32)
+        scores = queries_array @ self._vectors.T
+        ranked_indexes = _numpy().argsort(-scores, axis=1, kind="stable")[:, :top_k]
+        ranked_scores = _numpy().take_along_axis(scores, ranked_indexes, axis=1)
+        return ranked_scores.astype(_numpy().float32), ranked_indexes.astype(_numpy().int64)
+
+
+class QueryTestEmbedder:
+    model_name = "test-query-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self.mapping = mapping
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[float(value) for value in self.mapping[text]] for text in texts]
+
+
+def fake_faiss_module() -> SimpleNamespace:
+    def normalize_l2(matrix) -> None:
+        array = _numpy().asarray(matrix, dtype=_numpy().float32)
+        norms = _numpy().linalg.norm(array, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        array /= norms
+
+    def write_index(index: FakeFaissIndexFlatIP, path: str) -> None:
+        payload = {"d": index.d, "vectors": index._vectors}
+        with Path(path).open("wb") as handle:
+            pickle.dump(payload, handle)
+
+    def read_index(path: str) -> FakeFaissIndexFlatIP:
+        with Path(path).open("rb") as handle:
+            payload = pickle.load(handle)
+        index = FakeFaissIndexFlatIP(payload["d"])
+        index.add(payload["vectors"])
+        return index
+
+    return SimpleNamespace(
+        IndexFlatIP=FakeFaissIndexFlatIP,
+        normalize_L2=normalize_l2,
+        write_index=write_index,
+        read_index=read_index,
+    )
+
+
+def make_chunk(*, chunk_id: str, text: str, snapshot_id: str = "k8s-9e1e32b") -> ChunkRecord:
+    return ChunkRecord(
+        snapshot_id=snapshot_id,
+        doc_id="content-en-docs-concepts-pods",
+        chunk_id=chunk_id,
+        section_id=f"section-{chunk_id}",
+        section_index=0,
+        chunk_index=0,
+        doc_title="Pods",
+        section_path=["Pods"],
+        source_path="content/en/docs/concepts/workloads/pods/pods.md",
+        source_url="https://kubernetes.io/docs/concepts/workloads/pods/",
+        license="CC BY 4.0",
+        attribution="Kubernetes Documentation © The Kubernetes Authors",
+        language="en",
+        start_offset=0,
+        end_offset=len(text),
+        token_count=len(text.split()),
+        text=text,
+    )
+
+
+def write_chunks(path: Path, chunks: list[ChunkRecord]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(chunk.to_dict(), ensure_ascii=False) + "\n" for chunk in chunks),
+        encoding="utf-8",
+    )
+
+
+def install_fake_faiss(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss_module())
+
+
+@pytest.fixture
+def retrieval_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    install_fake_faiss(monkeypatch)
+
+    chunks_path = tmp_path / "data/processed/chunks.jsonl"
+    vectors_path = tmp_path / "data/processed/embeddings/chunk_embeddings.f32"
+    embedding_metadata_path = tmp_path / "data/processed/embeddings/chunk_embeddings.metadata.json"
+    index_path = tmp_path / "data/processed/indexes/faiss/chunk_index.faiss"
+    index_metadata_path = tmp_path / "data/processed/indexes/faiss/chunk_index.metadata.json"
+    row_mapping_path = tmp_path / "data/processed/indexes/faiss/chunk_index.row_mapping.json"
+
+    chunks = [
+        make_chunk(chunk_id="chunk-alpha", text="alpha pods can run one or more containers"),
+        make_chunk(chunk_id="chunk-beta", text="beta pods are related to pod templates"),
+        make_chunk(chunk_id="chunk-gamma", text="gamma services expose pods over the network"),
+    ]
+    write_chunks(chunks_path, chunks)
+
+    embedder = MappingTestEmbedder(
+        {
+            chunks[0].text: [1.0, 0.0, 0.0],
+            chunks[1].text: [0.8, 0.2, 0.0],
+            chunks[2].text: [0.0, 1.0, 0.0],
+        }
+    )
+    build_embedding_artifacts(
+        chunks_path=chunks_path,
+        vectors_path=vectors_path,
+        metadata_path=embedding_metadata_path,
+        embedder=embedder,
+        batch_size=2,
+    )
+    build_faiss_index_artifacts(
+        embedding_metadata_path=embedding_metadata_path,
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+    )
+
+    return {
+        "chunks_path": chunks_path,
+        "index_path": index_path,
+        "index_metadata_path": index_metadata_path,
+        "row_mapping_path": row_mapping_path,
+    }
+
+
+def test_smoke_dense_retrieval_cli_prints_ranked_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    retrieval_fixture: dict[str, Path],
+) -> None:
+    from supportdoc_rag_chatbot.retrieval import smoke
+
+    captured: dict[str, object] = {}
+
+    def fake_create_local_embedder(*, model_name, device, batch_size, normalize_embeddings):
+        captured["model_name"] = model_name
+        captured["device"] = device
+        captured["batch_size"] = batch_size
+        captured["normalize_embeddings"] = normalize_embeddings
+        return QueryTestEmbedder({"alpha pods": [1.0, 0.0, 0.0]})
+
+    monkeypatch.setattr(smoke, "create_local_embedder", fake_create_local_embedder)
+
+    exit_code = main(
+        [
+            "smoke-dense-retrieval",
+            "--query",
+            "alpha pods",
+            "--top-k",
+            "2",
+            "--index",
+            str(retrieval_fixture["index_path"]),
+            "--index-metadata",
+            str(retrieval_fixture["index_metadata_path"]),
+            "--row-mapping",
+            str(retrieval_fixture["row_mapping_path"]),
+            "--chunks",
+            str(retrieval_fixture["chunks_path"]),
+            "--preview-chars",
+            "24",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured == {
+        "model_name": "test-map-v1",
+        "device": "cpu",
+        "batch_size": 32,
+        "normalize_embeddings": True,
+    }
+
+    out = capsys.readouterr().out
+    assert "Dense retrieval smoke test" in out
+    assert 'query: "alpha pods"' in out
+    assert "model: test-map-v1" in out
+    assert "[1] score=" in out
+    assert "chunk_id=chunk-alpha" in out
+    assert "chunk_id=chunk-beta" in out
+    assert out.index("chunk_id=chunk-alpha") < out.index("chunk_id=chunk-beta")
+    assert "section_path: Pods" in out
+    assert "source_url: https://kubernetes.io/docs/concepts/workloads/pods/" in out
+    assert "preview: alpha pods can run one…" in out
+
+
+def test_smoke_dense_retrieval_cli_fails_when_index_metadata_is_missing(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    exit_code = main(
+        [
+            "smoke-dense-retrieval",
+            "--query",
+            "alpha pods",
+            "--index-metadata",
+            str(tmp_path / "missing/chunk_index.metadata.json"),
+        ]
+    )
+
+    assert exit_code == 2
+    expected_error = tmp_path / "missing/chunk_index.metadata.json"
+    assert f"Error: Index metadata artifact not found: {expected_error}" in capsys.readouterr().err
+
+
+def _numpy():
+    import numpy
+
+    return numpy


### PR DESCRIPTION
Closes #33

What changed:

- `src/supportdoc_rag_chatbot/cli.py`
  - adds `smoke-dense-retrieval`
- `src/supportdoc_rag_chatbot/retrieval/smoke.py`
  - new join/format/report logic for query → embed → FAISS search → chunk lookup
- `src/supportdoc_rag_chatbot/retrieval/__init__.py`
  - exports the smoke helpers
- `tests/test_retrieval_smoke_cli.py`
  - success test against a tiny fixture index
  - clear failure test for missing artifacts
- `README.md`
  - adds the copy-paste smoke command
  - updates status text so it matches the codebase

Behavior of the new CLI:

- loads the FAISS index + metadata
- defaults the query embedding model from the index metadata
- embeds the query text
- searches top-k
- joins hits back to `chunks.jsonl`
- prints:
  - rank
  - score
  - chunk ID
  - section path
  - source URL
  - short preview

Your branch is up to date with 'origin/feat/33-add-retrieval-smoke-test-cli-for-local-dense-search'.

Changes to be committed:
	modified:   README.md
	modified:   src/supportdoc_rag_chatbot/cli.py
	modified:   src/supportdoc_rag_chatbot/retrieval/__init__.py
	new file:   src/supportdoc_rag_chatbot/retrieval/smoke.py
	new file:   tests/test_retrieval_smoke_cli.py