### PR TITLE
On branch backend/49-define-JSON-response-schema-for-trust-layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The initial corpus is a pinned snapshot of Kubernetes documentation so the proje
 This README is maintained as a live project document and evolves with each completed task issue.
 
 ### Current Phase
-Retrieval baseline comparison documented with a provisional hybrid default.
+Trust-layer response contract scaffolded with a canonical schema, checked-in fixtures, and local smoke validation.
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
@@ -25,13 +25,16 @@ Retrieval baseline comparison documented with a provisional hybrid default.
 - Developer-facing retrieval smoke CLI for local dense search over a saved FAISS index.
 - Shared retrieval evaluation harness plus dense, BM25, and hybrid baseline runners that execute the committed Dev QA set and write deterministic result artifacts.
 - Retrieval comparison note documenting baseline configs, reference fixture metrics, trade-offs, and the provisional default retrieval mode for later epics.
+- Canonical trust-layer `QueryResponse` schema with Pydantic validation, checked-in JSON Schema, example answer/refusal fixtures, and a local trust smoke command.
 
 ### In Progress
-- Citation contract and refusal behavior integration.
+- Prompt rules for citation-backed generation.
+- Citation validation against retrieved evidence spans.
+- Retrieval sufficiency gating before final answer emission.
 
 ### Next Up
-- Validate the provisional hybrid default against regenerated local corpus-level artifacts.
-- Connect retrieval outputs to generation and citation validation.
+- Wire prompt-generation outputs onto the canonical trust response contract.
+- Connect citation validation and refusal gating to the provisional hybrid retrieval default.
 - Expand deployment and observability documentation as the backend/API layer matures.
 
 ---
@@ -273,19 +276,34 @@ Useful options:
 
 ### Local verification
 
-Run lint and tests:
+Run the standard local verification pass:
 
 ```bash
-uv run ruff check . --no-fix
+uv sync --locked --extra dev-tools --extra faiss --extra bm25
+uv run ruff check . --fix
+uv run ruff format .
 uv run ruff format --check .
+uv run pre-commit run --all-files
+uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py
 uv run pytest -q
+```
+
+### Run the local trust-contract smoke test
+
+```bash
+uv run python -m supportdoc_rag_chatbot smoke-trust-schema \
+  --schema docs/contracts/query_response.schema.json \
+  --answer-fixture docs/contracts/query_response.answer.example.json \
+  --refusal-fixture docs/contracts/query_response.refusal.example.json
 ```
 
 ---
 
 ## 8. Citations and Refusal Behavior
 
-The target product behavior is to answer only when retrieved evidence is sufficient and attributable. Citation validation and refusal rules are still being layered into the backend pipeline, but the repository structure already separates retrieval, generation, and trust-layer concerns so those checks can be added incrementally.
+The repository now includes a canonical trust-layer response contract under `src/supportdoc_rag_chatbot/app/schemas/trust.py`. That contract defines structured supported answers, structured refusals, restricted refusal reason codes, and deterministic JSON Schema export under `docs/contracts/`.
+
+Citation validation and refusal gating are still being layered into the backend pipeline, but later Epics can now reuse one checked-in `QueryResponse` contract instead of duplicating ad hoc response dictionaries.
 
 ---
 
@@ -347,4 +365,5 @@ The intended deployment path is a FastAPI backend with a web frontend, persisten
 - `docs/adr/` — architecture decisions and project rationale
 - `docs/process/hybrid_retrieval_baseline.md` — default hybrid baseline config and run command
 - `docs/process/retrieval_comparison_notes.md` — Epic 4 baseline comparison and provisional default selection
+- `docs/process/trust_response_contract.md` — canonical response contract, schema artifact, and smoke command
 - `PROPOSAL.md` — project proposal and delivery framing

--- a/docs/contracts/query_response.answer.example.json
+++ b/docs/contracts/query_response.answer.example.json
@@ -1,0 +1,17 @@
+{
+  "final_answer": "A Pod is the smallest deployable unit in Kubernetes and can run one or more containers that share network and storage resources.",
+  "citations": [
+    {
+      "marker": "[1]",
+      "doc_id": "content-en-docs-concepts-workloads-pods-pods",
+      "chunk_id": "content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+      "start_offset": 0,
+      "end_offset": 118
+    }
+  ],
+  "refusal": {
+    "is_refusal": false,
+    "reason_code": null,
+    "message": null
+  }
+}

