### PR TITLE
On branch doc/create-ADR-0002-through-ADR-0005

### DIFF
--- a/docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md
+++ b/docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md
@@ -1,0 +1,119 @@
+# ADR-0002: Ingestion Pipeline and Chunking Strategy
+
+- **Status:** Accepted
+- **Date:** 2026-03-22
+- **Deciders:** Rodrigo Arguello Serrano
+- **Related:** ADR-0001, EPIC 2, EPIC 5
+
+## Context
+
+The project ingests an allowlisted documentation corpus from a fixed snapshot and transforms it into retrievable chunks for downstream RAG. The ingestion pipeline must support reproducibility, retrieval quality, provenance, and later citation validation.
+
+A naive sliding-window approach is easy to implement but weak for traceability and often fragments meaning. Page-level chunks preserve context but add too much irrelevant text to retrieval and prompting. The project needs a deterministic, section-aware approach that preserves structure while remaining easy to debug.
+
+## Decision
+
+Use a **deterministic, section-aware ingestion pipeline**:
+
+- Parse documentation into a structured representation before chunking.
+- Prefer **section/subsection boundaries** as the primary chunk boundary.
+- Apply a **token cap** only when sections are too large.
+- Use moderate overlap only when a section split is required.
+- Preserve stable chunk metadata for provenance and citation validation.
+
+### Baseline chunking rules
+
+- **Primary boundary:** section/subsection structure from Markdown or HTML parsing
+- **Target chunk size:** about **350–800 tokens**
+- **Overlap:** about **50–120 tokens** when splitting large sections
+- Keep headings and nearby context attached to each chunk whenever practical
+
+### Required metadata
+
+Each chunk should preserve at least:
+
+```json
+{
+  "doc_id": "string",
+  "doc_title": "string",
+  "section_path": "string",
+  "chunk_id": "string",
+  "start_offset": 0,
+  "end_offset": 0,
+  "source_url": "string",
+  "license": "string",
+  "snapshot_id": "string"
+}
+```
+
+## Alternatives Considered
+
+### 1. Fixed-size sliding windows
+
+**Pros**
+- Simple implementation
+- Uniform chunk sizes
+
+**Cons**
+- Breaks semantic structure
+- Produces awkward evidence spans
+- Makes citation mapping less intuitive
+
+**Why not chosen**
+The project needs chunks that are easy to reason about and validate later.
+
+### 2. Page-level or document-level chunks
+
+**Pros**
+- Minimal preprocessing
+- Strong coherence
+
+**Cons**
+- Too much irrelevant context per retrieval result
+- Higher prompt cost
+- Lower ranking precision on focused troubleshooting questions
+
+**Why not chosen**
+The system needs targeted evidence retrieval, not broad page retrieval.
+
+### 3. Sentence-level chunks
+
+**Pros**
+- Fine-grained evidence mapping
+- Useful for narrow fact lookups
+
+**Cons**
+- Fragments explanations and procedures
+- Hurts recall for multi-step answers
+- Requires more downstream reassembly
+
+**Why not chosen**
+The baseline should preserve enough standalone meaning for retrieval and generation.
+
+## Consequences
+
+### Positive
+
+- Better retrieval quality by aligning chunks to author-written structure
+- Stable provenance for later citation enforcement
+- Deterministic, testable ingestion behavior
+- Lower prompt noise than page-level chunks
+
+### Negative / Trade-offs
+
+- Parsing is more complex than plain text splitting
+- Token-aware splitting adds a tokenizer dependency
+- Chunk size and overlap remain tuning parameters
+
+## Implementation Notes
+
+- Normalize formatting before token counting so offsets remain stable.
+- Generate chunk IDs deterministically from document identity and section/split position.
+- Keep parsing, normalization, chunking, and metadata generation as separate stages.
+- Record ingestion counts and total token counts for reproducibility reporting.
+
+## Links
+
+- **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §4.4, §5.2, §6.3, §10.1, §11.1
+- **Code:** `<replace-with-repo-path-to-ingestion-code>`
+- **Issue:** `<replace-with-sub-issue-number>`

