### PR TITLE
On branch retrieval/39-dense-retrieval-baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,6 @@ data/processed/embeddings/
 
 data/processed/indexes/
 
-# Local evaluation artifacts
+# Local retrieval evaluation outputs
 data/evaluation/runs/
 tmp/eval/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The initial corpus is a pinned snapshot of Kubernetes documentation so the proje
 This README is maintained as a live project document and evolves with each completed task issue.
 
 ### Current Phase
-Retrieval baseline evaluation harness.
+Dense retrieval baseline evaluation.
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
@@ -23,17 +23,16 @@ Retrieval baseline evaluation harness.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
 - Local FAISS backend that builds, persists, reloads, and searches a dense index over saved embedding artifacts.
 - Developer-facing retrieval smoke CLI for local dense search over a saved FAISS index.
-- Versioned Dev QA retrieval dataset tied to the current Kubernetes snapshot.
-- Retrieval evaluation harness that writes deterministic per-query and summary artifacts.
+- Shared retrieval evaluation harness and dense baseline runner that execute the committed Dev QA set and write deterministic result artifacts.
 
 ### In Progress
 - Citation contract and refusal behavior integration.
 
 ### Next Up
-- Run dense, BM25, and hybrid baselines through the shared evaluation harness.
-- Write retrieval comparison notes and choose the default retrieval configuration for the next stage.
+- Add BM25 and hybrid retrievers behind the same evaluation harness.
 - Connect retrieval outputs to generation and citation validation.
 - Expand deployment and observability documentation as the backend/API layer matures.
+- Compare dense, BM25, and hybrid retrieval artifacts to choose the default baseline.
 
 ---
 