--- a/docs/contracts/query_response.refusal.example.json
+++ b/docs/contracts/query_response.refusal.example.json
@@ -1,0 +1,9 @@
+{
+  "final_answer": "I can’t answer that from the approved support corpus.",
+  "citations": [],
+  "refusal": {
+    "is_refusal": true,
+    "reason_code": "no_relevant_docs",
+    "message": "I can’t answer that from the approved support corpus."
+  }
+}

--- a/docs/contracts/query_response.schema.json
+++ b/docs/contracts/query_response.schema.json
@@ -1,0 +1,126 @@
+{
+  "$defs": {
+    "CitationRecord": {
+      "additionalProperties": false,
+      "description": "Pointer to one supporting span inside the approved corpus.",
+      "properties": {
+        "chunk_id": {
+          "description": "Stable chunk identifier for the cited evidence span.",
+          "title": "Chunk Id",
+          "type": "string"
+        },
+        "doc_id": {
+          "description": "Stable source document identifier for the cited evidence.",
+          "title": "Doc Id",
+          "type": "string"
+        },
+        "end_offset": {
+          "description": "Exclusive end offset of the supporting span inside the chunk text.",
+          "minimum": 0,
+          "title": "End Offset",
+          "type": "integer"
+        },
+        "marker": {
+          "description": "User-visible citation marker, for example [1] or [2].",
+          "title": "Marker",
+          "type": "string"
+        },
+        "start_offset": {
+          "description": "Inclusive start offset of the supporting span inside the chunk text.",
+          "minimum": 0,
+          "title": "Start Offset",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "marker",
+        "doc_id",
+        "chunk_id",
+        "start_offset",
+        "end_offset"
+      ],
+      "title": "CitationRecord",
+      "type": "object"
+    },
+    "RefusalReasonCode": {
+      "description": "Allowed refusal categories for user-visible trust-layer refusals.",
+      "enum": [
+        "insufficient_evidence",
+        "no_relevant_docs",
+        "citation_validation_failed",
+        "out_of_scope"
+      ],
+      "title": "RefusalReasonCode",
+      "type": "string"
+    },
+    "RefusalRecord": {
+      "additionalProperties": false,
+      "description": "Structured refusal payload attached to every query response.",
+      "properties": {
+        "is_refusal": {
+          "description": "Whether the response is an explicit refusal instead of a supported answer.",
+          "title": "Is Refusal",
+          "type": "boolean"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "User-visible refusal message, or null for supported answers.",
+          "title": "Message"
+        },
+        "reason_code": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefusalReasonCode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Machine-readable refusal reason code, or null for supported answers."
+        }
+      },
+      "required": [
+        "is_refusal",
+        "reason_code",
+        "message"
+      ],
+      "title": "RefusalRecord",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Canonical response contract shared by generation, validation, and API serialization.",
+  "properties": {
+    "citations": {
+      "description": "Supporting citation records for a grounded answer. Refusals must return an empty list.",
+      "items": {
+        "$ref": "#/$defs/CitationRecord"
+      },
+      "title": "Citations",
+      "type": "array"
+    },
+    "final_answer": {
+      "description": "User-visible final answer text. For refusals this should be the refusal text shown to the user.",
+      "title": "Final Answer",
+      "type": "string"
+    },
+    "refusal": {
+      "$ref": "#/$defs/RefusalRecord",
+      "description": "Structured refusal state for the response."
+    }
+  },
+  "required": [
+    "final_answer",
+    "citations",
+    "refusal"
+  ],
+  "title": "QueryResponse",
+  "type": "object"
+}

--- a/docs/process/trust_response_contract.md
+++ b/docs/process/trust_response_contract.md
@@ -1,0 +1,90 @@
+# Trust Response Contract
+
+This document records the canonical structured response contract for citation-backed answers and explicit refusals.
+
+## Goal
+
+Define one Pydantic-backed response contract that generation, validation, API serialization, example payloads, and tests can all reuse without ad hoc dictionaries or duplicate dataclasses.
+
+The contract covers three model types:
+
+- `CitationRecord`
+- `RefusalRecord`
+- `QueryResponse`
+
+## Canonical fields
+
+`QueryResponse` requires:
+
+- `final_answer: str`
+- `citations: list[CitationRecord]`
+- `refusal: RefusalRecord`
+
+`CitationRecord` requires:
+
+- `marker`
+- `doc_id`
+- `chunk_id`
+- `start_offset`
+- `end_offset`
+
+`RefusalRecord` requires:
+
+- `is_refusal`
+- `reason_code`
+- `message`
+
+Allowed refusal reason codes:
+
+- `insufficient_evidence`
+- `no_relevant_docs`
+- `citation_validation_failed`
+- `out_of_scope`
+
+## Validation rules
+
+The trust contract currently enforces a few cross-field invariants:
+
+- supported answers must include at least one citation
+- refusals must return an empty citation list
+- refusal payloads must include both a `reason_code` and a user-visible `message`
+- non-refusal payloads must set `reason_code` and `message` to `null`
+- citation offsets must be non-negative and strictly increasing
+
+## Checked-in review artifacts
+
+The checked-in contract artifacts live under `docs/contracts/`:
+
+- `docs/contracts/query_response.schema.json`
+- `docs/contracts/query_response.answer.example.json`
+- `docs/contracts/query_response.refusal.example.json`
+
+The JSON Schema is exported from the canonical Pydantic model so reviewers can inspect the API shape directly.
+
+## Exact local commands
+
+Regenerate the checked-in schema artifact:
+
+```bash
+uv run python -m supportdoc_rag_chatbot export-trust-schema \
+  --output docs/contracts/query_response.schema.json
+```
+
+Run the local trust-contract smoke test:
+
+```bash
+uv run python -m supportdoc_rag_chatbot smoke-trust-schema \
+  --schema docs/contracts/query_response.schema.json \
+  --answer-fixture docs/contracts/query_response.answer.example.json \
+  --refusal-fixture docs/contracts/query_response.refusal.example.json
+```
+
+## Smoke test workflow
+
+The smoke command validates that:
+
+- the checked-in schema still matches the canonical `QueryResponse` model
+- the checked-in supported-answer fixture validates successfully
+- the checked-in refusal fixture validates successfully
+
+A broader repo verification pass can still use the standard local quality-gate workflow from the README.

--- a/src/supportdoc_rag_chatbot/app/schemas/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/schemas/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .trust import (
+    DEFAULT_TRUST_ANSWER_FIXTURE_PATH,
+    DEFAULT_TRUST_CONTRACT_DIR,
+    DEFAULT_TRUST_REFUSAL_FIXTURE_PATH,
+    DEFAULT_TRUST_SCHEMA_PATH,
+    CitationRecord,
+    QueryResponse,
+    RefusalReasonCode,
+    RefusalRecord,
+    TrustSchemaSmokeReport,
+    build_example_answer_response,
+    build_example_refusal_response,
+    export_query_response_schema,
+    generate_query_response_json_schema,
+    render_trust_schema_smoke_report,
+    run_trust_schema_smoke,
+)
+
+__all__ = [
+    "CitationRecord",
+    "DEFAULT_TRUST_ANSWER_FIXTURE_PATH",
+    "DEFAULT_TRUST_CONTRACT_DIR",
+    "DEFAULT_TRUST_REFUSAL_FIXTURE_PATH",
+    "DEFAULT_TRUST_SCHEMA_PATH",
+    "QueryResponse",
+    "RefusalReasonCode",
+    "RefusalRecord",
+    "TrustSchemaSmokeReport",
+    "build_example_answer_response",
+    "build_example_refusal_response",
+    "export_query_response_schema",
+    "generate_query_response_json_schema",
+    "render_trust_schema_smoke_report",
+    "run_trust_schema_smoke",
+]

--- a/src/supportdoc_rag_chatbot/app/schemas/trust.py
+++ b/src/supportdoc_rag_chatbot/app/schemas/trust.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+DEFAULT_TRUST_CONTRACT_DIR = Path("docs/contracts")
+DEFAULT_TRUST_SCHEMA_PATH = DEFAULT_TRUST_CONTRACT_DIR / "query_response.schema.json"
+DEFAULT_TRUST_ANSWER_FIXTURE_PATH = (
+    DEFAULT_TRUST_CONTRACT_DIR / "query_response.answer.example.json"
+)
+DEFAULT_TRUST_REFUSAL_FIXTURE_PATH = (
+    DEFAULT_TRUST_CONTRACT_DIR / "query_response.refusal.example.json"
+)
+
+
+class RefusalReasonCode(StrEnum):
+    """Allowed refusal categories for user-visible trust-layer refusals."""
+
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+    NO_RELEVANT_DOCS = "no_relevant_docs"
+    CITATION_VALIDATION_FAILED = "citation_validation_failed"
+    OUT_OF_SCOPE = "out_of_scope"
+
+
+class CitationRecord(BaseModel):
+    """Pointer to one supporting span inside the approved corpus."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    marker: str = Field(
+        description="User-visible citation marker, for example [1] or [2].",
+    )
+    doc_id: str = Field(
+        description="Stable source document identifier for the cited evidence.",
+    )
+    chunk_id: str = Field(
+        description="Stable chunk identifier for the cited evidence span.",
+    )
+    start_offset: int = Field(
+        ge=0,
+        description="Inclusive start offset of the supporting span inside the chunk text.",
+    )
+    end_offset: int = Field(
+        ge=0,
+        description="Exclusive end offset of the supporting span inside the chunk text.",
+    )
+
+    @field_validator("marker", "doc_id", "chunk_id")
+    @classmethod
+    def _validate_required_string(cls, value: str, info) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{info.field_name} must not be blank")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_offsets(self) -> "CitationRecord":
+        if self.end_offset <= self.start_offset:
+            raise ValueError("end_offset must be greater than start_offset")
+        return self
+
+
+class RefusalRecord(BaseModel):
+    """Structured refusal payload attached to every query response."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    is_refusal: bool = Field(
+        description="Whether the response is an explicit refusal instead of a supported answer.",
+    )
+    reason_code: RefusalReasonCode | None = Field(
+        description="Machine-readable refusal reason code, or null for supported answers.",
+    )
+    message: str | None = Field(
+        description="User-visible refusal message, or null for supported answers.",
+    )
+
+    @field_validator("message")
+    @classmethod
+    def _validate_optional_message(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("message must not be blank")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_refusal_fields(self) -> "RefusalRecord":
+        if self.is_refusal:
+            if self.reason_code is None:
+                raise ValueError("reason_code is required when is_refusal is True")
+            if self.message is None:
+                raise ValueError("message is required when is_refusal is True")
+            return self
+
+        if self.reason_code is not None:
+            raise ValueError("reason_code must be null when is_refusal is False")
+        if self.message is not None:
+            raise ValueError("message must be null when is_refusal is False")
+        return self
+
+
+class QueryResponse(BaseModel):
+    """Canonical response contract shared by generation, validation, and API serialization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    final_answer: str = Field(
+        description="User-visible final answer text. For refusals this should be the refusal text shown to the user.",
+    )
+    citations: list[CitationRecord] = Field(
+        description="Supporting citation records for a grounded answer. Refusals must return an empty list.",
+    )
+    refusal: RefusalRecord = Field(
+        description="Structured refusal state for the response.",
+    )
+
+    @field_validator("final_answer")
+    @classmethod
+    def _validate_final_answer(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("final_answer must not be blank")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_contract(self) -> "QueryResponse":
+        if self.refusal.is_refusal:
+            if self.citations:
+                raise ValueError("citations must be empty when refusal.is_refusal is True")
+            return self
+
+        if not self.citations:
+            raise ValueError(
+                "citations must contain at least one record when refusal.is_refusal is False"
+            )
+        return self
+
+
+@dataclass(slots=True)
+class TrustSchemaSmokeReport:
+    schema_path: str
+    answer_fixture_path: str
+    refusal_fixture_path: str
+    answer_citation_count: int
+    refusal_reason_code: str
+
+
+def build_example_answer_response() -> QueryResponse:
+    return QueryResponse(
+        final_answer=(
+            "A Pod is the smallest deployable unit in Kubernetes and can run one or more "
+            "containers that share network and storage resources."
+        ),
+        citations=[
+            CitationRecord(
+                marker="[1]",
+                doc_id="content-en-docs-concepts-workloads-pods-pods",
+                chunk_id="content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+                start_offset=0,
+                end_offset=118,
+            )
+        ],
+        refusal=RefusalRecord(
+            is_refusal=False,
+            reason_code=None,
+            message=None,
+        ),
+    )
+
+
+def build_example_refusal_response() -> QueryResponse:
+    message = "I can’t answer that from the approved support corpus."
+    return QueryResponse(
+        final_answer=message,
+        citations=[],
+        refusal=RefusalRecord(
+            is_refusal=True,
+            reason_code=RefusalReasonCode.NO_RELEVANT_DOCS,
+            message=message,
+        ),
+    )
+
+
+def generate_query_response_json_schema() -> dict[str, Any]:
+    """Return a deterministically ordered JSON Schema for QueryResponse."""
+
+    schema = QueryResponse.model_json_schema()
+    return _sorted_json_value(schema)
+
+
+def export_query_response_schema(
+    output_path: Path = DEFAULT_TRUST_SCHEMA_PATH,
+) -> Path:
+    """Write the canonical QueryResponse JSON Schema to disk."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_json(output_path, generate_query_response_json_schema())
+    return output_path
+
+
+def run_trust_schema_smoke(
+    *,
+    schema_path: Path = DEFAULT_TRUST_SCHEMA_PATH,
+    answer_fixture_path: Path = DEFAULT_TRUST_ANSWER_FIXTURE_PATH,
+    refusal_fixture_path: Path = DEFAULT_TRUST_REFUSAL_FIXTURE_PATH,
+) -> TrustSchemaSmokeReport:
+    """Validate the checked-in schema and example payload fixtures together."""
+
+    _require_path(schema_path, label="Trust schema")
+    _require_path(answer_fixture_path, label="Trust answer fixture")
+    _require_path(refusal_fixture_path, label="Trust refusal fixture")
+
+    expected_schema = generate_query_response_json_schema()
+    checked_in_schema = _read_json(schema_path)
+    if checked_in_schema != expected_schema:
+        raise ValueError(
+            "Checked-in trust schema is out of date; regenerate it with export_query_response_schema()"
+        )
+
+    answer_response = QueryResponse.model_validate(_read_json(answer_fixture_path))
+    if answer_response.refusal.is_refusal:
+        raise ValueError("Answer fixture must be a supported answer, not a refusal")
+
+    refusal_response = QueryResponse.model_validate(_read_json(refusal_fixture_path))
+    if not refusal_response.refusal.is_refusal:
+        raise ValueError("Refusal fixture must set refusal.is_refusal to True")
+
+    return TrustSchemaSmokeReport(
+        schema_path=str(schema_path),
+        answer_fixture_path=str(answer_fixture_path),
+        refusal_fixture_path=str(refusal_fixture_path),
+        answer_citation_count=len(answer_response.citations),
+        refusal_reason_code=str(refusal_response.refusal.reason_code),
+    )
+
+
+def render_trust_schema_smoke_report(report: TrustSchemaSmokeReport) -> str:
+    return "\n".join(
+        [
+            "Trust schema smoke test",
+            f"schema: {report.schema_path}",
+            (
+                "answer fixture: "
+                f"{report.answer_fixture_path} (citations={report.answer_citation_count})"
+            ),
+            (
+                "refusal fixture: "
+                f"{report.refusal_fixture_path} (reason_code={report.refusal_reason_code})"
+            ),
+            "status: ok",
+        ]
+    )
+
+
+def _sorted_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _sorted_json_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_sorted_json_value(item) for item in value]
+    return value
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _require_path(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} not found: {path}")
+
+
+__all__ = [
+    "CitationRecord",
+    "DEFAULT_TRUST_ANSWER_FIXTURE_PATH",
+    "DEFAULT_TRUST_CONTRACT_DIR",
+    "DEFAULT_TRUST_REFUSAL_FIXTURE_PATH",
+    "DEFAULT_TRUST_SCHEMA_PATH",
+    "QueryResponse",
+    "RefusalReasonCode",
+    "RefusalRecord",
+    "TrustSchemaSmokeReport",
+    "build_example_answer_response",
+    "build_example_refusal_response",
+    "export_query_response_schema",
+    "generate_query_response_json_schema",
+    "render_trust_schema_smoke_report",
+    "run_trust_schema_smoke",
+]

--- a/src/supportdoc_rag_chatbot/cli.py
+++ b/src/supportdoc_rag_chatbot/cli.py
@@ -5,6 +5,14 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from supportdoc_rag_chatbot.app.schemas import (
+    DEFAULT_TRUST_ANSWER_FIXTURE_PATH,
+    DEFAULT_TRUST_REFUSAL_FIXTURE_PATH,
+    DEFAULT_TRUST_SCHEMA_PATH,
+    export_query_response_schema,
+    render_trust_schema_smoke_report,
+    run_trust_schema_smoke,
+)
 from supportdoc_rag_chatbot.evaluation import (
     DEFAULT_BM25_B,
     DEFAULT_BM25_BASELINE_LABEL,
@@ -211,6 +219,42 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Maximum number of characters to print from each chunk preview",
     )
     smoke_parser.set_defaults(handler=_run_smoke_dense_retrieval)
+
+    trust_schema_export_parser = subparsers.add_parser(
+        "export-trust-schema",
+        help="Export the canonical trust-layer QueryResponse JSON Schema",
+    )
+    trust_schema_export_parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_TRUST_SCHEMA_PATH,
+        help="Output path for the checked-in QueryResponse JSON Schema",
+    )
+    trust_schema_export_parser.set_defaults(handler=_run_export_trust_schema)
+
+    trust_schema_smoke_parser = subparsers.add_parser(
+        "smoke-trust-schema",
+        help="Validate the checked-in trust schema and example answer/refusal payloads",
+    )
+    trust_schema_smoke_parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_TRUST_SCHEMA_PATH,
+        help="Path to the checked-in QueryResponse JSON Schema",
+    )
+    trust_schema_smoke_parser.add_argument(
+        "--answer-fixture",
+        type=Path,
+        default=DEFAULT_TRUST_ANSWER_FIXTURE_PATH,
+        help="Path to the checked-in supported-answer example payload",
+    )
+    trust_schema_smoke_parser.add_argument(
+        "--refusal-fixture",
+        type=Path,
+        default=DEFAULT_TRUST_REFUSAL_FIXTURE_PATH,
+        help="Path to the checked-in refusal example payload",
+    )
+    trust_schema_smoke_parser.set_defaults(handler=_run_smoke_trust_schema)
 
     eval_parser = subparsers.add_parser(
         "evaluate-retrieval",
@@ -642,6 +686,22 @@ def _run_smoke_dense_retrieval(args: argparse.Namespace) -> int:
         preview_chars=args.preview_chars,
     )
     print(render_dense_retrieval_smoke_report(report))
