### PR TITLE
On branch retrieval/41-hybrid-retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The initial corpus is a pinned snapshot of Kubernetes documentation so the proje
 This README is maintained as a live project document and evolves with each completed task issue.
 
 ### Current Phase
-Dense and BM25 retrieval baseline evaluation.
+Dense, BM25, and hybrid retrieval baseline evaluation.
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
@@ -23,16 +23,15 @@ Dense and BM25 retrieval baseline evaluation.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
 - Local FAISS backend that builds, persists, reloads, and searches a dense index over saved embedding artifacts.
 - Developer-facing retrieval smoke CLI for local dense search over a saved FAISS index.
-- Shared retrieval evaluation harness plus dense and BM25 baseline runners that execute the committed Dev QA set and write deterministic result artifacts.
+- Shared retrieval evaluation harness plus dense, BM25, and hybrid baseline runners that execute the committed Dev QA set and write deterministic result artifacts.
 
 ### In Progress
 - Citation contract and refusal behavior integration.
 
 ### Next Up
-- Add hybrid retrieval behind the same evaluation harness.
+- Compare dense, BM25, and hybrid retrieval artifacts to choose the default baseline.
 - Connect retrieval outputs to generation and citation validation.
 - Expand deployment and observability documentation as the backend/API layer matures.
-- Compare dense, BM25, and hybrid retrieval artifacts to choose the default baseline.
 
 ---
 
@@ -304,42 +303,26 @@ A small versioned development QA set now lives under `data/evaluation/` for retr
 
 The evaluation helpers in `src/supportdoc_rag_chatbot/evaluation/dev_qa.py` can load the dataset, load the companion metadata/registry files, and validate that every annotated evidence ID belongs to the same snapshot. See `docs/process/retrieval_dev_qa.md` for the schema, annotation rules, and validation workflow.
 
-## 9B. Dense Retrieval Baseline Evaluation
+## 9B. Hybrid Retrieval Baseline Evaluation
 
-The repository now includes a shared retrieval evaluation harness plus a dense baseline runner. The dense baseline loads an already-built FAISS index, embeds each committed Dev QA query with the embedding model recorded in the index metadata, retrieves top-k chunk IDs, and writes deterministic artifacts under `data/evaluation/runs/` by default.
+The repository now includes a hybrid baseline runner that combines dense FAISS retrieval with BM25 lexical retrieval using Reciprocal Rank Fusion (RRF). The hybrid baseline collects ranked candidates from both component retrievers, merges duplicate chunk IDs deterministically, and writes deterministic artifacts under `data/evaluation/runs/` by default.
 
-Default dense baseline command:
+Default hybrid baseline command:
 
 ```bash
-uv run python -m supportdoc_rag_chatbot run-dense-baseline \
+uv run python -m supportdoc_rag_chatbot run-hybrid-baseline \
+  --chunks data/processed/chunks.jsonl \
   --index data/processed/indexes/faiss/chunk_index.faiss \
   --index-metadata data/processed/indexes/faiss/chunk_index.metadata.json \
   --top-k 5
 ```
 
-The dense run writes:
+The hybrid run writes:
 
 - a per-query results JSONL artifact
 - a summary JSON artifact with hit@k, recall@k, MRR, and latency
 
-See `docs/process/dense_retrieval_baseline.md` for the exact baseline configuration and output layout.
-
-## 9C. BM25 Retrieval Baseline Evaluation
-
-The repository now includes a BM25 baseline runner over the canonical `chunks.jsonl` artifact. The BM25 baseline tokenizes queries and chunks with a lowercase regex tokenizer, scores chunks with deterministic BM25 ranking, and writes deterministic artifacts under `data/evaluation/runs/` by default.
-
-Default BM25 baseline command:
-
-```bash
-uv run python -m supportdoc_rag_chatbot run-bm25-baseline   --chunks data/processed/chunks.jsonl   --top-k 5
-```
-
-The BM25 run writes:
-
-- a per-query results JSONL artifact
-- a summary JSON artifact with hit@k, recall@k, MRR, and latency
-
-See `docs/process/bm25_retrieval_baseline.md` for the tokenization strategy, exact baseline configuration, and output layout.
+See `docs/process/hybrid_retrieval_baseline.md` for the default fusion strategy, exact baseline configuration, and output layout.
 
 ---
 
@@ -355,6 +338,5 @@ The intended deployment path is a FastAPI backend with a web frontend, persisten
 - `docs/data/corpus.md` — corpus scope and licensing notes
 - `docs/diagrams/ingestion_pipeline.md` — ingestion pipeline overview
 - `docs/adr/` — architecture decisions and project rationale
-- `docs/process/dense_retrieval_baseline.md` — default dense baseline config and run command
-- `docs/process/bm25_retrieval_baseline.md` — default BM25 baseline config and run command
+- `docs/process/hybrid_retrieval_baseline.md` — default hybrid baseline config and run command
 - `PROPOSAL.md` — project proposal and delivery framing

