### PR TITLE
On branch retrieval/40-bm25-baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The initial corpus is a pinned snapshot of Kubernetes documentation so the proje
 This README is maintained as a live project document and evolves with each completed task issue.
 
 ### Current Phase
-Dense retrieval baseline evaluation.
+Dense and BM25 retrieval baseline evaluation.
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
@@ -23,13 +23,13 @@ Dense retrieval baseline evaluation.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
 - Local FAISS backend that builds, persists, reloads, and searches a dense index over saved embedding artifacts.
 - Developer-facing retrieval smoke CLI for local dense search over a saved FAISS index.
-- Shared retrieval evaluation harness and dense baseline runner that execute the committed Dev QA set and write deterministic result artifacts.
+- Shared retrieval evaluation harness plus dense and BM25 baseline runners that execute the committed Dev QA set and write deterministic result artifacts.
 
 ### In Progress
 - Citation contract and refusal behavior integration.
 
 ### Next Up
-- Add BM25 and hybrid retrievers behind the same evaluation harness.
+- Add hybrid retrieval behind the same evaluation harness.
 - Connect retrieval outputs to generation and citation validation.
 - Expand deployment and observability documentation as the backend/API layer matures.
 - Compare dense, BM25, and hybrid retrieval artifacts to choose the default baseline.
@@ -324,6 +324,23 @@ The dense run writes:
 
 See `docs/process/dense_retrieval_baseline.md` for the exact baseline configuration and output layout.
 
+## 9C. BM25 Retrieval Baseline Evaluation
+
+The repository now includes a BM25 baseline runner over the canonical `chunks.jsonl` artifact. The BM25 baseline tokenizes queries and chunks with a lowercase regex tokenizer, scores chunks with deterministic BM25 ranking, and writes deterministic artifacts under `data/evaluation/runs/` by default.
+
+Default BM25 baseline command:
+
+```bash
+uv run python -m supportdoc_rag_chatbot run-bm25-baseline   --chunks data/processed/chunks.jsonl   --top-k 5
+```
+
+The BM25 run writes:
+
+- a per-query results JSONL artifact
+- a summary JSON artifact with hit@k, recall@k, MRR, and latency
+
+See `docs/process/bm25_retrieval_baseline.md` for the tokenization strategy, exact baseline configuration, and output layout.
+
 ---
 
 ## 10. Deployment Overview
@@ -339,4 +356,5 @@ The intended deployment path is a FastAPI backend with a web frontend, persisten
 - `docs/diagrams/ingestion_pipeline.md` — ingestion pipeline overview
 - `docs/adr/` — architecture decisions and project rationale
 - `docs/process/dense_retrieval_baseline.md` — default dense baseline config and run command
+- `docs/process/bm25_retrieval_baseline.md` — default BM25 baseline config and run command
 - `PROPOSAL.md` — project proposal and delivery framing

--- a/docs/process/bm25_retrieval_baseline.md
+++ b/docs/process/bm25_retrieval_baseline.md
@@ -1,0 +1,71 @@
+# BM25 Retrieval Baseline
+
+This document records the default BM25 retrieval baseline used for Epic 4 comparisons.
+
+## Goal
+
+Run the committed development QA dataset against the canonical `chunks.jsonl` artifact without rebuilding chunks, embeddings, or index artifacts.
+
+The baseline writes:
+
+- per-query ranked retrieval results (`.results.jsonl`)
+- summary metrics (`.summary.json`)
+
+## Default baseline configuration
+
+- Retriever name: `bm25`
+- Corpus artifact: `data/processed/chunks.jsonl`
+- Tokenization: lowercase regex tokenization using `r"[A-Za-z0-9]+(?:[._:/-][A-Za-z0-9]+)*"`
+- BM25 parameters:
+  - `k1 = 1.5`
+  - `b = 0.75`
+- Default top-k: `5`
+- Dataset: `data/evaluation/dev_qa.k8s-9e1e32b.v1.jsonl`
+
+## Tokenization / normalization strategy
+
+BM25 scoring uses a deterministic lexical tokenizer:
+
+- extract tokens with the regex `r"[A-Za-z0-9]+(?:[._:/-][A-Za-z0-9]+)*"`
+- lowercase every token
+- ignore punctuation outside the token pattern
+- preserve separators such as `.`, `_`, `:`, `/`, and `-` when they appear inside a token
+
+Examples:
+
+- `Kubernetes Service` -> `kubernetes`, `service`
+- `slow-starting` -> `slow-starting`
+- `v1/pods` -> `v1/pods`
+
+## Output paths
+
+By default, the BM25 baseline writes deterministic artifacts under:
+
+- `data/evaluation/runs/bm25-k8s-9e1e32b-v1-top5-default.results.jsonl`
+- `data/evaluation/runs/bm25-k8s-9e1e32b-v1-top5-default.summary.json`
+
+You can override either path explicitly from the CLI.
+
+## Exact local command
+
+After `data/processed/chunks.jsonl` exists, run:
+
+```bash
+uv run python -m supportdoc_rag_chatbot run-bm25-baseline \
+  --chunks data/processed/chunks.jsonl \
+  --top-k 5
+```
+
+The command loads the committed Dev QA set, tokenizes the query and chunk corpus deterministically, runs BM25 retrieval through the shared evaluation harness, and writes deterministic result artifacts.
+
+## Smoke test workflow
+
+This smoke path avoids depending on a committed local `chunks.jsonl` file by using the fixture-based test for the BM25 baseline.
+
+```bash
+uv sync --locked --extra dev-tools --extra bm25
+uv run ruff check . --fix
+uv run ruff format --check .
+uv run pytest -q tests/test_bm25_baseline.py
+uv run pytest -q
+```