+    return 0
+
+
+def _run_export_trust_schema(args: argparse.Namespace) -> int:
+    output_path = export_query_response_schema(args.output)
+    print(f"Wrote trust schema: {output_path}")
+    return 0
+
+
+def _run_smoke_trust_schema(args: argparse.Namespace) -> int:
+    report = run_trust_schema_smoke(
+        schema_path=args.schema,
+        answer_fixture_path=args.answer_fixture,
+        refusal_fixture_path=args.refusal_fixture,
+    )
+    print(render_trust_schema_smoke_report(report))
     return 0
 
 

--- a/tests/test_trust_schema.py
+++ b/tests/test_trust_schema.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from supportdoc_rag_chatbot.app.schemas import (
+    QueryResponse,
+    build_example_answer_response,
+    build_example_refusal_response,
+    export_query_response_schema,
+    generate_query_response_json_schema,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "docs/contracts/query_response.schema.json"
+ANSWER_FIXTURE_PATH = REPO_ROOT / "docs/contracts/query_response.answer.example.json"
+REFUSAL_FIXTURE_PATH = REPO_ROOT / "docs/contracts/query_response.refusal.example.json"
+
+
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_export_query_response_schema_writes_deterministic_schema(tmp_path: Path) -> None:
+    output_path = tmp_path / "query_response.schema.json"
+
+    returned_path = export_query_response_schema(output_path)
+
+    assert returned_path == output_path
+    assert _read_json(output_path) == generate_query_response_json_schema()
+    assert _read_json(output_path) == _read_json(SCHEMA_PATH)
+
+
+def test_checked_in_answer_fixture_matches_example_builder() -> None:
+    assert _read_json(ANSWER_FIXTURE_PATH) == build_example_answer_response().model_dump(
+        mode="json"
+    )
+
+
+def test_checked_in_refusal_fixture_matches_example_builder() -> None:
+    assert _read_json(REFUSAL_FIXTURE_PATH) == build_example_refusal_response().model_dump(
+        mode="json"
+    )
+
+
+def test_query_response_accepts_checked_in_answer_fixture() -> None:
+    response = QueryResponse.model_validate(_read_json(ANSWER_FIXTURE_PATH))
+
+    assert response.refusal.is_refusal is False
+    assert len(response.citations) == 1
+    assert response.citations[0].marker == "[1]"
+
+
+def test_query_response_accepts_checked_in_refusal_fixture() -> None:
+    response = QueryResponse.model_validate(_read_json(REFUSAL_FIXTURE_PATH))
+
+    assert response.refusal.is_refusal is True
+    assert response.refusal.reason_code == "no_relevant_docs"
+    assert response.citations == []
+
+
+def test_supported_answer_requires_at_least_one_citation() -> None:
+    payload = {
+        "final_answer": "Pods run containers.",
+        "citations": [],
+        "refusal": {
+            "is_refusal": False,
+            "reason_code": None,
+            "message": None,
+        },
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match="citations must contain at least one record when refusal.is_refusal is False",
+    ):
+        QueryResponse.model_validate(payload)
+
+
+def test_refusal_requires_empty_citation_list() -> None:
+    payload = {
+        "final_answer": "I can’t answer that from the approved support corpus.",
+        "citations": [
+            {
+                "marker": "[1]",
+                "doc_id": "doc-1",
+                "chunk_id": "chunk-1",
+                "start_offset": 0,
+                "end_offset": 5,
+            }
+        ],
+        "refusal": {
+            "is_refusal": True,
+            "reason_code": "no_relevant_docs",
+            "message": "I can’t answer that from the approved support corpus.",
+        },
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match="citations must be empty when refusal.is_refusal is True",
+    ):
+        QueryResponse.model_validate(payload)
+
+
+def test_refusal_requires_reason_code_and_message() -> None:
+    payload = {
+        "final_answer": "I can’t answer that from the approved support corpus.",
+        "citations": [],
+        "refusal": {
+            "is_refusal": True,
+            "reason_code": None,
+            "message": None,
+        },
+    }
+
+    with pytest.raises(ValidationError, match="reason_code is required when is_refusal is True"):
+        QueryResponse.model_validate(payload)
+
+
+def test_refusal_reason_code_is_restricted_to_allowed_values() -> None:
+    payload = {
+        "final_answer": "I can’t answer that from the approved support corpus.",
+        "citations": [],
+        "refusal": {
+            "is_refusal": True,
+            "reason_code": "made_up_reason",
+            "message": "I can’t answer that from the approved support corpus.",
+        },
+    }
+
+    with pytest.raises(ValidationError, match="insufficient_evidence"):
+        QueryResponse.model_validate(payload)
+
+
+def test_citation_offsets_must_increase() -> None:
+    payload = {
+        "final_answer": "Pods run containers.",
+        "citations": [
+            {
+                "marker": "[1]",
+                "doc_id": "doc-1",
+                "chunk_id": "chunk-1",
+                "start_offset": 10,
+                "end_offset": 10,
+            }
+        ],
+        "refusal": {
+            "is_refusal": False,
+            "reason_code": None,
+            "message": None,
+        },
+    }
+
+    with pytest.raises(ValidationError, match="end_offset must be greater than start_offset"):
+        QueryResponse.model_validate(payload)

--- a/tests/test_trust_schema_smoke_cli.py
+++ b/tests/test_trust_schema_smoke_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from supportdoc_rag_chatbot.cli import main
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "docs/contracts/query_response.schema.json"
+ANSWER_FIXTURE_PATH = REPO_ROOT / "docs/contracts/query_response.answer.example.json"
+REFUSAL_FIXTURE_PATH = REPO_ROOT / "docs/contracts/query_response.refusal.example.json"
+
+
+def test_smoke_trust_schema_cli_prints_success(capsys) -> None:
+    exit_code = main(
+        [
+            "smoke-trust-schema",
+            "--schema",
+            str(SCHEMA_PATH),
+            "--answer-fixture",
+            str(ANSWER_FIXTURE_PATH),
+            "--refusal-fixture",
+            str(REFUSAL_FIXTURE_PATH),
+        ]
+    )
+
+    assert exit_code == 0
+
+    out = capsys.readouterr().out
+    assert "Trust schema smoke test" in out
+    assert f"schema: {SCHEMA_PATH}" in out
+    assert f"answer fixture: {ANSWER_FIXTURE_PATH}" in out
+    assert f"refusal fixture: {REFUSAL_FIXTURE_PATH}" in out
+    assert "citations=1" in out
+    assert "reason_code=no_relevant_docs" in out
+    assert "status: ok" in out


### PR DESCRIPTION
Closes #49

---

- add the canonical trust-layer response contract in `src/supportdoc_rag_chatbot/app/schemas/trust.py` with `CitationRecord`, `RefusalRecord`, and `QueryResponse`
- restrict refusal reason codes to the approved set and enforce answer/refusal validation invariants with clear Pydantic errors
- export and check in the deterministic `QueryResponse` JSON Schema plus example answer/refusal payloads under `docs/contracts/`
- add CLI support to export the schema and run a local trust smoke test via `export-trust-schema` and `smoke-trust-schema`
- document the trust response contract and update the README local verification section and smoke-test command
- add unit coverage for valid fixtures, invalid payloads, deterministic schema export, and the trust smoke CLI

```bash
uv sync --locked --extra dev-tools --extra faiss --extra bm25
uv run ruff check . --fix
uv run ruff format .
uv run ruff format --check .
uv run pre-commit run --all-files
uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py
uv run pytest -q
uv run python -m supportdoc_rag_chatbot smoke-trust-schema \
  --schema docs/contracts/query_response.schema.json \
  --answer-fixture docs/contracts/query_response.answer.example.json \
  --refusal-fixture docs/contracts/query_response.refusal.example.json
```

- `src/supportdoc_rag_chatbot/app/schemas/trust.py`
- `src/supportdoc_rag_chatbot/app/schemas/__init__.py`
- `src/supportdoc_rag_chatbot/cli.py`
- `docs/contracts/query_response.schema.json`
- `docs/contracts/query_response.answer.example.json`
- `docs/contracts/query_response.refusal.example.json`
- `docs/process/trust_response_contract.md`
- `tests/test_trust_schema.py`
- `tests/test_trust_schema_smoke_cli.py`

---

Changes to be committed:
	modified:   README.md
	new file:   docs/contracts/query_response.answer.example.json
	new file:   docs/contracts/query_response.refusal.example.json
	new file:   docs/contracts/query_response.schema.json
	new file:   docs/process/trust_response_contract.md
	modified:   src/supportdoc_rag_chatbot/app/schemas/__init__.py
	new file:   src/supportdoc_rag_chatbot/app/schemas/trust.py
	modified:   src/supportdoc_rag_chatbot/cli.py
	new file:   tests/test_trust_schema.py
	new file:   tests/test_trust_schema_smoke_cli.py