--- a/docs/process/hybrid_retrieval_baseline.md
+++ b/docs/process/hybrid_retrieval_baseline.md
@@ -1,0 +1,78 @@
+# Hybrid Retrieval Baseline
+
+This document records the default hybrid retrieval baseline used for Epic 4 comparisons.
+
+## Goal
+
+Run the committed development QA dataset against a dense FAISS index plus the canonical `chunks.jsonl` artifact, then fuse dense and BM25 candidates into one ranked result list with Reciprocal Rank Fusion (RRF).
+
+The baseline writes:
+
+- per-query ranked retrieval results (`.results.jsonl`)
+- summary metrics (`.summary.json`)
+
+## Default baseline configuration
+
+- Retriever name: `hybrid-rrf`
+- Fusion strategy: Reciprocal Rank Fusion (`rrf`)
+- Dense retriever: `dense-faiss`
+- Lexical retriever: `bm25`
+- Corpus artifact: `data/processed/chunks.jsonl`
+- Dense index artifact: `data/processed/indexes/faiss/chunk_index.faiss`
+- Dense index metadata: `data/processed/indexes/faiss/chunk_index.metadata.json`
+- Default `rrf_k`: `60`
+- Default candidate depth: `20`
+- Default top-k: `5`
+- Dataset: `data/evaluation/dev_qa.k8s-9e1e32b.v1.jsonl`
+
+## Fusion strategy
+
+Hybrid retrieval uses a single deterministic fusion strategy:
+
+- collect ranked candidates from dense FAISS retrieval
+- collect ranked candidates from BM25 lexical retrieval
+- assign each candidate an RRF contribution of `1 / (rrf_k + rank)` per source retriever
+- sum contributions by `chunk_id`
+- merge duplicate chunk IDs into one fused entry
+- break score ties by ascending `chunk_id`
+
+Duplicate chunk IDs across dense and BM25 are merged deterministically. Metadata from the first observed hit is preserved and enriched with source rank provenance such as:
+
+- `dense-faiss_rank`
+- `bm25_rank`
+
+## Output paths
+
+By default, the hybrid baseline writes deterministic artifacts under:
+
+- `data/evaluation/runs/hybrid-rrf-k8s-9e1e32b-v1-top5-default.results.jsonl`
+- `data/evaluation/runs/hybrid-rrf-k8s-9e1e32b-v1-top5-default.summary.json`
+
+You can override either path explicitly from the CLI.
+
+## Exact local command
+
+After local chunk, embedding, and FAISS index artifacts exist, run:
+
+```bash
+uv run python -m supportdoc_rag_chatbot run-hybrid-baseline \
+  --chunks data/processed/chunks.jsonl \
+  --index data/processed/indexes/faiss/chunk_index.faiss \
+  --index-metadata data/processed/indexes/faiss/chunk_index.metadata.json \
+  --top-k 5
+```
+
+The command loads the committed Dev QA set, retrieves dense and lexical candidates, fuses them with RRF, and writes deterministic result artifacts.
+
+## Smoke test workflow
+
+This smoke path avoids depending on a committed local `chunks.jsonl` file by using the fixture-based hybrid baseline test.
+
+```bash
+uv sync --locked --extra dev-tools --extra faiss --extra bm25
+uv run ruff check . --fix
+uv run ruff format .
+uv run ruff format --check .
+uv run pytest -q tests/test_hybrid_baseline.py
+uv run pytest -q
+```

--- a/src/supportdoc_rag_chatbot/cli.py
+++ b/src/supportdoc_rag_chatbot/cli.py
@@ -10,13 +10,18 @@ from supportdoc_rag_chatbot.evaluation import (
     DEFAULT_BM25_BASELINE_LABEL,
     DEFAULT_BM25_BASELINE_TOP_K,
     DEFAULT_BM25_K1,
+    DEFAULT_DENSE_BASELINE_LABEL,
+    DEFAULT_DENSE_BASELINE_TOP_K,
     DEFAULT_EVAL_TOP_K,
+    DEFAULT_HYBRID_BASELINE_LABEL,
+    DEFAULT_HYBRID_BASELINE_TOP_K,
     DEFAULT_HYBRID_CANDIDATE_DEPTH,
     DEFAULT_RRF_K,
     BM25BaselineConfig,
     BM25ChunkEvaluationRetriever,
     DenseBaselineConfig,
     DenseFaissEvaluationRetriever,
+    HybridBaselineConfig,
     HybridRRFEvaluationRetriever,
     create_dev_qa_fixture_retriever,
     default_dev_qa_paths,
@@ -27,9 +32,11 @@ from supportdoc_rag_chatbot.evaluation import (
     load_evidence_registry,
     render_bm25_baseline_report,
     render_dense_baseline_report,
+    render_hybrid_baseline_report,
     render_retrieval_evaluation_report,
     run_bm25_baseline,
     run_dense_baseline,
+    run_hybrid_baseline,
     write_query_results,
     write_retrieval_run_summary,
 )
@@ -449,7 +456,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     dense_baseline_parser.add_argument(
         "--top-k",
         type=int,
-        default=DEFAULT_EVAL_TOP_K,
+        default=DEFAULT_DENSE_BASELINE_TOP_K,
         help="Number of ranked hits to keep per query",
     )
     dense_baseline_parser.add_argument(
@@ -459,7 +466,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     dense_baseline_parser.add_argument(
         "--run-label",
-        default="default",
+        default=DEFAULT_DENSE_BASELINE_LABEL,
         help="Logical label appended to the default dense run name",
     )
     dense_baseline_parser.add_argument(
@@ -475,6 +482,110 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Optional output path for the summary metrics JSON",
     )
     dense_baseline_parser.set_defaults(handler=_run_dense_baseline)
+
+    hybrid_baseline_parser = subparsers.add_parser(
+        "run-hybrid-baseline",
+        help="Run the hybrid retrieval baseline over the dev QA set and write deterministic artifacts",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=None,
+        help="Optional path to a dev QA dataset JSONL (defaults to committed dataset)",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--dataset-metadata",
+        type=Path,
+        default=None,
+        help="Optional path to dev QA metadata JSON (defaults to committed metadata)",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Optional path to an evidence registry JSON (defaults to committed registry or derives from chunks)",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--chunks",
+        type=Path,
+        default=DEFAULT_CHUNKS_PATH,
+        help="Path to chunks.jsonl used as the canonical lexical corpus",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--index",
+        type=Path,
+        default=DEFAULT_FAISS_INDEX_PATH,
+        help="Path to the persisted FAISS index file",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--index-metadata",
+        type=Path,
+        default=DEFAULT_FAISS_METADATA_PATH,
+        help="Path to the FAISS index metadata JSON",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--row-mapping",
+        type=Path,
+        default=None,
+        help="Optional FAISS row mapping override",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--model-name",
+        default=None,
+        help="Optional embedding model override for dense query embedding",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--device",
+        default=DEFAULT_DEVICE,
+        help="Embedding device, for example cpu, cuda, or mps",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Embedding batch size for query embedding",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--rrf-k",
+        type=int,
+        default=DEFAULT_RRF_K,
+        help="Reciprocal-rank-fusion constant for hybrid retrieval",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--candidate-depth",
+        type=int,
+        default=DEFAULT_HYBRID_CANDIDATE_DEPTH,
+        help="Candidate depth per component retriever before fusion",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_HYBRID_BASELINE_TOP_K,
+        help="Number of ranked hits to keep per query",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--run-name",
+        default=None,
+        help="Optional run name override for output artifact naming",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--run-label",
+        default=DEFAULT_HYBRID_BASELINE_LABEL,
+        help="Logical label appended to the default hybrid run name",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--results-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the per-query retrieval results JSONL",
+    )
+    hybrid_baseline_parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the summary metrics JSON",
+    )
+    hybrid_baseline_parser.set_defaults(handler=_run_hybrid_baseline)
 
     return parser
 
@@ -574,6 +685,32 @@ def _run_dense_baseline(args: argparse.Namespace) -> int:
         )
     )
     print(render_dense_baseline_report(run))