--- a/src/supportdoc_rag_chatbot/cli.py
+++ b/src/supportdoc_rag_chatbot/cli.py
@@ -6,9 +6,14 @@ from pathlib import Path
 from typing import Sequence
 
 from supportdoc_rag_chatbot.evaluation import (
+    DEFAULT_BM25_B,
+    DEFAULT_BM25_BASELINE_LABEL,
+    DEFAULT_BM25_BASELINE_TOP_K,
+    DEFAULT_BM25_K1,
     DEFAULT_EVAL_TOP_K,
     DEFAULT_HYBRID_CANDIDATE_DEPTH,
     DEFAULT_RRF_K,
+    BM25BaselineConfig,
     BM25ChunkEvaluationRetriever,
     DenseBaselineConfig,
     DenseFaissEvaluationRetriever,
@@ -20,8 +25,10 @@ from supportdoc_rag_chatbot.evaluation import (
     load_dev_qa_dataset,
     load_dev_qa_metadata,
     load_evidence_registry,
+    render_bm25_baseline_report,
     render_dense_baseline_report,
     render_retrieval_evaluation_report,
+    run_bm25_baseline,
     run_dense_baseline,
     write_query_results,
     write_retrieval_run_summary,
@@ -313,6 +320,76 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     eval_parser.set_defaults(handler=_run_evaluate_retrieval)
 
+    bm25_baseline_parser = subparsers.add_parser(
+        "run-bm25-baseline",
+        help="Run the BM25 retrieval baseline over the dev QA set and write deterministic artifacts",
+    )
+    bm25_baseline_parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=None,
+        help="Optional path to a dev QA dataset JSONL (defaults to committed dataset)",
+    )
+    bm25_baseline_parser.add_argument(
+        "--dataset-metadata",
+        type=Path,
+        default=None,
+        help="Optional path to dev QA metadata JSON (defaults to committed metadata)",
+    )
+    bm25_baseline_parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Optional path to an evidence registry JSON (defaults to committed registry or derives from chunks)",
+    )
+    bm25_baseline_parser.add_argument(
+        "--chunks",
+        type=Path,
+        default=DEFAULT_CHUNKS_PATH,
+        help="Path to chunks.jsonl used as the canonical BM25 corpus",
+    )
+    bm25_baseline_parser.add_argument(
+        "--k1",
+        type=float,
+        default=DEFAULT_BM25_K1,
+        help="BM25 term-frequency saturation constant",
+    )
+    bm25_baseline_parser.add_argument(
+        "--b",
+        type=float,
+        default=DEFAULT_BM25_B,
+        help="BM25 length normalization constant",
+    )
+    bm25_baseline_parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_BM25_BASELINE_TOP_K,
+        help="Number of ranked hits to keep per query",
+    )
+    bm25_baseline_parser.add_argument(
+        "--run-name",
+        default=None,
+        help="Optional run name override for output artifact naming",
+    )
+    bm25_baseline_parser.add_argument(
+        "--run-label",
+        default=DEFAULT_BM25_BASELINE_LABEL,
+        help="Logical label appended to the default BM25 run name",
+    )
+    bm25_baseline_parser.add_argument(
+        "--results-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the per-query retrieval results JSONL",
+    )
+    bm25_baseline_parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the summary metrics JSON",
+    )
+    bm25_baseline_parser.set_defaults(handler=_run_bm25_baseline)
+
     dense_baseline_parser = subparsers.add_parser(
         "run-dense-baseline",
         help="Run the dense retrieval baseline over the dev QA set and write deterministic artifacts",
@@ -454,6 +531,26 @@ def _run_smoke_dense_retrieval(args: argparse.Namespace) -> int:
         preview_chars=args.preview_chars,
     )
     print(render_dense_retrieval_smoke_report(report))