--- a/docs/adr/0003-embedding-model-and-serving-strategy.md
+++ b/docs/adr/0003-embedding-model-and-serving-strategy.md
@@ -1,0 +1,99 @@
+# ADR-0003: Embedding Model and Serving Strategy
+
+- **Status:** Accepted
+- **Date:** 2026-03-22
+- **Deciders:** Rodrigo Arguello Serrano
+- **Related:** ADR-0002, ADR-0004, EPIC 3, EPIC 5
+
+## Context
+
+The retrieval stack requires a dense embedding model that is practical for a capstone-scale RAG system, reproducible across runs, and straightforward to serve locally and later in a deployment environment.
+
+The proposal narrows the candidate space to **E5** or **BGE**-class embedding models and allows either local serving or a dedicated embeddings service boundary.
+
+## Decision
+
+Use an **E5/BGE-class dense bi-encoder embedding model** as the semantic retrieval baseline.
+
+The architectural rules are:
+
+- Pin the exact checkpoint in configuration, for example with `EMBEDDING_MODEL_ID`.
+- Start with **local/in-process serving** for development simplicity.
+- Preserve the option to move embeddings behind a dedicated service boundary, such as **TEI**, when throughput or deployment isolation matters.
+- Record the exact model identifier and revision in evaluation artifacts for reproducibility.
+
+## Alternatives Considered
+
+### 1. Proprietary hosted embedding APIs
+
+**Pros**
+- Simple setup
+- Managed scaling
+
+**Cons**
+- Extra dependency
+- Cost and rate-limit exposure
+- Harder reproducibility
+- Less control over local evaluation
+
+**Why not chosen**
+The project is explicitly oriented around an open-source, reproducible stack.
+
+### 2. Sparse-only retrieval
+
+**Pros**
+- Simpler system
+- No embedding service needed
+
+**Cons**
+- Misses semantically relevant passages with different phrasing
+- Weakens the core semantic-search value proposition
+
+**Why not chosen**
+Semantic retrieval is a primary requirement for the support-doc use case.
+
+### 3. Larger embedding models by default
+
+**Pros**
+- Potential quality gains
+- Broader capability
+
+**Cons**
+- Higher memory and latency cost
+- More operational complexity
+- Unnecessary for the initial scoped corpus
+
+**Why not chosen**
+The baseline should optimize for reliability and tractable serving.
+
+## Consequences
+
+### Positive
+
+- Keeps the retrieval stack aligned with semantic search requirements
+- Preserves flexibility to benchmark exact E5/BGE checkpoints
+- Supports local experimentation and later service isolation
+- Improves reproducibility through version pinning
+
+### Negative / Trade-offs
+
+- Requires benchmarking before finalizing a single checkpoint
+- Adds an extra component if TEI is introduced later
+- Index-time and query-time preprocessing must remain consistent
+
+## Implementation Notes
+
+- Record the final values for `EMBEDDING_MODEL_ID`, revision, vector dimension, and normalization strategy.
+- Use the same preprocessing rules for indexing and query embedding.
+- Batch embeddings where practical during ingestion.
+- Cache document embeddings as durable artifacts when possible.
+
+## Links
+
+- **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §5.1, §6.3.2, §10.1, §11.2
+- **Code:** `<replace-with-repo-path-to-embedding-config-and-service-code>`
+- **Issue:** `<replace-with-sub-issue-number>`
+
+## Follow-up
+
+Replace this placeholder in the committed version with the exact checkpoint pinned in code, for example one specific E5 or BGE model ID. Only one model ID should remain in the final accepted ADR.