+    return 0
+
+
+def _run_hybrid_baseline(args: argparse.Namespace) -> int:
+    run = run_hybrid_baseline(
+        config=HybridBaselineConfig(
+            dataset_path=args.dataset,
+            dataset_metadata_path=args.dataset_metadata,
+            registry_path=args.registry,
+            chunks_path=args.chunks,
+            index_path=args.index,
+            index_metadata_path=args.index_metadata,
+            row_mapping_path=args.row_mapping,
+            model_name=args.model_name,
+            device=args.device,
+            batch_size=args.batch_size,
+            rrf_k=args.rrf_k,
+            candidate_depth=args.candidate_depth,
+            top_k=args.top_k,
+            run_name=args.run_name,
+            run_label=args.run_label,
+            results_output_path=args.results_output,
+            summary_output_path=args.summary_output,
+        )
+    )
+    print(render_hybrid_baseline_report(run))
     return 0
 
 

--- a/src/supportdoc_rag_chatbot/evaluation/__init__.py
+++ b/src/supportdoc_rag_chatbot/evaluation/__init__.py
@@ -67,6 +67,14 @@ from .harness import (
     write_query_results,
     write_retrieval_run_summary,
 )
+from .hybrid_baseline import (
+    DEFAULT_HYBRID_BASELINE_LABEL,
+    DEFAULT_HYBRID_BASELINE_TOP_K,
+    HybridBaselineConfig,
+    HybridBaselineRetriever,
+    render_hybrid_baseline_report,
+    run_hybrid_baseline,
+)
 from .retrievers import (
     DEFAULT_HYBRID_CANDIDATE_DEPTH,
     DEFAULT_RRF_K,
@@ -100,6 +108,12 @@ __all__ = [
     "DenseBaselineConfig",
     "DEFAULT_DENSE_BASELINE_TOP_K",
     "DEFAULT_DENSE_BASELINE_LABEL",
+    "HybridBaselineRetriever",
+    "HybridBaselineConfig",
+    "DEFAULT_HYBRID_BASELINE_TOP_K",
+    "DEFAULT_HYBRID_BASELINE_LABEL",
+    "render_hybrid_baseline_report",
+    "run_hybrid_baseline",
     "DEFAULT_DATASET_FILENAME",
     "DEFAULT_DATASET_VERSION",
     "DEFAULT_EVAL_TOP_K",

--- a/src/supportdoc_rag_chatbot/evaluation/hybrid_baseline.py
+++ b/src/supportdoc_rag_chatbot/evaluation/hybrid_baseline.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from supportdoc_rag_chatbot.retrieval.embeddings import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_CHUNKS_PATH,
+    DEFAULT_DEVICE,
+    load_chunk_records,
+)
+from supportdoc_rag_chatbot.retrieval.indexes import (
+    DEFAULT_FAISS_INDEX_PATH,
+    DEFAULT_FAISS_METADATA_PATH,
+)
+
+from .artifacts import (
+    RetrievalQueryArtifact,
+    RetrievalRunArtifacts,
+    RetrievalSummaryArtifact,
+    RetrievedChunkArtifact,
+    write_retrieval_results,
+    write_retrieval_summary,
+)
+from .dev_qa import (
+    DevQAEntry,
+    DevQAMetadata,
+    EvidenceRegistry,
+    default_dev_qa_paths,
+    load_default_dev_qa_dataset,
+    load_default_dev_qa_metadata,
+    load_default_evidence_registry,
+    load_dev_qa_dataset,
+    load_dev_qa_metadata,
+    load_evidence_registry,
+)
+from .harness import evaluate_retriever
+from .retrievers import (
+    DEFAULT_HYBRID_CANDIDATE_DEPTH,
+    DEFAULT_RRF_K,
+    BM25ChunkEvaluationRetriever,
+    DenseFaissEvaluationRetriever,
+    HybridRRFEvaluationRetriever,
+)
+
+DEFAULT_HYBRID_BASELINE_TOP_K = 5
+DEFAULT_HYBRID_BASELINE_LABEL = "default"
+
+
+@dataclass(slots=True)
+class HybridBaselineConfig:
+    chunks_path: Path = DEFAULT_CHUNKS_PATH
+    index_path: Path = DEFAULT_FAISS_INDEX_PATH
+    index_metadata_path: Path = DEFAULT_FAISS_METADATA_PATH
+    row_mapping_path: Path | None = None
+    dataset_path: Path | None = None
+    dataset_metadata_path: Path | None = None
+    registry_path: Path | None = None
+    model_name: str | None = None
+    device: str = DEFAULT_DEVICE
+    batch_size: int = DEFAULT_BATCH_SIZE
+    rrf_k: int = DEFAULT_RRF_K
+    candidate_depth: int = DEFAULT_HYBRID_CANDIDATE_DEPTH
+    top_k: int = DEFAULT_HYBRID_BASELINE_TOP_K
+    run_name: str | None = None
+    run_label: str = DEFAULT_HYBRID_BASELINE_LABEL
+    results_output_path: Path | None = None
+    summary_output_path: Path | None = None
+
+
+class HybridBaselineRetriever(HybridRRFEvaluationRetriever):
+    def __init__(self, config: HybridBaselineConfig) -> None:
+        if config.top_k <= 0:
+            raise ValueError("top_k must be > 0")
+        dense_retriever = DenseFaissEvaluationRetriever(
+            name="dense-faiss",
+            index_path=config.index_path,
+            index_metadata_path=config.index_metadata_path,
+            row_mapping_path=config.row_mapping_path,
+            chunks_path=config.chunks_path,
+            model_name=config.model_name,
+            device=config.device,
+            batch_size=config.batch_size,
+        )
+        lexical_retriever = BM25ChunkEvaluationRetriever(
+            name="bm25",
+            chunks_path=config.chunks_path,
+        )
+        super().__init__(
+            dense_retriever=dense_retriever,
+            lexical_retriever=lexical_retriever,
+            name="hybrid-rrf",
+            rrf_k=config.rrf_k,
+            candidate_depth=config.candidate_depth,
+        )
+
+
+def run_hybrid_baseline(config: HybridBaselineConfig | None = None) -> RetrievalRunArtifacts:
+    runtime_config = config or HybridBaselineConfig()
+
+    dataset_entries, dataset_metadata = _load_dataset_surface(runtime_config)
+    registry = _load_registry_surface(runtime_config, dataset_metadata)
+    retriever = HybridBaselineRetriever(runtime_config)
+
+    results_output_path, summary_output_path = _resolve_output_paths(
+        config=runtime_config,
+        dataset_metadata=dataset_metadata,
+    )
+    run_name = runtime_config.run_name or _default_run_name(
+        metadata=dataset_metadata,
+        top_k=runtime_config.top_k,
+        label=runtime_config.run_label,
+    )
+
+    harness_results, harness_summary = evaluate_retriever(
+        retriever=retriever,
+        entries=dataset_entries,
+        metadata=dataset_metadata,
+        registry=registry,
+        top_k=runtime_config.top_k,
+    )
+
+    result_artifacts = [
+        RetrievalQueryArtifact(
+            query_id=result.query_id,
+            question=result.question,
+            answerable=result.answerable,
+            snapshot_id=result.snapshot_id,
+            retriever_name=result.retriever_name,
+            top_k=result.top_k,
+            latency_ms=result.latency_ms,
+            expected_chunk_ids=list(result.expected_chunk_ids),
+            matches=[
+                RetrievedChunkArtifact(
+                    chunk_id=hit.chunk_id,
+                    rank=hit.rank,
+                    score=hit.score,
+                )
+                for hit in result.hits
+            ],
+            retriever_config=dict(result.retriever_config),
+        )
+        for result in harness_results
+    ]
+
+    summary_artifact = RetrievalSummaryArtifact(
+        run_name=run_name,
+        dataset_name=dataset_metadata.dataset_name,
+        dataset_version=dataset_metadata.dataset_version,
+        snapshot_id=dataset_metadata.snapshot_id,
+        retriever_name=harness_summary.retriever_name,
+        top_k=harness_summary.top_k,
+        query_count=harness_summary.total_query_count,
+        answerable_query_count=harness_summary.answerable_query_count,
+        hit_at_k=harness_summary.hit_at_k,
+        recall_at_k=harness_summary.recall_at_k,
+        mrr=harness_summary.mrr,
+        mean_latency_ms=harness_summary.average_latency_ms,
+        max_latency_ms=harness_summary.max_latency_ms,
+        results_output_path=str(results_output_path),
+        summary_output_path=str(summary_output_path),
+        retriever_config=dict(harness_summary.retriever_config),
+    )
+
+    write_retrieval_results(results_output_path, result_artifacts)
+    write_retrieval_summary(summary_output_path, summary_artifact)
+    return RetrievalRunArtifacts(results=result_artifacts, summary=summary_artifact)
+
+
+def render_hybrid_baseline_report(run: RetrievalRunArtifacts) -> str:
+    summary = run.summary
+    config = summary.retriever_config
+    lines = [
+        "Hybrid retrieval baseline",
+        f"run_name: {summary.run_name}",
+        f"dataset: {summary.dataset_name}:{summary.dataset_version}",
+        f"snapshot_id: {summary.snapshot_id}",
+        f"fusion_strategy: {config.get('fusion_strategy_name', '(unknown)')}",
+        f"rrf_k: {config.get('rrf_k', '(unknown)')}",
+        f"candidate_depth: {config.get('candidate_depth', '(unknown)')}",
+        f"dense_retriever: {config.get('dense_retriever', '(unknown)')}",
+        f"lexical_retriever: {config.get('lexical_retriever', '(unknown)')}",
+        f"top_k: {summary.top_k}",
+        f"query_count: {summary.query_count}",
+        f"answerable_query_count: {summary.answerable_query_count}",
+        f"hit@k: {summary.hit_at_k:.6f}",
+        f"recall@k: {summary.recall_at_k:.6f}",
+        f"mrr: {summary.mrr:.6f}",
+        f"mean_latency_ms: {summary.mean_latency_ms:.3f}",
+        f"max_latency_ms: {summary.max_latency_ms:.3f}",
+        f"results_output: {summary.results_output_path}",
+        f"summary_output: {summary.summary_output_path}",
+    ]
+    return "\n".join(lines)
+
+
+def _load_dataset_surface(
+    config: HybridBaselineConfig,
+) -> tuple[list[DevQAEntry], DevQAMetadata]:
+    if config.dataset_path is None:
+        dataset_entries = load_default_dev_qa_dataset()
+    else:
+        dataset_entries = load_dev_qa_dataset(config.dataset_path)
+
+    if config.dataset_metadata_path is None:
+        dataset_metadata = load_default_dev_qa_metadata()
+    else:
+        dataset_metadata = load_dev_qa_metadata(config.dataset_metadata_path)
+
+    return dataset_entries, dataset_metadata
+
+
+def _load_registry_surface(
+    config: HybridBaselineConfig,
+    metadata: DevQAMetadata,
+) -> EvidenceRegistry:
+    if config.registry_path is not None:
+        return load_evidence_registry(config.registry_path)
+
+    if config.dataset_path is None and config.dataset_metadata_path is None:
+        return load_default_evidence_registry()
+
+    chunks = load_chunk_records(config.chunks_path)
+    return EvidenceRegistry(
+        snapshot_id=metadata.snapshot_id,
+        source_manifest_path=metadata.source_manifest_path,
+        doc_ids=sorted({chunk.doc_id for chunk in chunks}),
+        section_ids=sorted({chunk.section_id for chunk in chunks}),
+        chunk_ids=sorted({chunk.chunk_id for chunk in chunks}),
+        default_chunking=dict(metadata.default_chunking),
+    )
+
+
+def _resolve_output_paths(
+    *,
+    config: HybridBaselineConfig,
+    dataset_metadata: DevQAMetadata,
+) -> tuple[Path, Path]:
+    results_output_path = config.results_output_path
+    summary_output_path = config.summary_output_path
+
+    if results_output_path is not None and summary_output_path is not None:
+        return results_output_path, summary_output_path
+
+    default_dataset_path, _, _ = default_dev_qa_paths()
+    repo_root = default_dataset_path.parents[2]
+    run_name = config.run_name or _default_run_name(
+        metadata=dataset_metadata,
+        top_k=config.top_k,
+        label=config.run_label,
+    )
+
+    if results_output_path is None:
+        results_output_path = (
+            repo_root / "data" / "evaluation" / "runs" / f"{run_name}.results.jsonl"
+        )
+    if summary_output_path is None:
+        summary_output_path = (
+            repo_root / "data" / "evaluation" / "runs" / f"{run_name}.summary.json"
+        )
+    return results_output_path, summary_output_path
+
+
+def _default_run_name(*, metadata: DevQAMetadata, top_k: int, label: str) -> str:
+    return f"hybrid-rrf-{metadata.snapshot_id}-{metadata.dataset_version}-top{top_k}-{label}"

--- a/src/supportdoc_rag_chatbot/evaluation/retrievers.py
+++ b/src/supportdoc_rag_chatbot/evaluation/retrievers.py
@@ -235,11 +235,18 @@ class HybridRRFEvaluationRetriever:
 
     @property
     def config(self) -> dict[str, Any]:
+        dense_config = getattr(self.dense_retriever, "config", {})
+        lexical_config = getattr(self.lexical_retriever, "config", {})
         return {
+            "fusion_strategy": "rrf",
+            "fusion_strategy_name": "reciprocal-rank-fusion",
             "rrf_k": self.rrf_k,
             "candidate_depth": self.candidate_depth,
+            "tie_break": "chunk_id ascending",
             "dense_retriever": getattr(self.dense_retriever, "name", "dense"),
             "lexical_retriever": getattr(self.lexical_retriever, "name", "lexical"),
+            "dense_config": dict(dense_config),
+            "lexical_config": dict(lexical_config),
         }
 
     def retrieve(self, entry: DevQAEntry, *, top_k: int) -> list[RetrievalHit]:

--- a/tests/test_hybrid_baseline.py
+++ b/tests/test_hybrid_baseline.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import json
+import pickle
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from supportdoc_rag_chatbot.cli import main
+from supportdoc_rag_chatbot.evaluation import (
+    HybridRRFEvaluationRetriever,
+    RetrievalHit,
+    StaticEvaluationRetriever,
+    read_retrieval_results,
+    read_retrieval_summary,
+)
+from supportdoc_rag_chatbot.evaluation.dev_qa import DevQAEntry, DevQAMetadata, EvidenceRegistry
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import build_embedding_artifacts
+from supportdoc_rag_chatbot.retrieval.indexes import build_faiss_index_artifacts
+
+
+class MappingTestEmbedder:
+    model_name = "test-map-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self.mapping = mapping
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[float(value) for value in self.mapping[text]] for text in texts]
+
+
+class FakeFaissIndexFlatIP:
+    def __init__(self, dimension: int) -> None:
+        self.d = int(dimension)
+        self.ntotal = 0
+        self._vectors = _numpy().empty((0, self.d), dtype=_numpy().float32)
+
+    def add(self, vectors) -> None:
+        vectors_array = _numpy().asarray(vectors, dtype=_numpy().float32)
+        if vectors_array.ndim != 2 or vectors_array.shape[1] != self.d:
+            raise ValueError("FakeFaissIndexFlatIP.add received vectors with the wrong shape")
+        self._vectors = _numpy().vstack([self._vectors, vectors_array])
+        self.ntotal = int(self._vectors.shape[0])
+
+    def search(self, queries, top_k: int):
+        queries_array = _numpy().asarray(queries, dtype=_numpy().float32)
+        scores = queries_array @ self._vectors.T
+        ranked_indexes = _numpy().argsort(-scores, axis=1, kind="stable")[:, :top_k]
+        ranked_scores = _numpy().take_along_axis(scores, ranked_indexes, axis=1)
+        return ranked_scores.astype(_numpy().float32), ranked_indexes.astype(_numpy().int64)
+
+
+class QueryTestEmbedder:
+    model_name = "test-query-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]) -> None:
+        self.mapping = mapping
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [[float(value) for value in self.mapping[text]] for text in texts]
+
+
+@pytest.fixture
+def fake_faiss(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "faiss", fake_faiss_module())
+
+
+@pytest.fixture
+def hybrid_baseline_fixture(tmp_path: Path, fake_faiss) -> dict[str, Path]:
+    chunks_path = tmp_path / "data/processed/chunks.jsonl"
+    vectors_path = tmp_path / "data/processed/embeddings/chunk_embeddings.f32"
+    embedding_metadata_path = tmp_path / "data/processed/embeddings/chunk_embeddings.metadata.json"
+    index_path = tmp_path / "data/processed/indexes/faiss/chunk_index.faiss"
+    index_metadata_path = tmp_path / "data/processed/indexes/faiss/chunk_index.metadata.json"
+    row_mapping_path = tmp_path / "data/processed/indexes/faiss/chunk_index.row_mapping.json"
+
+    dataset_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.jsonl"
+    dataset_metadata_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.metadata.json"
+    registry_path = tmp_path / "data/evaluation/dev_qa.fixture.v1.registry.json"
+    results_output_path = tmp_path / "tmp/eval/hybrid.results.jsonl"
+    summary_output_path = tmp_path / "tmp/eval/hybrid.summary.json"
+
+    chunks = [
+        make_chunk(
+            chunk_id="chunk-service",
+            doc_id="doc-service",
+            section_id="section-service",
+            text="A Kubernetes Service provides stable networking in front of Pods.",
+        ),
+        make_chunk(
+            chunk_id="chunk-probe",
+            doc_id="doc-probe",
+            section_id="section-probe",
+            text="Startup probes protect slow-starting containers from early restarts.",
+        ),
+        make_chunk(
+            chunk_id="chunk-noise",
+            doc_id="doc-noise",
+            section_id="section-noise",
+            text="This unrelated chunk mentions Pods and Services only briefly.",
+        ),
+    ]
+    write_chunks(chunks_path, chunks)
+
+    embedder = MappingTestEmbedder(
+        {
+            chunks[0].text: [1.0, 0.0, 0.0],
+            chunks[1].text: [0.0, 1.0, 0.0],
+            chunks[2].text: [0.3, 0.3, 0.0],
+        }
+    )
+    build_embedding_artifacts(
+        chunks_path=chunks_path,
+        vectors_path=vectors_path,
+        metadata_path=embedding_metadata_path,
+        embedder=embedder,
+        batch_size=2,
+    )
+    build_faiss_index_artifacts(
+        embedding_metadata_path=embedding_metadata_path,
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+    )
+
+    entries = [
+        DevQAEntry(
+            query_id="service-purpose",
+            snapshot_id="k8s-9e1e32b",
+            question="Why would you use a Kubernetes Service?",
+            answerable=True,
+            category="definition",
+            tags=["services"],
+            doc_ids=["doc-service"],
+            expected_section_ids=["section-service"],
+            expected_chunk_ids=["chunk-service"],
+            notes="service evidence",
+        ),
+        DevQAEntry(
+            query_id="startup-probe",
+            snapshot_id="k8s-9e1e32b",
+            question="How can startup probes protect slow-starting containers?",
+            answerable=True,
+            category="troubleshooting",
+            tags=["probes"],
+            doc_ids=["doc-probe"],
+            expected_section_ids=["section-probe"],
+            expected_chunk_ids=["chunk-probe"],
+            notes="probe evidence",
+        ),
+    ]
+    write_dataset(dataset_path, entries)
+    write_metadata(
+        dataset_metadata_path,
+        DevQAMetadata(
+            dataset_name="fixture_hybrid_baseline",
+            dataset_version="v1",
+            snapshot_id="k8s-9e1e32b",
+            source_manifest_path="data/manifests/source_manifest.jsonl",
+            artifact_path=str(dataset_path),
+            registry_path=str(registry_path),
+            row_count=len(entries),
+            doc_count=3,
+            section_id_count=3,
+            chunk_id_count=3,
+            default_chunking={"max_tokens": 350, "overlap_tokens": 50},
+            notes="fixture metadata",
+        ),
+    )
+    write_registry(
+        registry_path,
+        EvidenceRegistry(
+            snapshot_id="k8s-9e1e32b",
+            source_manifest_path="data/manifests/source_manifest.jsonl",
+            doc_ids=["doc-noise", "doc-probe", "doc-service"],
+            section_ids=["section-noise", "section-probe", "section-service"],
+            chunk_ids=["chunk-noise", "chunk-probe", "chunk-service"],
+            default_chunking={"max_tokens": 350, "overlap_tokens": 50},
+        ),
+    )
+
+    return {
+        "dataset_path": dataset_path,
+        "dataset_metadata_path": dataset_metadata_path,
+        "registry_path": registry_path,
+        "chunks_path": chunks_path,
+        "index_path": index_path,
+        "index_metadata_path": index_metadata_path,
+        "row_mapping_path": row_mapping_path,
+        "results_output_path": results_output_path,
+        "summary_output_path": summary_output_path,
+    }
+
+
+def test_run_hybrid_baseline_cli_writes_retrieval_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    hybrid_baseline_fixture: dict[str, Path],
+) -> None:
+    from supportdoc_rag_chatbot.evaluation import hybrid_baseline
+
+    def fake_create_local_embedder(*, model_name, device, batch_size, normalize_embeddings):
+        assert model_name == "test-map-v1"
+        assert device == "cpu"
+        assert batch_size == 32
+        assert normalize_embeddings is True
+        return QueryTestEmbedder(
+            {
+                "Why would you use a Kubernetes Service?": [1.0, 0.0, 0.0],
+                "How can startup probes protect slow-starting containers?": [0.0, 1.0, 0.0],
+            }
+        )
+
+    monkeypatch.setattr(
+        hybrid_baseline, "create_local_embedder", fake_create_local_embedder, raising=False
+    )
+    from supportdoc_rag_chatbot.evaluation import retrievers
+
+    monkeypatch.setattr(retrievers, "create_local_embedder", fake_create_local_embedder)
+
+    exit_code = main(
+        [
+            "run-hybrid-baseline",
+            "--dataset",
+            str(hybrid_baseline_fixture["dataset_path"]),
+            "--dataset-metadata",
+            str(hybrid_baseline_fixture["dataset_metadata_path"]),
+            "--registry",
+            str(hybrid_baseline_fixture["registry_path"]),
+            "--chunks",
+            str(hybrid_baseline_fixture["chunks_path"]),
+            "--index",
+            str(hybrid_baseline_fixture["index_path"]),
+            "--index-metadata",
+            str(hybrid_baseline_fixture["index_metadata_path"]),
+            "--row-mapping",
+            str(hybrid_baseline_fixture["row_mapping_path"]),
+            "--top-k",
+            "2",
+            "--rrf-k",
+            "10",
+            "--candidate-depth",
+            "3",
+            "--results-output",
+            str(hybrid_baseline_fixture["results_output_path"]),
+            "--summary-output",
+            str(hybrid_baseline_fixture["summary_output_path"]),
+        ]
+    )
+
+    assert exit_code == 0
+
+    results = read_retrieval_results(hybrid_baseline_fixture["results_output_path"])
+    summary = read_retrieval_summary(hybrid_baseline_fixture["summary_output_path"])
+
+    assert len(results) == 2
+    assert [match.chunk_id for match in results[0].matches] == ["chunk-service", "chunk-noise"]
+    assert [match.chunk_id for match in results[1].matches] == ["chunk-probe", "chunk-noise"]
+    assert summary.retriever_name == "hybrid-rrf"
+    assert summary.top_k == 2
+    assert summary.query_count == 2
+    assert summary.answerable_query_count == 2
+    assert summary.hit_at_k == pytest.approx(1.0)
+    assert summary.recall_at_k == pytest.approx(1.0)
+    assert summary.mrr == pytest.approx(1.0)
+    assert summary.retriever_config["fusion_strategy"] == "rrf"
+    assert summary.retriever_config["rrf_k"] == 10
+    assert summary.retriever_config["candidate_depth"] == 3
+    assert summary.retriever_config["dense_retriever"] == "dense-faiss"
+    assert summary.retriever_config["lexical_retriever"] == "bm25"
+
+    out = capsys.readouterr().out
+    assert "Hybrid retrieval baseline" in out
+    assert "fusion_strategy: reciprocal-rank-fusion" in out
+    assert "rrf_k: 10" in out
+    assert "candidate_depth: 3" in out
+    assert f"results_output: {hybrid_baseline_fixture['results_output_path']}" in out
+    assert f"summary_output: {hybrid_baseline_fixture['summary_output_path']}" in out
+
+
+def test_hybrid_rrf_merges_duplicate_hits_deterministically() -> None:
+    entry = DevQAEntry(
+        query_id="q1",
+        snapshot_id="k8s-9e1e32b",
+        question="Why would you use a Kubernetes Service?",
+        answerable=True,
+        category="definition",
+        tags=["services"],
+        doc_ids=["doc-service"],
+        expected_section_ids=["section-service"],
+        expected_chunk_ids=["chunk-service"],
+        notes="service evidence",
+    )
+    dense = StaticEvaluationRetriever(
+        name="dense-faiss",
+        retriever_type="dense",
+        hits_by_query_id={
+            "q1": [
+                RetrievalHit(
+                    chunk_id="chunk-noise",
+                    score=0.9,
+                    rank=1,
+                    doc_id="doc-noise",
+                    section_id="section-noise",
+                ),
+                RetrievalHit(
+                    chunk_id="chunk-service",
+                    score=0.8,
+                    rank=2,
+                    doc_id="doc-service",
+                    section_id="section-service",
+                ),
+            ]
+        },
+    )
+    lexical = StaticEvaluationRetriever(
+        name="bm25",
+        retriever_type="bm25",
+        hits_by_query_id={
+            "q1": [
+                RetrievalHit(
+                    chunk_id="chunk-service",
+                    score=4.0,
+                    rank=1,
+                    doc_id="doc-service",
+                    section_id="section-service",
+                ),
+                RetrievalHit(
+                    chunk_id="chunk-noise",
+                    score=2.0,
+                    rank=2,
+                    doc_id="doc-noise",
+                    section_id="section-noise",
+                ),
+            ]
+        },
+    )
+    retriever = HybridRRFEvaluationRetriever(
+        dense_retriever=dense,
+        lexical_retriever=lexical,
+        rrf_k=10,
+        candidate_depth=5,
+    )
+
+    hits = retriever.retrieve(entry, top_k=2)
+
+    assert [hit.chunk_id for hit in hits] == ["chunk-noise", "chunk-service"]
+    assert hits[0].rank == 1
+    assert hits[0].metadata == {"bm25_rank": 2, "dense-faiss_rank": 1}
+    assert hits[1].metadata == {"bm25_rank": 1, "dense-faiss_rank": 2}
+
+
+def fake_faiss_module() -> SimpleNamespace:
+    def normalize_l2(matrix) -> None:
+        array = _numpy().asarray(matrix, dtype=_numpy().float32)
+        norms = _numpy().linalg.norm(array, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        array /= norms
+
+    def write_index(index: FakeFaissIndexFlatIP, path: str) -> None:
+        payload = {"d": index.d, "vectors": index._vectors}
+        with Path(path).open("wb") as handle:
+            pickle.dump(payload, handle)
+
+    def read_index(path: str) -> FakeFaissIndexFlatIP:
+        with Path(path).open("rb") as handle:
+            payload = pickle.load(handle)
+        index = FakeFaissIndexFlatIP(payload["d"])
+        index.add(payload["vectors"])
+        return index
+
+    return SimpleNamespace(
+        IndexFlatIP=FakeFaissIndexFlatIP,
+        normalize_L2=normalize_l2,
+        write_index=write_index,
+        read_index=read_index,
+    )
+
+
+def make_chunk(
+    *,
+    chunk_id: str,
+    doc_id: str,
+    section_id: str,
+    text: str,
+    snapshot_id: str = "k8s-9e1e32b",
+) -> ChunkRecord:
+    return ChunkRecord(
+        snapshot_id=snapshot_id,
+        doc_id=doc_id,
+        chunk_id=chunk_id,
+        section_id=section_id,
+        section_index=0,
+        chunk_index=0,
+        doc_title=doc_id,
+        section_path=[section_id],
+        source_path=f"{doc_id}.md",
+        source_url=f"https://example.test/{doc_id}",
+        license="CC BY 4.0",
+        attribution="fixture",
+        language="en",
+        start_offset=0,
+        end_offset=len(text),
+        token_count=len(text.split()),
+        text=text,
+    )
+
+
+def write_chunks(path: Path, chunks: list[ChunkRecord]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(chunk.to_dict(), ensure_ascii=False) + "\n" for chunk in chunks),
+        encoding="utf-8",
+    )
+
+
+def write_dataset(path: Path, entries: list[DevQAEntry]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n" for entry in entries),
+        encoding="utf-8",
+    )
+
+
+def write_metadata(path: Path, metadata: DevQAMetadata) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_registry(path: Path, registry: EvidenceRegistry) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(registry.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _numpy():
+    import numpy
+
+    return numpy


### PR DESCRIPTION
Closes #41

This change adds the **hybrid retrieval baseline** for Epic 4.

It combines dense FAISS retrieval and BM25 lexical retrieval into a single fused ranking using **Reciprocal Rank Fusion (RRF)**, then runs that retriever through the shared evaluation harness.

The hybrid baseline produces deterministic:

- per-query ranked retrieval results
- summary retrieval metrics

This gives Epic 4 a reproducible dense + lexical fusion baseline for direct comparison against the dense and BM25 baselines.

---

Added a hybrid baseline runner that:

- loads an existing FAISS index and metadata
- loads the canonical chunk corpus for BM25
- retrieves dense and BM25 candidates per query
- fuses candidates with Reciprocal Rank Fusion (RRF)
- evaluates the fused results through the shared retrieval harness

---

Added a retriever adapter that:

- wraps `DenseFaissEvaluationRetriever`
- wraps `BM25ChunkEvaluationRetriever`
- merges duplicate `chunk_id` values deterministically
- breaks fused-score ties by ascending `chunk_id`

The retriever records configuration including:

- fusion strategy
- `rrf_k`
- candidate depth
- dense retriever name/config
- lexical retriever name/config
- tie-break behavior

---

The hybrid baseline is fully wired into the shared evaluation harness:

- uses the Dev QA dataset as evaluation input
- produces per-query result artifacts
- computes summary metrics:
  - hit@k
  - recall@k
  - MRR
  - latency

---

Added deterministic output artifacts:

- results: `*.results.jsonl`
- summary: `*.summary.json`

Artifacts include:

- dataset version
- snapshot ID
- retriever/config metadata
- query counts
- hit@k / recall@k / MRR
- latency summary

---

Added fixture-based tests:

- `tests/test_hybrid_baseline.py`

The tests validate:

- hybrid baseline execution through the CLI
- fusion behavior
- duplicate-hit merging
- deterministic tie-breaking
- artifact writing

---

Added:

- `docs/process/hybrid_retrieval_baseline.md`
- `README.md` updates

Documentation now records:

- default fusion strategy
- default hybrid baseline config
- exact baseline command
- smoke-test workflow that does not depend on a committed `chunks.jsonl`

---

```bash
uv sync --locked --extra dev-tools --extra faiss --extra bm25
uv run ruff check . --fix
uv run ruff format .
uv run ruff format --check .
uv run pytest -q tests/test_hybrid_baseline.py
uv run pytest -q

Changes to be committed:
	modified:   README.md
	new file:   docs/process/hybrid_retrieval_baseline.md
	modified:   src/supportdoc_rag_chatbot/cli.py
	modified:   src/supportdoc_rag_chatbot/evaluation/__init__.py
	new file:   src/supportdoc_rag_chatbot/evaluation/hybrid_baseline.py
	modified:   src/supportdoc_rag_chatbot/evaluation/retrievers.py
	new file:   tests/test_hybrid_baseline.py