+    return 0
+
+
+def _run_bm25_baseline(args: argparse.Namespace) -> int:
+    run = run_bm25_baseline(
+        config=BM25BaselineConfig(
+            chunks_path=args.chunks,
+            dataset_path=args.dataset,
+            dataset_metadata_path=args.dataset_metadata,
+            registry_path=args.registry,
+            k1=args.k1,
+            b=args.b,
+            top_k=args.top_k,
+            run_name=args.run_name,
+            run_label=args.run_label,
+            results_output_path=args.results_output,
+            summary_output_path=args.summary_output,
+        )
+    )
+    print(render_bm25_baseline_report(run))
     return 0
 
 

--- a/src/supportdoc_rag_chatbot/evaluation/__init__.py
+++ b/src/supportdoc_rag_chatbot/evaluation/__init__.py
@@ -8,6 +8,16 @@ from .artifacts import (
     write_retrieval_results,
     write_retrieval_summary,
 )
+from .bm25_baseline import (
+    DEFAULT_BM25_B,
+    DEFAULT_BM25_BASELINE_LABEL,
+    DEFAULT_BM25_BASELINE_TOP_K,
+    DEFAULT_BM25_K1,
+    BM25BaselineConfig,
+    BM25BaselineRetriever,
+    render_bm25_baseline_report,
+    run_bm25_baseline,
+)
 from .dense_baseline import (
     DEFAULT_DENSE_BASELINE_LABEL,
     DEFAULT_DENSE_BASELINE_TOP_K,
@@ -68,6 +78,14 @@ from .retrievers import (
 )
 
 __all__ = [
+    "BM25BaselineConfig",
+    "BM25BaselineRetriever",
+    "DEFAULT_BM25_B",
+    "DEFAULT_BM25_BASELINE_LABEL",
+    "DEFAULT_BM25_BASELINE_TOP_K",
+    "DEFAULT_BM25_K1",
+    "render_bm25_baseline_report",
+    "run_bm25_baseline",
     "write_retrieval_summary",
     "write_retrieval_results",
     "run_dense_baseline",

--- a/src/supportdoc_rag_chatbot/evaluation/artifacts.py
+++ b/src/supportdoc_rag_chatbot/evaluation/artifacts.py
@@ -51,8 +51,7 @@ class RetrievalQueryArtifact:
             latency_ms=float(payload["latency_ms"]),
             expected_chunk_ids=[str(item) for item in payload.get("expected_chunk_ids", [])],
             matches=[
-                RetrievedChunkArtifact.from_dict(match)
-                for match in payload.get("matches", [])
+                RetrievedChunkArtifact.from_dict(match) for match in payload.get("matches", [])
             ],
             retriever_config=dict(payload.get("retriever_config", {})),
         )
@@ -113,13 +112,11 @@ class RetrievalRunArtifacts:
     summary: RetrievalSummaryArtifact
 
 
-
 def write_retrieval_results(path: Path, results: Iterable[RetrievalQueryArtifact]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
         for row in results:
             handle.write(json.dumps(row.to_dict(), sort_keys=True) + "\n")
-
 
 
 def read_retrieval_results(path: Path) -> list[RetrievalQueryArtifact]:
@@ -141,14 +138,12 @@ def read_retrieval_results(path: Path) -> list[RetrievalQueryArtifact]:
     return rows
 
 
-
 def write_retrieval_summary(path: Path, summary: RetrievalSummaryArtifact) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(summary.to_dict(), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-
 
 
 def read_retrieval_summary(path: Path) -> RetrievalSummaryArtifact:

--- a/src/supportdoc_rag_chatbot/evaluation/bm25_baseline.py
+++ b/src/supportdoc_rag_chatbot/evaluation/bm25_baseline.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from supportdoc_rag_chatbot.retrieval.embeddings import DEFAULT_CHUNKS_PATH, load_chunk_records
+
+from .artifacts import (
+    RetrievalQueryArtifact,
+    RetrievalRunArtifacts,
+    RetrievalSummaryArtifact,
+    RetrievedChunkArtifact,
+    write_retrieval_results,
+    write_retrieval_summary,
+)
+from .dev_qa import (
+    DevQAEntry,
+    DevQAMetadata,
+    EvidenceRegistry,
+    default_dev_qa_paths,
+    load_default_dev_qa_dataset,
+    load_default_dev_qa_metadata,
+    load_default_evidence_registry,
+    load_dev_qa_dataset,
+    load_dev_qa_metadata,
+    load_evidence_registry,
+)
+from .harness import evaluate_retriever
+from .retrievers import BM25ChunkEvaluationRetriever
+
+DEFAULT_BM25_BASELINE_TOP_K = 5
+DEFAULT_BM25_BASELINE_LABEL = "default"
+DEFAULT_BM25_K1 = 1.5
+DEFAULT_BM25_B = 0.75
+
+
+@dataclass(slots=True)
+class BM25BaselineConfig:
+    chunks_path: Path = DEFAULT_CHUNKS_PATH
+    dataset_path: Path | None = None
+    dataset_metadata_path: Path | None = None
+    registry_path: Path | None = None
+    k1: float = DEFAULT_BM25_K1
+    b: float = DEFAULT_BM25_B
+    top_k: int = DEFAULT_BM25_BASELINE_TOP_K
+    run_name: str | None = None
+    run_label: str = DEFAULT_BM25_BASELINE_LABEL
+    results_output_path: Path | None = None
+    summary_output_path: Path | None = None
+
+
+class BM25BaselineRetriever(BM25ChunkEvaluationRetriever):
+    def __init__(self, config: BM25BaselineConfig) -> None:
+        if config.top_k <= 0:
+            raise ValueError("top_k must be > 0")
+        super().__init__(
+            chunks_path=config.chunks_path,
+            name="bm25",
+            k1=config.k1,
+            b=config.b,
+        )
+
+
+def run_bm25_baseline(config: BM25BaselineConfig | None = None) -> RetrievalRunArtifacts:
+    runtime_config = config or BM25BaselineConfig()
+
+    dataset_entries, dataset_metadata = _load_dataset_surface(runtime_config)
+    registry = _load_registry_surface(runtime_config, dataset_metadata)
+    retriever = BM25BaselineRetriever(runtime_config)
+
+    results_output_path, summary_output_path = _resolve_output_paths(
+        config=runtime_config,
+        dataset_metadata=dataset_metadata,
+    )
+    run_name = runtime_config.run_name or _default_run_name(
+        metadata=dataset_metadata,
+        top_k=runtime_config.top_k,
+        label=runtime_config.run_label,
+    )
+
+    harness_results, harness_summary = evaluate_retriever(
+        retriever=retriever,
+        entries=dataset_entries,
+        metadata=dataset_metadata,
+        registry=registry,
+        top_k=runtime_config.top_k,
+    )
+
+    result_artifacts = [
+        RetrievalQueryArtifact(
+            query_id=result.query_id,
+            question=result.question,
+            answerable=result.answerable,
+            snapshot_id=result.snapshot_id,
+            retriever_name=result.retriever_name,
+            top_k=result.top_k,
+            latency_ms=result.latency_ms,
+            expected_chunk_ids=list(result.expected_chunk_ids),
+            matches=[
+                RetrievedChunkArtifact(
+                    chunk_id=hit.chunk_id,
+                    rank=hit.rank,
+                    score=hit.score,
+                )
+                for hit in result.hits
+            ],
+            retriever_config=dict(result.retriever_config),
+        )
+        for result in harness_results
+    ]
+
+    summary_artifact = RetrievalSummaryArtifact(
+        run_name=run_name,
+        dataset_name=dataset_metadata.dataset_name,
+        dataset_version=dataset_metadata.dataset_version,
+        snapshot_id=dataset_metadata.snapshot_id,
+        retriever_name=harness_summary.retriever_name,
+        top_k=harness_summary.top_k,
+        query_count=harness_summary.total_query_count,
+        answerable_query_count=harness_summary.answerable_query_count,
+        hit_at_k=harness_summary.hit_at_k,
+        recall_at_k=harness_summary.recall_at_k,
+        mrr=harness_summary.mrr,
+        mean_latency_ms=harness_summary.average_latency_ms,
+        max_latency_ms=harness_summary.max_latency_ms,
+        results_output_path=str(results_output_path),
+        summary_output_path=str(summary_output_path),
+        retriever_config=dict(harness_summary.retriever_config),
+    )
+
+    write_retrieval_results(results_output_path, result_artifacts)
+    write_retrieval_summary(summary_output_path, summary_artifact)
+    return RetrievalRunArtifacts(results=result_artifacts, summary=summary_artifact)
+
+
+def render_bm25_baseline_report(run: RetrievalRunArtifacts) -> str:
+    summary = run.summary
+    config = summary.retriever_config
+    lines = [
+        "BM25 retrieval baseline",
+        f"run_name: {summary.run_name}",
+        f"dataset: {summary.dataset_name}:{summary.dataset_version}",
+        f"snapshot_id: {summary.snapshot_id}",
+        f"chunks_path: {config.get('chunks_path', '(unknown)')}",
+        f"tokenization: {config.get('tokenization', '(unknown)')}",
+        f"k1: {config.get('k1', '(unknown)')}",
+        f"b: {config.get('b', '(unknown)')}",
+        f"top_k: {summary.top_k}",
+        f"query_count: {summary.query_count}",
+        f"answerable_query_count: {summary.answerable_query_count}",
+        f"hit@k: {summary.hit_at_k:.6f}",
+        f"recall@k: {summary.recall_at_k:.6f}",
+        f"mrr: {summary.mrr:.6f}",
+        f"mean_latency_ms: {summary.mean_latency_ms:.3f}",
+        f"max_latency_ms: {summary.max_latency_ms:.3f}",
+        f"results_output: {summary.results_output_path}",
+        f"summary_output: {summary.summary_output_path}",
+    ]
+    return "\n".join(lines)
+
+
+def _load_dataset_surface(
+    config: BM25BaselineConfig,
+) -> tuple[list[DevQAEntry], DevQAMetadata]:
+    if config.dataset_path is None:
+        dataset_entries = load_default_dev_qa_dataset()
+    else:
+        dataset_entries = load_dev_qa_dataset(config.dataset_path)
+
+    if config.dataset_metadata_path is None:
+        dataset_metadata = load_default_dev_qa_metadata()
+    else:
+        dataset_metadata = load_dev_qa_metadata(config.dataset_metadata_path)
+
+    return dataset_entries, dataset_metadata
+
+
+def _load_registry_surface(
+    config: BM25BaselineConfig,
+    metadata: DevQAMetadata,
+) -> EvidenceRegistry:
+    if config.registry_path is not None:
+        return load_evidence_registry(config.registry_path)
+
+    if config.dataset_path is None and config.dataset_metadata_path is None:
+        return load_default_evidence_registry()
+
+    chunks = load_chunk_records(config.chunks_path)
+    return EvidenceRegistry(
+        snapshot_id=metadata.snapshot_id,
+        source_manifest_path=metadata.source_manifest_path,
+        doc_ids=sorted({chunk.doc_id for chunk in chunks}),
+        section_ids=sorted({chunk.section_id for chunk in chunks}),
+        chunk_ids=sorted({chunk.chunk_id for chunk in chunks}),
+        default_chunking=dict(metadata.default_chunking),
+    )
+
+
+def _resolve_output_paths(
+    *,
+    config: BM25BaselineConfig,
+    dataset_metadata: DevQAMetadata,
+) -> tuple[Path, Path]:
+    results_output_path = config.results_output_path
+    summary_output_path = config.summary_output_path
+
+    if results_output_path is not None and summary_output_path is not None:
+        return results_output_path, summary_output_path
+
+    default_dataset_path, _, _ = default_dev_qa_paths()
+    repo_root = default_dataset_path.parents[2]
+    run_name = config.run_name or _default_run_name(
+        metadata=dataset_metadata,
+        top_k=config.top_k,
+        label=config.run_label,
+    )
+
+    if results_output_path is None:
+        results_output_path = (
+            repo_root / "data" / "evaluation" / "runs" / f"{run_name}.results.jsonl"
+        )
+    if summary_output_path is None:
+        summary_output_path = (
+            repo_root / "data" / "evaluation" / "runs" / f"{run_name}.summary.json"
+        )
+    return results_output_path, summary_output_path
+
+
+def _default_run_name(*, metadata: DevQAMetadata, top_k: int, label: str) -> str:
+    return f"bm25-{metadata.snapshot_id}-{metadata.dataset_version}-top{top_k}-{label}"

--- a/src/supportdoc_rag_chatbot/evaluation/dense_baseline.py
+++ b/src/supportdoc_rag_chatbot/evaluation/dense_baseline.py
@@ -83,7 +83,8 @@ class DenseBaselineRetriever:
             normalize_embeddings=True,
         )
         self.chunk_info_by_id = {
-            chunk.chunk_id: chunk for chunk in load_chunk_records(Path(index_metadata.source_chunks_path))
+            chunk.chunk_id: chunk
+            for chunk in load_chunk_records(Path(index_metadata.source_chunks_path))
         }
         self.config = {
             "embedding_model_name": self.model_name,
@@ -192,7 +193,6 @@ def run_dense_baseline(config: DenseBaselineConfig | None = None) -> RetrievalRu
     return RetrievalRunArtifacts(results=result_artifacts, summary=summary_artifact)
 
 
-
 def render_dense_baseline_report(run: RetrievalRunArtifacts) -> str:
     summary = run.summary
     config = summary.retriever_config
@@ -217,7 +217,6 @@ def render_dense_baseline_report(run: RetrievalRunArtifacts) -> str:
     return "\n".join(lines)
 
 
-
 def _load_dataset_surface(
     config: DenseBaselineConfig,
 ) -> tuple[list[DevQAEntry], DevQAMetadata]:
@@ -232,7 +231,6 @@ def _load_dataset_surface(
         dataset_metadata = load_dev_qa_metadata(config.dataset_metadata_path)
 
     return dataset_entries, dataset_metadata
-
 
 
 def _load_registry_surface(
@@ -260,29 +258,30 @@ def _load_registry_surface(
         {section_id for entry in entries for section_id in entry.expected_section_ids}
     )
     chunk_ids = sorted({chunk.chunk_id for chunk in chunks})
-    entry_chunk_ids = sorted({chunk_id for entry in entries for chunk_id in entry.expected_chunk_ids})
+    entry_chunk_ids = sorted(
+        {chunk_id for entry in entries for chunk_id in entry.expected_chunk_ids}
+    )
 
     return EvidenceRegistry(
         snapshot_id=metadata.snapshot_id,
         source_manifest_path=metadata.source_manifest_path,
-        doc_ids=_select_ids(expected_count=metadata.doc_count, primary=entry_doc_ids, fallback=chunk_doc_ids),
+        doc_ids=_select_ids(
+            expected_count=metadata.doc_count, primary=entry_doc_ids, fallback=chunk_doc_ids
+        ),
         section_ids=_select_ids(
             expected_count=metadata.section_id_count,
             primary=entry_section_ids,
             fallback=chunk_section_ids,
         ),
-        chunk_ids=_select_ids(expected_count=metadata.chunk_id_count, primary=chunk_ids, fallback=entry_chunk_ids),
+        chunk_ids=_select_ids(
+            expected_count=metadata.chunk_id_count, primary=chunk_ids, fallback=entry_chunk_ids
+        ),
         default_chunking=dict(metadata.default_chunking),
     )
 
 
-
 def _default_run_name(*, metadata: DevQAMetadata, top_k: int, label: str) -> str:
-    return (
-        f"dense-{metadata.snapshot_id}-{metadata.dataset_version}-"
-        f"top{top_k}-{label}"
-    )
-
+    return f"dense-{metadata.snapshot_id}-{metadata.dataset_version}-top{top_k}-{label}"
 
 
 def _resolve_output_paths(
@@ -308,7 +307,6 @@ def _resolve_output_paths(
         repo_root / "data" / "evaluation" / "runs" / f"{run_name}.summary.json"
     )
     return results_output_path, summary_output_path
-
 
 
 def _select_ids(*, expected_count: int, primary: list[str], fallback: list[str]) -> list[str]:

--- a/src/supportdoc_rag_chatbot/evaluation/metrics.py
+++ b/src/supportdoc_rag_chatbot/evaluation/metrics.py
@@ -18,7 +18,6 @@ class RetrievalMetrics:
     max_latency_ms: float
 
 
-
 def compute_retrieval_metrics(results: Iterable[RetrievalQueryArtifact]) -> RetrievalMetrics:
     rows = list(results)
     query_count = len(rows)

--- a/src/supportdoc_rag_chatbot/evaluation/retrievers.py
+++ b/src/supportdoc_rag_chatbot/evaluation/retrievers.py
@@ -159,6 +159,7 @@ class BM25ChunkEvaluationRetriever:
             "chunks_path": str(self.chunks_path),
             "k1": self.k1,
             "b": self.b,
+            "tokenization": f"lowercase regex: {_TOKEN_PATTERN.pattern}",
         }
 
     def retrieve(self, entry: DevQAEntry, *, top_k: int) -> list[RetrievalHit]:

--- a/tests/test_bm25_baseline.py
+++ b/tests/test_bm25_baseline.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from supportdoc_rag_chatbot.cli import main
+from supportdoc_rag_chatbot.evaluation import read_retrieval_results, read_retrieval_summary
+from supportdoc_rag_chatbot.evaluation.dev_qa import DevQAEntry, DevQAMetadata, EvidenceRegistry
+from supportdoc_rag_chatbot.evaluation.retrievers import BM25ChunkEvaluationRetriever
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+
+
+@pytest.fixture
+def bm25_baseline_fixture(tmp_path: Path) -> dict[str, Path]:
+    chunks_path = tmp_path / "data/processed/chunks.jsonl"
+    dataset_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.jsonl"
+    dataset_metadata_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.metadata.json"
+    registry_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.registry.json"
+    results_output_path = tmp_path / "tmp/eval/bm25.results.jsonl"
+    summary_output_path = tmp_path / "tmp/eval/bm25.summary.json"
+
+    chunks = [
+        make_chunk(
+            chunk_id="chunk-service",
+            doc_id="doc-service",
+            section_id="section-service",
+            text="A Kubernetes Service provides stable networking in front of Pods.",
+        ),
+        make_chunk(
+            chunk_id="chunk-probe",
+            doc_id="doc-probe",
+            section_id="section-probe",
+            text="Startup probes protect slow-starting containers from early restarts.",
+        ),
+        make_chunk(
+            chunk_id="chunk-noise",
+            doc_id="doc-noise",
+            section_id="section-noise",
+            text="This chunk discusses unrelated scheduling details.",
+        ),
+    ]
+    write_chunks(chunks_path, chunks)
+
+    entries = [
+        DevQAEntry(
+            query_id="service-purpose",
+            snapshot_id="k8s-9e1e32b",
+            question="Why would you use a Kubernetes Service?",
+            answerable=True,
+            category="definition",
+            tags=["services"],
+            doc_ids=["doc-service"],
+            expected_section_ids=["section-service"],
+            expected_chunk_ids=["chunk-service"],
+            notes="service evidence",
+        ),
+        DevQAEntry(
+            query_id="startup-probe",
+            snapshot_id="k8s-9e1e32b",
+            question="How can startup probes protect slow-starting containers?",
+            answerable=True,
+            category="troubleshooting",
+            tags=["probes"],
+            doc_ids=["doc-probe"],
+            expected_section_ids=["section-probe"],
+            expected_chunk_ids=["chunk-probe"],
+            notes="probe evidence",
+        ),
+    ]
+    write_dataset(dataset_path, entries)
+    write_metadata(
+        dataset_metadata_path,
+        DevQAMetadata(
+            dataset_name="fixture_bm25_baseline",
+            dataset_version="v1",
+            snapshot_id="k8s-9e1e32b",
+            source_manifest_path="data/manifests/source_manifest.jsonl",
+            artifact_path=str(dataset_path),
+            registry_path=str(registry_path),
+            row_count=len(entries),
+            doc_count=3,
+            section_id_count=3,
+            chunk_id_count=3,
+            default_chunking={"max_tokens": 350, "overlap_tokens": 50},
+            notes="fixture metadata",
+        ),
+    )
+    write_registry(
+        registry_path,
+        EvidenceRegistry(
+            snapshot_id="k8s-9e1e32b",
+            source_manifest_path="data/manifests/source_manifest.jsonl",
+            doc_ids=["doc-noise", "doc-probe", "doc-service"],
+            section_ids=["section-noise", "section-probe", "section-service"],
+            chunk_ids=["chunk-noise", "chunk-probe", "chunk-service"],
+            default_chunking={"max_tokens": 350, "overlap_tokens": 50},
+        ),
+    )
+
+    return {
+        "chunks_path": chunks_path,
+        "dataset_path": dataset_path,
+        "dataset_metadata_path": dataset_metadata_path,
+        "registry_path": registry_path,
+        "results_output_path": results_output_path,
+        "summary_output_path": summary_output_path,
+    }
+
+
+def test_run_bm25_baseline_cli_writes_retrieval_artifacts(
+    capsys: pytest.CaptureFixture[str],
+    bm25_baseline_fixture: dict[str, Path],
+) -> None:
+    exit_code = main(
+        [
+            "run-bm25-baseline",
+            "--chunks",
+            str(bm25_baseline_fixture["chunks_path"]),
+            "--dataset",
+            str(bm25_baseline_fixture["dataset_path"]),
+            "--dataset-metadata",
+            str(bm25_baseline_fixture["dataset_metadata_path"]),
+            "--registry",
+            str(bm25_baseline_fixture["registry_path"]),
+            "--top-k",
+            "2",
+            "--results-output",
+            str(bm25_baseline_fixture["results_output_path"]),
+            "--summary-output",
+            str(bm25_baseline_fixture["summary_output_path"]),
+        ]
+    )
+
+    assert exit_code == 0
+
+    results = read_retrieval_results(bm25_baseline_fixture["results_output_path"])
+    summary = read_retrieval_summary(bm25_baseline_fixture["summary_output_path"])
+
+    assert len(results) == 2
+    assert [match.chunk_id for match in results[0].matches] == ["chunk-service"]
+    assert [match.chunk_id for match in results[1].matches] == ["chunk-probe"]
+    assert summary.retriever_name == "bm25"
+    assert summary.top_k == 2
+    assert summary.query_count == 2
+    assert summary.answerable_query_count == 2
+    assert summary.hit_at_k == pytest.approx(1.0)
+    assert summary.recall_at_k == pytest.approx(1.0)
+    assert summary.mrr == pytest.approx(1.0)
+    assert summary.retriever_config["k1"] == pytest.approx(1.5)
+    assert summary.retriever_config["b"] == pytest.approx(0.75)
+    assert "tokenization" in summary.retriever_config
+
+    out = capsys.readouterr().out
+    assert "BM25 retrieval baseline" in out
+    assert "k1: 1.5" in out
+    assert "b: 0.75" in out
+    assert f"results_output: {bm25_baseline_fixture['results_output_path']}" in out
+    assert f"summary_output: {bm25_baseline_fixture['summary_output_path']}" in out
+
+
+def test_bm25_retriever_rejects_empty_chunks_fixture(tmp_path: Path) -> None:
+    chunks_path = tmp_path / "chunks.jsonl"
+    chunks_path.write_text("", encoding="utf-8")
+    retriever = BM25ChunkEvaluationRetriever(chunks_path=chunks_path)
+    entry = DevQAEntry(
+        query_id="q1",
+        snapshot_id="k8s-9e1e32b",
+        question="What is a Service?",
+        answerable=True,
+        category="definition",
+        tags=[],
+        doc_ids=[],
+        expected_section_ids=[],
+        expected_chunk_ids=[],
+        notes="",
+    )
+
+    with pytest.raises(ValueError, match="Chunks artifact is empty"):
+        retriever.retrieve(entry, top_k=5)
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    doc_id: str,
+    section_id: str,
+    text: str,
+    snapshot_id: str = "k8s-9e1e32b",
+) -> ChunkRecord:
+    return ChunkRecord(
+        snapshot_id=snapshot_id,
+        doc_id=doc_id,
+        chunk_id=chunk_id,
+        section_id=section_id,
+        section_index=0,
+        chunk_index=0,
+        doc_title=doc_id,
+        section_path=[section_id],
+        source_path=f"{doc_id}.md",
+        source_url=f"https://example.test/{doc_id}",
+        license="CC BY 4.0",
+        attribution="fixture",
+        language="en",
+        start_offset=0,
+        end_offset=len(text),
+        token_count=len(text.split()),
+        text=text,
+    )
+
+
+def write_chunks(path: Path, chunks: list[ChunkRecord]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(chunk.to_dict(), ensure_ascii=False) + "\n" for chunk in chunks),
+        encoding="utf-8",
+    )
+
+
+def write_dataset(path: Path, entries: list[DevQAEntry]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n" for entry in entries),
+        encoding="utf-8",
+    )
+
+
+def write_metadata(path: Path, metadata: DevQAMetadata) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_registry(path: Path, registry: EvidenceRegistry) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(registry.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )


### PR DESCRIPTION
Closes #40

This change adds the **BM25 retrieval baseline** for Epic 4.

It implements a deterministic lexical retriever over the canonical chunk artifact and wires it into the shared retrieval evaluation harness so BM25 can be compared directly against the dense baseline.

The BM25 baseline produces deterministic:

- per-query ranked retrieval results
- summary retrieval metrics

This gives Epic 4 its first non-dense comparator.

---

Added a BM25 baseline runner that:

- loads the canonical `chunks.jsonl` corpus
- tokenizes queries and chunk text deterministically
- scores chunks with BM25
- runs all Dev QA queries in batch
- evaluates results through the shared evaluation harness

---

Added a retriever adapter that:

- wraps lexical BM25 retrieval over chunk text
- keeps metadata lookup separate from lexical scoring
- returns ranked results compatible with the shared evaluation schema

The retriever records baseline configuration including:

- chunk corpus path
- `k1`
- `b`
- tokenization strategy

---

The BM25 baseline is fully wired into the shared evaluation harness:

- uses the Dev QA dataset as evaluation input
- produces per-query result artifacts
- computes summary metrics:
  - hit@k
  - recall@k
  - MRR
  - latency

---

Added deterministic output artifacts:

- results: `*.results.jsonl`
- summary: `*.summary.json`

Artifacts include:

- dataset version
- snapshot ID
- retriever/config metadata
- query counts
- hit@k / recall@k / MRR
- latency summary

---

Added fixture-based tests:

- `tests/test_bm25_baseline.py`

The tests validate:

- deterministic BM25 ranking on a tiny chunk fixture
- baseline execution through the CLI
- artifact writing
- bad-input handling for empty chunk artifacts

---

Added:

- `docs/process/bm25_retrieval_baseline.md`
- `README.md` updates

Documentation now records:

- tokenization / normalization strategy
- default BM25 parameters
- exact baseline command
- smoke-test workflow that does not depend on a committed `chunks.jsonl`

---

```bash
uv sync --locked --extra dev-tools --extra bm25
uv run ruff check . --fix
uv run ruff format .
uv run ruff format --check .
uv run pytest -q tests/test_bm25_baseline.py
uv run pytest -q

---

Changes to be committed:
	modified:   README.md
	new file:   docs/process/bm25_retrieval_baseline.md
	modified:   src/supportdoc_rag_chatbot/cli.py
	modified:   src/supportdoc_rag_chatbot/evaluation/__init__.py
	new file:   src/supportdoc_rag_chatbot/evaluation/bm25_baseline.py
	modified:   src/supportdoc_rag_chatbot/evaluation/retrievers.py
	new file:   tests/test_bm25_baseline.py