--- a/docs/adr/0004-vector-index-and-storage-strategy.md
+++ b/docs/adr/0004-vector-index-and-storage-strategy.md
@@ -1,0 +1,98 @@
+# ADR-0004: Vector Index and Storage Strategy
+
+- **Status:** Accepted
+- **Date:** 2026-03-22
+- **Deciders:** Rodrigo Arguello Serrano
+- **Related:** ADR-0002, ADR-0003, EPIC 3, EPIC 5
+
+## Context
+
+The project needs a vector index that is cheap to run, easy to debug, and adequate for a documentation corpus on the order of thousands to low tens of thousands of chunks.
+
+The proposal keeps three options open:
+
+- **FAISS** for the simplest local baseline
+- **pgvector** for a Postgres-backed deployment path
+- **OpenSearch vector search** for a more managed production path
+
+At the current stage, fast local iteration is more important than managed infrastructure.
+
+## Decision
+
+Use **FAISS as the baseline vector index for local development and experimentation**, while keeping **pgvector** and **OpenSearch vector search** as later upgrade paths.
+
+More specifically:
+
+- Build the first working dense-retrieval baseline on FAISS.
+- Keep chunk metadata outside the FAISS index in the metadata store or serialized retrieval artifacts.
+- Start with a **simple exact or near-exact index configuration** before introducing more complex ANN structures.
+- Treat migration to pgvector or OpenSearch as an explicit later decision, not an implicit implementation drift.
+
+## Alternatives Considered
+
+### 1. pgvector as the first baseline
+
+**Pros**
+- Durable storage
+- Straightforward SQL-backed operational model
+- Easier transition to a service deployment
+
+**Cons**
+- More setup than FAISS
+- Slower local iteration during early experimentation
+
+**Why not chosen**
+The project benefits more from rapid local experimentation at this stage.
+
+### 2. OpenSearch vector search as the first baseline
+
+**Pros**
+- Production-style managed service
+- Strong fit for later AWS deployment
+
+**Cons**
+- Highest operational complexity
+- Infrastructure concerns can obscure retrieval debugging
+
+**Why not chosen**
+This is a sensible upgrade path, not the best first baseline.
+
+### 3. Custom brute-force vector search
+
+**Pros**
+- Transparent behavior
+- Minimal abstraction
+
+**Cons**
+- Reinvents existing tooling
+- Poor scalability
+- Unnecessary engineering effort
+
+**Why not chosen**
+FAISS already provides a practical, well-understood baseline.
+
+## Consequences
+
+### Positive
+
+- Fast, low-cost retrieval experimentation
+- Easier isolation of semantic retrieval quality before deployment work
+- Clear migration path to managed storage later
+
+### Negative / Trade-offs
+
+- FAISS is not the final answer for all deployment scenarios
+- Metadata joins and persistence live outside the vector index
+- Production-scale operational behavior still requires a later storage decision
+
+## Implementation Notes
+
+- Persist the FAISS artifact alongside the chunk metadata snapshot used to build it.
+- Version the index with the embedding model ID and corpus snapshot ID.
+- Do not switch to a more complex index type until measurements justify it.
+
+## Links
+
+- **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §5.1, §6.2, §6.6, §9.2.1, §10.1
+- **Code:** `<replace-with-repo-path-to-vector-index-code>`
+- **Issue:** `<replace-with-sub-issue-number>`