@@ -141,17 +140,16 @@ The row-mapping artifact stores the chunk IDs in row order so the FAISS index ca
 
 ```text
 src/supportdoc_rag_chatbot/
-  evaluation/             # Dev QA loaders, retrievers, and evaluation harness
   ingestion/              # Manifest, parse, chunk, validation pipeline
   retrieval/
     embeddings/           # Local embedding job + artifact I/O
     indexes/              # Dense index interfaces + local FAISS backend
     smoke.py              # Developer-facing dense retrieval smoke helpers
   app/                    # Backend orchestration entrypoints (to grow over time)
+  evaluation/             # Dev QA loading, retrieval harness, and baseline runners
   resources/              # Default config and packaged resources
 
 data/
-  evaluation/             # Versioned dev QA sets and local evaluation runs
   manifests/              # Source manifests
   parsed/                 # Section-level parsed artifacts
   processed/              # Chunk, embedding, and index artifacts
@@ -273,45 +271,6 @@ Useful options:
 - `--device cpu|cuda|mps`
 - `--preview-chars 200`
 
-### Run a retrieval-evaluation smoke test
-
-The evaluation harness can run with a static fixture retriever, so you can verify artifact writing and metric computation without building local embeddings or indexes first.
-
-```bash
-uv run python -m supportdoc_rag_chatbot evaluate-retrieval \
-  --retriever-kind static \
-  --fixture-name oracle \
-  --top-k 5
-```
-
-By default, the evaluation command:
-
-- loads the committed dev QA dataset under `data/evaluation/`,
-- validates it against the committed metadata + evidence registry,
-- writes per-query artifacts under `data/evaluation/runs/`, and
-- writes a companion summary artifact with hit@k, recall@k, MRR, and latency statistics.
-
-If you want to run the lexical retriever over a local `chunks.jsonl` artifact, use:
-
-```bash
-uv run python -m supportdoc_rag_chatbot evaluate-retrieval \
-  --retriever-kind bm25 \
-  --chunks data/processed/chunks.jsonl \
-  --top-k 5
-```
-
-If you want to run dense or hybrid evaluation over the local FAISS backend, install the dense extras first and pass the saved index artifacts:
-
-```bash
-uv sync --locked --extra dev-tools --extra embeddings-local --extra faiss
-
-uv run python -m supportdoc_rag_chatbot evaluate-retrieval \
-  --retriever-kind dense \
-  --index data/processed/indexes/faiss/chunk_index.faiss \
-  --index-metadata data/processed/indexes/faiss/chunk_index.metadata.json \
-  --top-k 5
-```
-
 ### Local verification
 
 Run lint and tests:
@@ -345,19 +304,25 @@ A small versioned development QA set now lives under `data/evaluation/` for retr
 
 The evaluation helpers in `src/supportdoc_rag_chatbot/evaluation/dev_qa.py` can load the dataset, load the companion metadata/registry files, and validate that every annotated evidence ID belongs to the same snapshot. See `docs/process/retrieval_dev_qa.md` for the schema, annotation rules, and validation workflow.
 
-## 9B. Retrieval Evaluation Harness
+## 9B. Dense Retrieval Baseline Evaluation
 
-The evaluation harness lives in `src/supportdoc_rag_chatbot/evaluation/harness.py` and `src/supportdoc_rag_chatbot/evaluation/retrievers.py`.
+The repository now includes a shared retrieval evaluation harness plus a dense baseline runner. The dense baseline loads an already-built FAISS index, embeds each committed Dev QA query with the embedding model recorded in the index metadata, retrieves top-k chunk IDs, and writes deterministic artifacts under `data/evaluation/runs/` by default.
 
-It provides:
+Default dense baseline command:
 
-- deterministic run IDs and default output paths,
-- a common retriever interface for dense, BM25, hybrid, and static fixture runs,
-- per-query JSONL artifacts with ranked chunk hits,
-- summary JSON artifacts with hit@k, recall@k, MRR, and latency statistics, and
-- a CLI entrypoint via `supportdoc_rag_chatbot evaluate-retrieval`.
+```bash
+uv run python -m supportdoc_rag_chatbot run-dense-baseline \
+  --index data/processed/indexes/faiss/chunk_index.faiss \
+  --index-metadata data/processed/indexes/faiss/chunk_index.metadata.json \
+  --top-k 5
+```
 
-See `docs/process/retrieval_evaluation_harness.md` for the artifact schema, smoke-test workflow, and implementation notes.
+The dense run writes:
+
+- a per-query results JSONL artifact
+- a summary JSON artifact with hit@k, recall@k, MRR, and latency
+
+See `docs/process/dense_retrieval_baseline.md` for the exact baseline configuration and output layout.
 
 ---
 
@@ -370,9 +335,8 @@ The intended deployment path is a FastAPI backend with a web frontend, persisten
 ## 11. Documentation Map / Roadmap
 
 - `docs/process/git_workflow.md` — branch / PR / lockfile workflow
-- `docs/process/retrieval_dev_qa.md` — dev QA dataset schema and annotation rules
-- `docs/process/retrieval_evaluation_harness.md` — evaluation harness schema and local workflow
 - `docs/data/corpus.md` — corpus scope and licensing notes
 - `docs/diagrams/ingestion_pipeline.md` — ingestion pipeline overview
 - `docs/adr/` — architecture decisions and project rationale
+- `docs/process/dense_retrieval_baseline.md` — default dense baseline config and run command
 - `PROPOSAL.md` — project proposal and delivery framing

--- a/docs/process/dense_retrieval_baseline.md
+++ b/docs/process/dense_retrieval_baseline.md
@@ -1,0 +1,51 @@
+# Dense Retrieval Baseline
+
+This document records the default dense retrieval baseline used for Epic 4 comparisons.
+
+## Goal
+
+Run the committed development QA dataset against an already-built local FAISS index without rebuilding chunks, embeddings, or index artifacts.
+
+The baseline writes:
+
+- per-query ranked retrieval results (`.results.jsonl`)
+- summary metrics (`.summary.json`)
+
+## Default baseline configuration
+
+- Retriever name: `dense`
+- Embedding model: recorded in the FAISS index metadata, defaulting to `sentence-transformers/all-MiniLM-L6-v2` for local MVP work
+- Index backend: `faiss-flat-ip`
+- Default top-k: `5`
+- Dataset: `data/evaluation/dev_qa.k8s-9e1e32b.v1.jsonl`
+
+## Output paths
+
+By default, the dense baseline writes deterministic artifacts under:
+
+- `data/evaluation/runs/dense-k8s-9e1e32b-v1-top5-default.results.jsonl`
+- `data/evaluation/runs/dense-k8s-9e1e32b-v1-top5-default.summary.json`
+
+You can override either path explicitly from the CLI.
+
+## Exact local command
+
+After local embedding and FAISS index artifacts exist, run:
+
+```bash
+uv run python -m supportdoc_rag_chatbot run-dense-baseline \
+  --index data/processed/indexes/faiss/chunk_index.faiss \
+  --index-metadata data/processed/indexes/faiss/chunk_index.metadata.json \
+  --top-k 5
+```
+
+The command loads the committed Dev QA set, embeds each question with the embedding model recorded in the FAISS metadata, runs dense retrieval through the shared evaluation harness, and writes deterministic result artifacts.
+
+## Smoke test workflow
+
+```bash
+uv sync --locked --extra dev-tools --extra faiss
+uv run pytest -q tests/test_dense_retrieval_baseline.py
+uv run pre-commit run --all-files
+uv run pytest -q
+```

--- a/src/supportdoc_rag_chatbot/cli.py
+++ b/src/supportdoc_rag_chatbot/cli.py
@@ -10,6 +10,7 @@ from supportdoc_rag_chatbot.evaluation import (
     DEFAULT_HYBRID_CANDIDATE_DEPTH,
     DEFAULT_RRF_K,
     BM25ChunkEvaluationRetriever,
+    DenseBaselineConfig,
     DenseFaissEvaluationRetriever,
     HybridRRFEvaluationRetriever,
     create_dev_qa_fixture_retriever,
@@ -19,7 +20,9 @@ from supportdoc_rag_chatbot.evaluation import (
     load_dev_qa_dataset,
     load_dev_qa_metadata,
     load_evidence_registry,
+    render_dense_baseline_report,
     render_retrieval_evaluation_report,
+    run_dense_baseline,
     write_query_results,
     write_retrieval_run_summary,
 )
@@ -310,6 +313,92 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     eval_parser.set_defaults(handler=_run_evaluate_retrieval)
 
+    dense_baseline_parser = subparsers.add_parser(
+        "run-dense-baseline",
+        help="Run the dense retrieval baseline over the dev QA set and write deterministic artifacts",
+    )
+    dense_baseline_parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=None,
+        help="Optional path to a dev QA dataset JSONL (defaults to committed dataset)",
+    )
+    dense_baseline_parser.add_argument(
+        "--dataset-metadata",
+        type=Path,
+        default=None,
+        help="Optional path to dev QA metadata JSON (defaults to committed metadata)",
+    )
+    dense_baseline_parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Optional path to an evidence registry JSON (defaults to committed registry or derives from chunks)",
+    )
+    dense_baseline_parser.add_argument(
+        "--index",
+        type=Path,
+        default=DEFAULT_FAISS_INDEX_PATH,
+        help="Path to the persisted FAISS index file",
+    )
+    dense_baseline_parser.add_argument(
+        "--index-metadata",
+        type=Path,
+        default=DEFAULT_FAISS_METADATA_PATH,
+        help="Path to the FAISS index metadata JSON",
+    )
+    dense_baseline_parser.add_argument(
+        "--row-mapping",
+        type=Path,
+        default=None,
+        help="Optional FAISS row mapping override",
+    )
+    dense_baseline_parser.add_argument(
+        "--model-name",
+        default=None,
+        help="Optional embedding model override for query embedding",
+    )
+    dense_baseline_parser.add_argument(
+        "--device",
+        default=DEFAULT_DEVICE,
+        help="Embedding device, for example cpu, cuda, or mps",
+    )
+    dense_baseline_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Embedding batch size for query embedding",
+    )
+    dense_baseline_parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_EVAL_TOP_K,
+        help="Number of ranked hits to keep per query",
+    )
+    dense_baseline_parser.add_argument(
+        "--run-name",
+        default=None,
+        help="Optional run name override for output artifact naming",
+    )
+    dense_baseline_parser.add_argument(
+        "--run-label",
+        default="default",
+        help="Logical label appended to the default dense run name",
+    )
+    dense_baseline_parser.add_argument(
+        "--results-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the per-query retrieval results JSONL",
+    )
+    dense_baseline_parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the summary metrics JSON",
+    )
+    dense_baseline_parser.set_defaults(handler=_run_dense_baseline)
+
     return parser
 
 
@@ -365,6 +454,29 @@ def _run_smoke_dense_retrieval(args: argparse.Namespace) -> int:
         preview_chars=args.preview_chars,
     )
     print(render_dense_retrieval_smoke_report(report))
+    return 0
+
+
+def _run_dense_baseline(args: argparse.Namespace) -> int:
+    run = run_dense_baseline(
+        config=DenseBaselineConfig(
+            dataset_path=args.dataset,
+            dataset_metadata_path=args.dataset_metadata,
+            registry_path=args.registry,
+            index_path=args.index,
+            index_metadata_path=args.index_metadata,
+            row_mapping_path=args.row_mapping,
+            model_name=args.model_name,
+            device=args.device,
+            batch_size=args.batch_size,
+            top_k=args.top_k,
+            run_name=args.run_name,
+            run_label=args.run_label,
+            results_output_path=args.results_output,
+            summary_output_path=args.summary_output,
+        )
+    )
+    print(render_dense_baseline_report(run))
     return 0
 
 

--- a/src/supportdoc_rag_chatbot/evaluation/__init__.py
+++ b/src/supportdoc_rag_chatbot/evaluation/__init__.py
@@ -1,3 +1,21 @@
+from .artifacts import (
+    RetrievalQueryArtifact,
+    RetrievalRunArtifacts,
+    RetrievalSummaryArtifact,
+    RetrievedChunkArtifact,
+    read_retrieval_results,
+    read_retrieval_summary,
+    write_retrieval_results,
+    write_retrieval_summary,
+)
+from .dense_baseline import (
+    DEFAULT_DENSE_BASELINE_LABEL,
+    DEFAULT_DENSE_BASELINE_TOP_K,
+    DenseBaselineConfig,
+    DenseBaselineRetriever,
+    render_dense_baseline_report,
+    run_dense_baseline,
+)
 from .dev_qa import (
     DEFAULT_DATASET_FILENAME,
     DEFAULT_DATASET_VERSION,
@@ -50,6 +68,20 @@ from .retrievers import (
 )
 
 __all__ = [
+    "write_retrieval_summary",
+    "write_retrieval_results",
+    "run_dense_baseline",
+    "render_dense_baseline_report",
+    "read_retrieval_summary",
+    "read_retrieval_results",
+    "RetrievedChunkArtifact",
+    "RetrievalSummaryArtifact",
+    "RetrievalRunArtifacts",
+    "RetrievalQueryArtifact",
+    "DenseBaselineRetriever",
+    "DenseBaselineConfig",
+    "DEFAULT_DENSE_BASELINE_TOP_K",
+    "DEFAULT_DENSE_BASELINE_LABEL",
     "DEFAULT_DATASET_FILENAME",
     "DEFAULT_DATASET_VERSION",
     "DEFAULT_EVAL_TOP_K",

--- a/src/supportdoc_rag_chatbot/evaluation/artifacts.py
+++ b/src/supportdoc_rag_chatbot/evaluation/artifacts.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_EVALUATION_RUNS_DIR = Path("data/evaluation/runs")
+
+
+@dataclass(slots=True)
+class RetrievedChunkArtifact:
+    chunk_id: str
+    rank: int
+    score: float
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RetrievedChunkArtifact":
+        return cls(
+            chunk_id=str(payload["chunk_id"]),
+            rank=int(payload["rank"]),
+            score=float(payload["score"]),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RetrievalQueryArtifact:
+    query_id: str
+    question: str
+    answerable: bool
+    snapshot_id: str
+    retriever_name: str
+    top_k: int
+    latency_ms: float
+    expected_chunk_ids: list[str]
+    matches: list[RetrievedChunkArtifact]
+    retriever_config: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RetrievalQueryArtifact":
+        return cls(
+            query_id=str(payload["query_id"]),
+            question=str(payload["question"]),
+            answerable=bool(payload["answerable"]),
+            snapshot_id=str(payload["snapshot_id"]),
+            retriever_name=str(payload["retriever_name"]),
+            top_k=int(payload["top_k"]),
+            latency_ms=float(payload["latency_ms"]),
+            expected_chunk_ids=[str(item) for item in payload.get("expected_chunk_ids", [])],
+            matches=[
+                RetrievedChunkArtifact.from_dict(match)
+                for match in payload.get("matches", [])
+            ],
+            retriever_config=dict(payload.get("retriever_config", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["matches"] = [match.to_dict() for match in self.matches]
+        return payload
+
+
+@dataclass(slots=True)
+class RetrievalSummaryArtifact:
+    run_name: str
+    dataset_name: str
+    dataset_version: str
+    snapshot_id: str
+    retriever_name: str
+    top_k: int
+    query_count: int
+    answerable_query_count: int
+    hit_at_k: float
+    recall_at_k: float
+    mrr: float
+    mean_latency_ms: float
+    max_latency_ms: float
+    results_output_path: str
+    summary_output_path: str
+    retriever_config: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RetrievalSummaryArtifact":
+        return cls(
+            run_name=str(payload["run_name"]),
+            dataset_name=str(payload["dataset_name"]),
+            dataset_version=str(payload["dataset_version"]),
+            snapshot_id=str(payload["snapshot_id"]),
+            retriever_name=str(payload["retriever_name"]),
+            top_k=int(payload["top_k"]),
+            query_count=int(payload["query_count"]),
+            answerable_query_count=int(payload["answerable_query_count"]),
+            hit_at_k=float(payload["hit_at_k"]),
+            recall_at_k=float(payload["recall_at_k"]),
+            mrr=float(payload["mrr"]),
+            mean_latency_ms=float(payload["mean_latency_ms"]),
+            max_latency_ms=float(payload["max_latency_ms"]),
+            results_output_path=str(payload["results_output_path"]),
+            summary_output_path=str(payload["summary_output_path"]),
+            retriever_config=dict(payload.get("retriever_config", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RetrievalRunArtifacts:
+    results: list[RetrievalQueryArtifact]
+    summary: RetrievalSummaryArtifact
+
+
+
+def write_retrieval_results(path: Path, results: Iterable[RetrievalQueryArtifact]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in results:
+            handle.write(json.dumps(row.to_dict(), sort_keys=True) + "\n")
+
+
+
+def read_retrieval_results(path: Path) -> list[RetrievalQueryArtifact]:
+    rows: list[RetrievalQueryArtifact] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            payload = line.strip()
+            if not payload:
+                continue
+            try:
+                row = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSONL in {path} on line {line_number}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(
+                    f"Invalid JSONL record in {path} on line {line_number}: expected object"
+                )
+            rows.append(RetrievalQueryArtifact.from_dict(row))
+    return rows
+
+
+
+def write_retrieval_summary(path: Path, summary: RetrievalSummaryArtifact) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(summary.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+
+def read_retrieval_summary(path: Path) -> RetrievalSummaryArtifact:
+    return RetrievalSummaryArtifact.from_dict(json.loads(path.read_text(encoding="utf-8")))

--- a/src/supportdoc_rag_chatbot/evaluation/dense_baseline.py
+++ b/src/supportdoc_rag_chatbot/evaluation/dense_baseline.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from supportdoc_rag_chatbot.retrieval.embeddings import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_DEVICE,
+    create_local_embedder,
+    load_chunk_records,
+)
+from supportdoc_rag_chatbot.retrieval.indexes import (
+    DEFAULT_FAISS_INDEX_PATH,
+    DEFAULT_FAISS_METADATA_PATH,
+    load_faiss_index_backend,
+    read_index_metadata,
+)
+
+from .artifacts import (
+    RetrievalQueryArtifact,
+    RetrievalRunArtifacts,
+    RetrievalSummaryArtifact,
+    RetrievedChunkArtifact,
+    write_retrieval_results,
+    write_retrieval_summary,
+)
+from .dev_qa import (
+    DevQAEntry,
+    DevQAMetadata,
+    EvidenceRegistry,
+    default_dev_qa_paths,
+    load_default_dev_qa_dataset,
+    load_default_dev_qa_metadata,
+    load_default_evidence_registry,
+    load_dev_qa_dataset,
+    load_dev_qa_metadata,
+    load_evidence_registry,
+)
+from .harness import RetrievalHit, evaluate_retriever
+
+DEFAULT_DENSE_BASELINE_TOP_K = 5
+DEFAULT_DENSE_BASELINE_LABEL = "default"
+
+
+@dataclass(slots=True)
+class DenseBaselineConfig:
+    index_path: Path = DEFAULT_FAISS_INDEX_PATH
+    index_metadata_path: Path = DEFAULT_FAISS_METADATA_PATH
+    row_mapping_path: Path | None = None
+    dataset_path: Path | None = None
+    dataset_metadata_path: Path | None = None
+    registry_path: Path | None = None
+    model_name: str | None = None
+    device: str = DEFAULT_DEVICE
+    batch_size: int = DEFAULT_BATCH_SIZE
+    top_k: int = DEFAULT_DENSE_BASELINE_TOP_K
+    run_name: str | None = None
+    run_label: str = DEFAULT_DENSE_BASELINE_LABEL
+    results_output_path: Path | None = None
+    summary_output_path: Path | None = None
+
+
+class DenseBaselineRetriever:
+    name = "dense"
+    retriever_type = "dense"
+
+    def __init__(self, config: DenseBaselineConfig) -> None:
+        if config.top_k <= 0:
+            raise ValueError("top_k must be > 0")
+
+        index_metadata = read_index_metadata(config.index_metadata_path)
+        self.backend = load_faiss_index_backend(
+            index_path=config.index_path,
+            metadata_path=config.index_metadata_path,
+            row_mapping_path=config.row_mapping_path,
+        )
+        self.model_name = config.model_name or index_metadata.embedding_model_name
+        self.index_backend_name = index_metadata.backend_name
+        self.embedder = create_local_embedder(
+            model_name=self.model_name,
+            device=config.device,
+            batch_size=config.batch_size,
+            normalize_embeddings=True,
+        )
+        self.chunk_info_by_id = {
+            chunk.chunk_id: chunk for chunk in load_chunk_records(Path(index_metadata.source_chunks_path))
+        }
+        self.config = {
+            "embedding_model_name": self.model_name,
+            "index_backend": self.index_backend_name,
+            "top_k": config.top_k,
+            "index_path": str(config.index_path),
+            "index_metadata_path": str(config.index_metadata_path),
+        }
+
+    def retrieve(self, entry: DevQAEntry, *, top_k: int) -> list[RetrievalHit]:
+        normalized_query = " ".join(entry.question.split())
+        if not normalized_query:
+            return []
+
+        query_vectors = self.embedder.embed_texts([normalized_query])
+        if len(query_vectors) != 1:
+            raise ValueError(
+                f"Embedding backend returned {len(query_vectors)} rows for a single query"
+            )
+
+        results = self.backend.search(query_vectors[0], top_k=top_k)
+        hits: list[RetrievalHit] = []
+        for result in results:
+            chunk = self.chunk_info_by_id.get(result.chunk_id)
+            hits.append(
+                RetrievalHit(
+                    chunk_id=result.chunk_id,
+                    score=float(result.score),
+                    rank=int(result.rank),
+                    doc_id=(chunk.doc_id if chunk is not None else None),
+                    section_id=(chunk.section_id if chunk is not None else None),
+                )
+            )
+        return hits
+
+
+def run_dense_baseline(config: DenseBaselineConfig | None = None) -> RetrievalRunArtifacts:
+    runtime_config = config or DenseBaselineConfig()
+
+    dataset_entries, dataset_metadata = _load_dataset_surface(runtime_config)
+    registry = _load_registry_surface(runtime_config, dataset_metadata)
+    retriever = DenseBaselineRetriever(runtime_config)
+
+    results_output_path, summary_output_path = _resolve_output_paths(
+        config=runtime_config,
+        dataset_metadata=dataset_metadata,
+    )
+    run_name = runtime_config.run_name or _default_run_name(
+        metadata=dataset_metadata,
+        top_k=runtime_config.top_k,
+        label=runtime_config.run_label,
+    )
+
+    harness_results, harness_summary = evaluate_retriever(
+        retriever=retriever,
+        entries=dataset_entries,
+        metadata=dataset_metadata,
+        registry=registry,
+        top_k=runtime_config.top_k,
+    )
+
+    result_artifacts = [
+        RetrievalQueryArtifact(
+            query_id=result.query_id,
+            question=result.question,
+            answerable=result.answerable,
+            snapshot_id=result.snapshot_id,
+            retriever_name=result.retriever_name,
+            top_k=result.top_k,
+            latency_ms=result.latency_ms,
+            expected_chunk_ids=list(result.expected_chunk_ids),
+            matches=[
+                RetrievedChunkArtifact(
+                    chunk_id=hit.chunk_id,
+                    rank=hit.rank,
+                    score=hit.score,
+                )
+                for hit in result.hits
+            ],
+            retriever_config=dict(result.retriever_config),
+        )
+        for result in harness_results
+    ]
+
+    summary_artifact = RetrievalSummaryArtifact(
+        run_name=run_name,
+        dataset_name=dataset_metadata.dataset_name,
+        dataset_version=dataset_metadata.dataset_version,
+        snapshot_id=dataset_metadata.snapshot_id,
+        retriever_name=harness_summary.retriever_name,
+        top_k=harness_summary.top_k,
+        query_count=harness_summary.total_query_count,
+        answerable_query_count=harness_summary.answerable_query_count,
+        hit_at_k=harness_summary.hit_at_k,
+        recall_at_k=harness_summary.recall_at_k,
+        mrr=harness_summary.mrr,
+        mean_latency_ms=harness_summary.average_latency_ms,
+        max_latency_ms=harness_summary.max_latency_ms,
+        results_output_path=str(results_output_path),
+        summary_output_path=str(summary_output_path),
+        retriever_config=dict(harness_summary.retriever_config),
+    )
+
+    write_retrieval_results(results_output_path, result_artifacts)
+    write_retrieval_summary(summary_output_path, summary_artifact)
+    return RetrievalRunArtifacts(results=result_artifacts, summary=summary_artifact)
+
+
+
+def render_dense_baseline_report(run: RetrievalRunArtifacts) -> str:
+    summary = run.summary
+    config = summary.retriever_config
+    lines = [
+        "Dense retrieval baseline",
+        f"run_name: {summary.run_name}",
+        f"dataset: {summary.dataset_name}:{summary.dataset_version}",
+        f"snapshot_id: {summary.snapshot_id}",
+        f"embedding_model: {config.get('embedding_model_name', '(unknown)')}",
+        f"index_backend: {config.get('index_backend', '(unknown)')}",
+        f"top_k: {summary.top_k}",
+        f"query_count: {summary.query_count}",
+        f"answerable_query_count: {summary.answerable_query_count}",
+        f"hit@k: {summary.hit_at_k:.6f}",
+        f"recall@k: {summary.recall_at_k:.6f}",
+        f"mrr: {summary.mrr:.6f}",
+        f"mean_latency_ms: {summary.mean_latency_ms:.3f}",
+        f"max_latency_ms: {summary.max_latency_ms:.3f}",
+        f"results_output: {summary.results_output_path}",
+        f"summary_output: {summary.summary_output_path}",
+    ]
+    return "\n".join(lines)
+
+
+
+def _load_dataset_surface(
+    config: DenseBaselineConfig,
+) -> tuple[list[DevQAEntry], DevQAMetadata]:
+    if config.dataset_path is None:
+        dataset_entries = load_default_dev_qa_dataset()
+    else:
+        dataset_entries = load_dev_qa_dataset(config.dataset_path)
+
+    if config.dataset_metadata_path is None:
+        dataset_metadata = load_default_dev_qa_metadata()
+    else:
+        dataset_metadata = load_dev_qa_metadata(config.dataset_metadata_path)
+
+    return dataset_entries, dataset_metadata
+
+
+
+def _load_registry_surface(
+    config: DenseBaselineConfig,
+    metadata: DevQAMetadata,
+) -> EvidenceRegistry:
+    if config.registry_path is not None:
+        return load_evidence_registry(config.registry_path)
+
+    if config.dataset_path is None and config.dataset_metadata_path is None:
+        return load_default_evidence_registry()
+
+    entries = (
+        load_default_dev_qa_dataset()
+        if config.dataset_path is None
+        else load_dev_qa_dataset(config.dataset_path)
+    )
+    index_metadata = read_index_metadata(config.index_metadata_path)
+    chunks = load_chunk_records(Path(index_metadata.source_chunks_path))
+
+    chunk_doc_ids = sorted({chunk.doc_id for chunk in chunks})
+    entry_doc_ids = sorted({doc_id for entry in entries for doc_id in entry.doc_ids})
+    chunk_section_ids = sorted({chunk.section_id for chunk in chunks})
+    entry_section_ids = sorted(
+        {section_id for entry in entries for section_id in entry.expected_section_ids}
+    )
+    chunk_ids = sorted({chunk.chunk_id for chunk in chunks})
+    entry_chunk_ids = sorted({chunk_id for entry in entries for chunk_id in entry.expected_chunk_ids})
+
+    return EvidenceRegistry(
+        snapshot_id=metadata.snapshot_id,
+        source_manifest_path=metadata.source_manifest_path,
+        doc_ids=_select_ids(expected_count=metadata.doc_count, primary=entry_doc_ids, fallback=chunk_doc_ids),
+        section_ids=_select_ids(
+            expected_count=metadata.section_id_count,
+            primary=entry_section_ids,
+            fallback=chunk_section_ids,
+        ),
+        chunk_ids=_select_ids(expected_count=metadata.chunk_id_count, primary=chunk_ids, fallback=entry_chunk_ids),
+        default_chunking=dict(metadata.default_chunking),
+    )
+
+
+
+def _default_run_name(*, metadata: DevQAMetadata, top_k: int, label: str) -> str:
+    return (
+        f"dense-{metadata.snapshot_id}-{metadata.dataset_version}-"
+        f"top{top_k}-{label}"
+    )
+
+
+
+def _resolve_output_paths(
+    *,
+    config: DenseBaselineConfig,
+    dataset_metadata: DevQAMetadata,
+) -> tuple[Path, Path]:
+    if config.results_output_path is not None and config.summary_output_path is not None:
+        return config.results_output_path, config.summary_output_path
+
+    run_name = config.run_name or _default_run_name(
+        metadata=dataset_metadata,
+        top_k=config.top_k,
+        label=config.run_label,
+    )
+    default_dataset_path, _, _ = default_dev_qa_paths()
+    repo_root = default_dataset_path.parents[2]
+
+    results_output_path = config.results_output_path or (
+        repo_root / "data" / "evaluation" / "runs" / f"{run_name}.results.jsonl"
+    )
+    summary_output_path = config.summary_output_path or (
+        repo_root / "data" / "evaluation" / "runs" / f"{run_name}.summary.json"
+    )
+    return results_output_path, summary_output_path
+
+
+
+def _select_ids(*, expected_count: int, primary: list[str], fallback: list[str]) -> list[str]:
+    if len(primary) == expected_count:
+        return primary
+    if len(fallback) == expected_count:
+        return fallback
+    if primary:
+        return primary
+    return fallback

--- a/src/supportdoc_rag_chatbot/evaluation/metrics.py
+++ b/src/supportdoc_rag_chatbot/evaluation/metrics.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Iterable
+
+from .artifacts import RetrievalQueryArtifact
+
+
+@dataclass(slots=True)
+class RetrievalMetrics:
+    query_count: int
+    answerable_query_count: int
+    hit_at_k: float
+    recall_at_k: float
+    mrr: float
+    mean_latency_ms: float
+    max_latency_ms: float
+
+
+
+def compute_retrieval_metrics(results: Iterable[RetrievalQueryArtifact]) -> RetrievalMetrics:
+    rows = list(results)
+    query_count = len(rows)
+    answerable_rows = [row for row in rows if row.answerable]
+    answerable_query_count = len(answerable_rows)
+
+    latencies = [max(0.0, float(row.latency_ms)) for row in rows]
+    mean_latency_ms = mean(latencies) if latencies else 0.0
+    max_latency_ms = max(latencies, default=0.0)
+
+    if answerable_query_count == 0:
+        return RetrievalMetrics(
+            query_count=query_count,
+            answerable_query_count=0,
+            hit_at_k=0.0,
+            recall_at_k=0.0,
+            mrr=0.0,
+            mean_latency_ms=mean_latency_ms,
+            max_latency_ms=max_latency_ms,
+        )
+
+    hit_values: list[float] = []
+    recall_values: list[float] = []
+    reciprocal_ranks: list[float] = []
+
+    for row in answerable_rows:
+        relevant = set(row.expected_chunk_ids)
+        retrieved = [match.chunk_id for match in row.matches]
+        retrieved_relevant = [chunk_id for chunk_id in retrieved if chunk_id in relevant]
+
+        hit_values.append(1.0 if retrieved_relevant else 0.0)
+        recall_values.append(len(set(retrieved_relevant)) / len(relevant) if relevant else 0.0)
+
+        reciprocal_rank = 0.0
+        for match in row.matches:
+            if match.chunk_id in relevant:
+                reciprocal_rank = 1.0 / float(match.rank)
+                break
+        reciprocal_ranks.append(reciprocal_rank)
+
+    return RetrievalMetrics(
+        query_count=query_count,
+        answerable_query_count=answerable_query_count,
+        hit_at_k=mean(hit_values),
+        recall_at_k=mean(recall_values),
+        mrr=mean(reciprocal_ranks),
+        mean_latency_ms=mean_latency_ms,
+        max_latency_ms=max_latency_ms,
+    )

--- a/tests/test_dense_retrieval_baseline.py
+++ b/tests/test_dense_retrieval_baseline.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+import pickle
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from supportdoc_rag_chatbot.cli import main
+from supportdoc_rag_chatbot.evaluation import read_retrieval_results, read_retrieval_summary
+from supportdoc_rag_chatbot.evaluation.dev_qa import DevQAEntry, DevQAMetadata
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import build_embedding_artifacts
+from supportdoc_rag_chatbot.retrieval.indexes import build_faiss_index_artifacts
+
+
+class MappingTestEmbedder:
+    model_name = "test-map-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self.mapping = mapping
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[float(value) for value in self.mapping[text]] for text in texts]
+
+
+class FakeFaissIndexFlatIP:
+    def __init__(self, dimension: int) -> None:
+        self.d = int(dimension)
+        self.ntotal = 0
+        self._vectors = _numpy().empty((0, self.d), dtype=_numpy().float32)
+
+    def add(self, vectors) -> None:
+        vectors_array = _numpy().asarray(vectors, dtype=_numpy().float32)
+        if vectors_array.ndim != 2 or vectors_array.shape[1] != self.d:
+            raise ValueError("FakeFaissIndexFlatIP.add received vectors with the wrong shape")
+        self._vectors = _numpy().vstack([self._vectors, vectors_array])
+        self.ntotal = int(self._vectors.shape[0])
+
+    def search(self, queries, top_k: int):
+        queries_array = _numpy().asarray(queries, dtype=_numpy().float32)
+        scores = queries_array @ self._vectors.T
+        ranked_indexes = _numpy().argsort(-scores, axis=1, kind="stable")[:, :top_k]
+        ranked_scores = _numpy().take_along_axis(scores, ranked_indexes, axis=1)
+        return ranked_scores.astype(_numpy().float32), ranked_indexes.astype(_numpy().int64)
+
+
+class QueryTestEmbedder:
+    model_name = "test-query-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self.mapping = mapping
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[float(value) for value in self.mapping[text]] for text in texts]
+
+
+@pytest.fixture
+def fake_faiss(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss_module())
+
+
+@pytest.fixture
+def dense_baseline_fixture(tmp_path: Path, fake_faiss) -> dict[str, Path]:
+    chunks_path = tmp_path / "data/processed/chunks.jsonl"
+    vectors_path = tmp_path / "data/processed/embeddings/chunk_embeddings.f32"
+    embedding_metadata_path = tmp_path / "data/processed/embeddings/chunk_embeddings.metadata.json"
+    index_path = tmp_path / "data/processed/indexes/faiss/chunk_index.faiss"
+    index_metadata_path = tmp_path / "data/processed/indexes/faiss/chunk_index.metadata.json"
+    row_mapping_path = tmp_path / "data/processed/indexes/faiss/chunk_index.row_mapping.json"
+
+    dataset_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.jsonl"
+    dataset_metadata_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.metadata.json"
+    results_output_path = tmp_path / "tmp/eval/dense.results.jsonl"
+    summary_output_path = tmp_path / "tmp/eval/dense.summary.json"
+
+    chunks = [
+        make_chunk(
+            chunk_id="chunk-service",
+            doc_id="doc-service",
+            section_id="section-service",
+            text="Services provide stable networking for backend Pods",
+        ),
+        make_chunk(
+            chunk_id="chunk-probe",
+            doc_id="doc-probe",
+            section_id="section-probe",
+            text="Startup probes protect slow containers from early liveness failures",
+        ),
+        make_chunk(
+            chunk_id="chunk-other",
+            doc_id="doc-other",
+            section_id="section-other",
+            text="Other chunk content that should rank lower",
+        ),
+    ]
+    write_chunks(chunks_path, chunks)
+
+    embedder = MappingTestEmbedder(
+        {
+            chunks[0].text: [1.0, 0.0, 0.0],
+            chunks[1].text: [0.0, 1.0, 0.0],
+            chunks[2].text: [0.2, 0.2, 0.0],
+        }
+    )
+    build_embedding_artifacts(
+        chunks_path=chunks_path,
+        vectors_path=vectors_path,
+        metadata_path=embedding_metadata_path,
+        embedder=embedder,
+        batch_size=2,
+    )
+    build_faiss_index_artifacts(
+        embedding_metadata_path=embedding_metadata_path,
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+    )
+
+    entries = [
+        DevQAEntry(
+            query_id="service-purpose",
+            snapshot_id="k8s-9e1e32b",
+            question="Why would you use a Kubernetes Service?",
+            answerable=True,
+            category="definition",
+            tags=["services"],
+            doc_ids=["doc-service"],
+            expected_section_ids=["section-service"],
+            expected_chunk_ids=["chunk-service"],
+            notes="service evidence",
+        ),
+        DevQAEntry(
+            query_id="startup-probe",
+            snapshot_id="k8s-9e1e32b",
+            question="How can startup probes protect slow-starting containers?",
+            answerable=True,
+            category="troubleshooting",
+            tags=["probes"],
+            doc_ids=["doc-probe"],
+            expected_section_ids=["section-probe"],
+            expected_chunk_ids=["chunk-probe"],
+            notes="probe evidence",
+        ),
+    ]
+    write_dataset(dataset_path, entries)
+    write_metadata(
+        dataset_metadata_path,
+        DevQAMetadata(
+            dataset_name="fixture_dense_baseline",
+            dataset_version="v1",
+            snapshot_id="k8s-9e1e32b",
+            source_manifest_path="data/manifests/source_manifest.jsonl",
+            artifact_path=str(dataset_path),
+            registry_path="data/evaluation/dev_qa.fixture.v1.registry.json",
+            row_count=len(entries),
+            doc_count=2,
+            section_id_count=2,
+            chunk_id_count=3,
+            default_chunking={"max_tokens": 350, "overlap_tokens": 50},
+            notes="fixture metadata",
+        ),
+    )
+
+    return {
+        "dataset_path": dataset_path,
+        "dataset_metadata_path": dataset_metadata_path,
+        "index_path": index_path,
+        "index_metadata_path": index_metadata_path,
+        "row_mapping_path": row_mapping_path,
+        "results_output_path": results_output_path,
+        "summary_output_path": summary_output_path,
+    }
+
+
+def test_run_dense_baseline_cli_writes_retrieval_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    dense_baseline_fixture: dict[str, Path],
+) -> None:
+    from supportdoc_rag_chatbot.evaluation import dense_baseline
+
+    def fake_create_local_embedder(*, model_name, device, batch_size, normalize_embeddings):
+        assert model_name == "test-map-v1"
+        assert device == "cpu"
+        assert batch_size == 32
+        assert normalize_embeddings is True
+        return QueryTestEmbedder(
+            {
+                "Why would you use a Kubernetes Service?": [1.0, 0.0, 0.0],
+                "How can startup probes protect slow-starting containers?": [0.0, 1.0, 0.0],
+            }
+        )
+
+    monkeypatch.setattr(dense_baseline, "create_local_embedder", fake_create_local_embedder)
+
+    exit_code = main(
+        [
+            "run-dense-baseline",
+            "--dataset",
+            str(dense_baseline_fixture["dataset_path"]),
+            "--dataset-metadata",
+            str(dense_baseline_fixture["dataset_metadata_path"]),
+            "--index",
+            str(dense_baseline_fixture["index_path"]),
+            "--index-metadata",
+            str(dense_baseline_fixture["index_metadata_path"]),
+            "--row-mapping",
+            str(dense_baseline_fixture["row_mapping_path"]),
+            "--top-k",
+            "2",
+            "--results-output",
+            str(dense_baseline_fixture["results_output_path"]),
+            "--summary-output",
+            str(dense_baseline_fixture["summary_output_path"]),
+        ]
+    )
+
+    assert exit_code == 0
+
+    results = read_retrieval_results(dense_baseline_fixture["results_output_path"])
+    summary = read_retrieval_summary(dense_baseline_fixture["summary_output_path"])
+
+    assert len(results) == 2
+    assert [match.chunk_id for match in results[0].matches] == ["chunk-service", "chunk-other"]
+    assert [match.chunk_id for match in results[1].matches] == ["chunk-probe", "chunk-other"]
+    assert summary.retriever_name == "dense"
+    assert summary.top_k == 2
+    assert summary.query_count == 2
+    assert summary.answerable_query_count == 2
+    assert summary.hit_at_k == pytest.approx(1.0)
+    assert summary.recall_at_k == pytest.approx(1.0)
+    assert summary.mrr == pytest.approx(1.0)
+    assert summary.retriever_config["embedding_model_name"] == "test-map-v1"
+    assert summary.retriever_config["index_backend"] == "faiss-flat-ip"
+
+    out = capsys.readouterr().out
+    assert "Dense retrieval baseline" in out
+    assert "embedding_model: test-map-v1" in out
+    assert "index_backend: faiss-flat-ip" in out
+    assert f"results_output: {dense_baseline_fixture['results_output_path']}" in out
+    assert f"summary_output: {dense_baseline_fixture['summary_output_path']}" in out
+
+
+def fake_faiss_module() -> SimpleNamespace:
+    def normalize_l2(matrix) -> None:
+        array = _numpy().asarray(matrix, dtype=_numpy().float32)
+        norms = _numpy().linalg.norm(array, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        array /= norms
+
+    def write_index(index: FakeFaissIndexFlatIP, path: str) -> None:
+        payload = {"d": index.d, "vectors": index._vectors}
+        with Path(path).open("wb") as handle:
+            pickle.dump(payload, handle)
+
+    def read_index(path: str) -> FakeFaissIndexFlatIP:
+        with Path(path).open("rb") as handle:
+            payload = pickle.load(handle)
+        index = FakeFaissIndexFlatIP(payload["d"])
+        index.add(payload["vectors"])
+        return index
+
+    return SimpleNamespace(
+        IndexFlatIP=FakeFaissIndexFlatIP,
+        normalize_L2=normalize_l2,
+        write_index=write_index,
+        read_index=read_index,
+    )
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    doc_id: str,
+    section_id: str,
+    text: str,
+    snapshot_id: str = "k8s-9e1e32b",
+) -> ChunkRecord:
+    return ChunkRecord(
+        snapshot_id=snapshot_id,
+        doc_id=doc_id,
+        chunk_id=chunk_id,
+        section_id=section_id,
+        section_index=0,
+        chunk_index=0,
+        doc_title=doc_id,
+        section_path=[section_id],
+        source_path=f"{doc_id}.md",
+        source_url=f"https://example.test/{doc_id}",
+        license="CC BY 4.0",
+        attribution="fixture",
+        language="en",
+        start_offset=0,
+        end_offset=len(text),
+        token_count=len(text.split()),
+        text=text,
+    )
+
+
+def write_chunks(path: Path, chunks: list[ChunkRecord]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(chunk.to_dict(), ensure_ascii=False) + "\n" for chunk in chunks),
+        encoding="utf-8",
+    )
+
+
+def write_dataset(path: Path, entries: list[DevQAEntry]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n" for entry in entries),
+        encoding="utf-8",
+    )
+
+
+def write_metadata(path: Path, metadata: DevQAMetadata) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _numpy():
+    import numpy
+
+    return numpy


### PR DESCRIPTION
Closes #39

This change completes the **dense retrieval baseline** on top of the existing local dense foundations.

It integrates the FAISS-based dense retriever with the shared evaluation harness (Issue #38), enabling reproducible baseline runs against the committed Dev QA dataset.

The dense baseline produces deterministic:

- per-query ranked retrieval results
- summary retrieval metrics

This provides the first concrete baseline for comparing retrieval strategies in Epic 4.

---

Added a dense baseline runner that:

- loads an existing FAISS index and metadata
- uses the embedding model recorded in the index metadata by default
- runs all Dev QA queries in batch
- retrieves top-k chunk matches
- evaluates results through the shared evaluation harness

This keeps the baseline focused on evaluation rather than artifact generation.

---

Added a retriever adapter that:

- wraps the FAISS backend
- embeds queries using the configured embedding model
- returns ranked retrieval results compatible with the evaluation harness

The adapter records baseline configuration including:

- embedding model name
- index backend (`faiss-flat-ip`)
- top-k
- index paths

---

The dense baseline is fully wired into the shared evaluation harness:

- uses Dev QA dataset as evaluation input
- produces per-query result artifacts
- computes summary metrics:
  - hit@k
  - recall@k
  - MRR
  - latency

The evaluation layer remains backend-agnostic and reusable for BM25 and hybrid baselines.

---

Added deterministic output artifacts:

- results: `*.results.jsonl`
- summary: `*.summary.json`

Artifacts include:

- dataset version
- snapshot ID
- retriever/config metadata
- query counts
- hit@k / recall@k / MRR
- latency summary

Output paths are derived deterministically from:

- dataset snapshot
- dataset version
- top-k
- run label

---

Added fixture-based end-to-end test:

- `tests/test_dense_retrieval_baseline.py`

The test:

- builds temporary chunk, embedding, and FAISS artifacts
- runs the dense baseline through the CLI
- validates:
  - retrieval ordering
  - metrics correctness
  - artifact outputs
  - retriever configuration metadata

---

Added:

- `docs/process/dense_retrieval_baseline.md`
- `README.md` updates

Documentation includes:

- default dense baseline configuration
- exact baseline command
- artifact structure
- local validation workflow

---

Updated `.gitignore` to exclude local evaluation outputs:

- `data/evaluation/runs/`
- `tmp/eval/`

---

```bash
uv sync --locked --extra dev-tools --extra faiss
```

```
uv run pytest -q tests/test_dense_retrieval_baseline.py
```

This validates:

- chunk → embedding → FAISS → retrieval → evaluation
- artifact writing
- metrics correctness

------

```
uv run python -m supportdoc_rag_chatbot evaluate-retrieval \
  --retriever-kind static \
  --fixture-name oracle \
  --top-k 5
```

Validates:

- CLI wiring
- evaluation harness behavior
- artifact output format

------

```
uv run pytest -q
```

------

- This task does **not** duplicate embedding or index construction logic.
- It assumes local dense artifacts exist for real baseline runs.
- Fixture-based tests provide full validation without requiring local data setup.
- The evaluation layer introduced here is reusable for BM25 and hybrid baselines.

Changes to be committed:
	modified:   .gitignore
	modified:   README.md
	new file:   docs/process/dense_retrieval_baseline.md
	modified:   src/supportdoc_rag_chatbot/cli.py
	modified:   src/supportdoc_rag_chatbot/evaluation/__init__.py
	new file:   src/supportdoc_rag_chatbot/evaluation/artifacts.py
	new file:   src/supportdoc_rag_chatbot/evaluation/dense_baseline.py
	new file:   src/supportdoc_rag_chatbot/evaluation/metrics.py
	new file:   tests/test_dense_retrieval_baseline.py