--- a/docs/adr/0005-retrieval-strategy-and-baseline-selection.md
+++ b/docs/adr/0005-retrieval-strategy-and-baseline-selection.md
@@ -1,0 +1,110 @@
+# ADR-0005: Retrieval Strategy and Baseline Selection
+
+- **Status:** Accepted
+- **Date:** 2026-03-22
+- **Deciders:** Rodrigo Arguello Serrano
+- **Related:** ADR-0002, ADR-0003, ADR-0004, EPIC 4, EPIC 5
+
+## Context
+
+The project’s core product claim depends on retrieving the correct evidence before generation. The proposal treats retrieval as an experimentally tuned subsystem and explicitly identifies these candidate configurations:
+
+- **BM25-only**
+- **Dense-only**
+- **Hybrid retrieval**
+- **Optional reranker**
+
+The proposal also defines the winner-selection rule: choose the configuration that maximizes retrieval quality metrics such as recall@k and context precision while keeping latency acceptable.
+
+## Decision
+
+Use **hybrid retrieval as the default target strategy**, while preserving **BM25-only** and **dense-only** as required benchmark baselines.
+
+### Default retrieval shape
+
+- Run a lexical retriever and a dense retriever in parallel.
+- Merge candidate sets using **score normalization and/or Reciprocal Rank Fusion (RRF)**.
+- Start with **top-k = 8** as the default generation context size.
+- Defer reranking until the baseline retrieval comparison is complete.
+
+### Winner-selection rule
+
+The default configuration must be justified using at least:
+
+- **Recall@k**
+- **Context precision / relevance**
+- **Retrieval latency**
+- **End-to-end latency or TTFT impact**
+
+If later measurements show that a simpler strategy clearly outperforms hybrid retrieval for this corpus and latency budget, this ADR should be superseded with the measured result.
+
+## Alternatives Considered
+
+### 1. BM25-only retrieval
+
+**Pros**
+- Simple
+- Strong exact-match baseline
+- Easy to debug
+
+**Cons**
+- Misses semantically similar phrasing
+- Weaker for natural-language support questions
+
+**Why not chosen as default**
+It is an important benchmark, but not the best target architecture.
+
+### 2. Dense-only retrieval
+
+**Pros**
+- Strong semantic matching
+- Good for paraphrased queries
+
+**Cons**
+- Can miss exact identifiers, commands, and product-specific strings
+- Harder to inspect when rankings fail
+
+**Why not chosen as default**
+Lexical evidence still matters in documentation-heavy workflows.
+
+### 3. Immediate hybrid + reranker
+
+**Pros**
+- Often best precision
+- Good final-ranking quality
+
+**Cons**
+- Higher latency
+- More infrastructure complexity
+- Harder to reason about baseline quality
+
+**Why not chosen initially**
+The baseline hybrid system should be stabilized before adding another ranking stage.
+
+## Consequences
+
+### Positive
+
+- Balances semantic coverage and exact-match behavior
+- Keeps baseline comparisons honest and repeatable
+- Leaves a clean path to later reranking if the gain is worth the latency cost
+
+### Negative / Trade-offs
+
+- More moving parts than a single retriever
+- Requires candidate-fusion logic and tuning
+- Debugging can be harder when lexical and dense signals disagree
+
+## Implementation Notes
+
+- Keep BM25-only and dense-only runnable as first-class baselines.
+- Log component-level retrieval scores where practical.
+- Record `k`, fusion method, and retriever configuration in evaluation artifacts.
+- Link this ADR to the retrieval comparison note or report once that artifact exists.
+
+## Links
+
+- **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §5.2, §6.2, §7.3.1, §7.4, §7.5, §10.1, §11.3
+- **Code:** `<replace-with-repo-path-to-retriever-and-rank-fusion-code>`
+- **Issue:** `<replace-with-sub-issue-number>`
+- **Evaluation artifact:** `<replace-with-retrieval-comparison-note-or-report>`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,7 @@
 # Architecture Decision Records
 
 - [ADR-0001: Use a pinned Kubernetes documentation snapshot as the initial corpus](./0001-corpus-snapshot-and-licensing-strategy.md)
+- [ADR-0002: Ingestion pipeline and chunking strategy](./0002-ingestion-pipeline-and-chunking-strategy.md)
+- [ADR-0003: Embedding Model and Serving Strategy](./0003-embedding-model-and-serving-strategy.md)
+- [ADR-0004: Vector Index and Storage Strategy](0004-vector-index-and-storage-strategy.md)
+- [ADR-0005: Retrieval Strategy and Baseline Selection](0005-retrieval-strategy-and-baseline-selection.md)


### PR DESCRIPTION
Closes #54

What is this task?
Summary
Create ADR-0002 through ADR-0005 to document the implementation decisions already shaping the ingestion and retrieval path. Track this under EPIC 5 so later citation/validation work has explicit upstream architectural references.

Scope
Add the following ADR files under docs/adr/:

0002-ingestion-pipeline-and-chunking-strategy.md
0003-embedding-model-and-serving-strategy.md
0004-vector-index-and-storage-strategy.md
0005-retrieval-strategy-and-baseline-selection.md
Why
These decisions already exist in the project, but they are not yet recorded as ADRs. Without that, EPIC 5 depends on implicit assumptions about:

how docs are parsed, chunked, and annotated with metadata which embedding model and serving boundary are used which vector index/storage baseline is in place
how retrieval is selected and evaluated
Documenting them now gives traceability from corpus/retrieval design into citation enforcement, refusal behavior, evaluation, and deployment.

Deliverables
ADR-0002: parsing strategy, section-aware chunking, token cap/overlap choices, chunk metadata schema ADR-0003: embedding model selection, version pinning, and serving strategy ADR-0004: vector index/storage choice, current baseline, and upgrade path ADR-0005: retrieval strategy, BM25 vs dense vs hybrid comparison, top-k defaults, and winner-selection criteria

Changes to be committed:
	new file:   docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md
	new file:   docs/adr/0003-embedding-model-and-serving-strategy.md
	new file:   docs/adr/0004-vector-index-and-storage-strategy.md
	new file:   docs/adr/0005-retrieval-strategy-and-baseline-selection.md
	modified:   docs/adr/README.md