### PR TITLE
On branch backend/61-api-skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,25 @@ uv run python -m supportdoc_rag_chatbot smoke-retrieval-sufficiency \
   --config src/supportdoc_rag_chatbot/resources/default_config.yaml
 ```
 
+### Run the local API skeleton
+
+The backend now exports the default Uvicorn target `supportdoc_rag_chatbot.app.api:app` with three bootable endpoints:
+
+- `GET /healthz`
+- `GET /readyz`
+- `POST /query`
+
+The `/query` route currently validates the request body and returns a canonical `QueryResponse` refusal placeholder until orchestration work is wired in.
+
+```bash
+uv run uvicorn supportdoc_rag_chatbot.app.api:app --host 127.0.0.1 --port 9001
+curl http://127.0.0.1:9001/healthz
+curl http://127.0.0.1:9001/readyz
+curl -X POST http://127.0.0.1:9001/query \
+  -H 'content-type: application/json' \
+  -d '{"question":"What is a Pod?"}'
+```
+
 ---
 
 ## 8. Citations and Refusal Behavior

--- a/src/supportdoc_rag_chatbot/app/api/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/api/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from supportdoc_rag_chatbot.config import BackendSettings, get_backend_settings
+
+from .errors import register_exception_handlers
+from .routes import query_router, system_router
+
+
+def create_app(*, settings: BackendSettings | None = None) -> FastAPI:
+    """Create the bootable FastAPI application shell for backend work."""
+
+    resolved_settings = settings or get_backend_settings()
+    app = FastAPI(
+        title=resolved_settings.app_name,
+        version=resolved_settings.api_version,
+        docs_url=resolved_settings.docs_url,
+        redoc_url=resolved_settings.redoc_url,
+    )
+    app.state.settings = resolved_settings
+
+    register_exception_handlers(app)
+    app.include_router(system_router)
+    app.include_router(query_router)
+    return app
+
+
+app = create_app()
+
+__all__ = ["app", "create_app"]

--- a/src/supportdoc_rag_chatbot/app/api/errors.py
+++ b/src/supportdoc_rag_chatbot/app/api/errors.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from .schemas import ApiError, ApiErrorResponse
+
+logger = logging.getLogger(__name__)
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register deterministic JSON exception handlers for the API shell."""
+
+    @app.exception_handler(RequestValidationError)
+    async def _handle_request_validation_error(
+        request: Request,
+        exc: RequestValidationError,
+    ) -> JSONResponse:
+        del request
+        payload = ApiErrorResponse(
+            error=ApiError(
+                code="request_validation_error",
+                message="Request validation failed.",
+                details=_serialize_validation_details(exc.errors()),
+            )
+        )
+        return JSONResponse(status_code=422, content=payload.model_dump())
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _handle_http_exception(
+        request: Request,
+        exc: StarletteHTTPException,
+    ) -> JSONResponse:
+        del request
+        payload = ApiErrorResponse(
+            error=ApiError(
+                code=f"http_{exc.status_code}",
+                message=_normalize_http_detail(exc.detail),
+            )
+        )
+        return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+    @app.exception_handler(Exception)
+    async def _handle_unexpected_exception(
+        request: Request,
+        exc: Exception,
+    ) -> JSONResponse:
+        logger.exception("Unhandled API exception", extra={"path": str(request.url.path)})
+        payload = ApiErrorResponse(
+            error=ApiError(
+                code="internal_server_error",
+                message="Internal server error.",
+            )
+        )
+        return JSONResponse(status_code=500, content=payload.model_dump())
+
+
+def _normalize_http_detail(detail: Any) -> str:
+    if isinstance(detail, str):
+        normalized = detail.strip()
+        if normalized:
+            return normalized
+    return "Request failed."
+
+
+def _serialize_validation_details(details: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for detail in details:
+        serialized = {
+            "type": detail.get("type"),
+            "loc": list(detail.get("loc", ())),
+            "msg": detail.get("msg"),
+        }
+        if "input" in detail:
+            serialized["input"] = detail["input"]
+        payload.append(serialized)
+    return payload
+
+
+__all__ = ["register_exception_handlers"]

--- a/src/supportdoc_rag_chatbot/app/api/routes/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/api/routes/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .query import router as query_router
+from .system import router as system_router
+
+__all__ = ["query_router", "system_router"]

--- a/src/supportdoc_rag_chatbot/app/api/routes/query.py
+++ b/src/supportdoc_rag_chatbot/app/api/routes/query.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+from supportdoc_rag_chatbot.app.services import build_refusal_response
+
+from ..schemas import QueryRequest
+
+router = APIRouter(tags=["query"])
+
+
+@router.post(
+    "/query",
+    response_model=QueryResponse,
+    summary="Validate a query request and return the canonical response envelope",
+)
+def post_query(payload: QueryRequest) -> QueryResponse:
+    del payload
+    return build_refusal_response(RefusalReasonCode.NO_RELEVANT_DOCS)

--- a/src/supportdoc_rag_chatbot/app/api/routes/system.py
+++ b/src/supportdoc_rag_chatbot/app/api/routes/system.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from supportdoc_rag_chatbot.config import BackendSettings, get_request_settings
+
+from ..schemas import HealthStatusResponse, ReadinessStatusResponse
+
+router = APIRouter(tags=["system"])
+
+
+@router.get(
+    "/healthz",
+    response_model=HealthStatusResponse,
+    summary="Liveness probe",
+)
+def get_healthz() -> HealthStatusResponse:
+    return HealthStatusResponse(status="ok")
+
+
+@router.get(
+    "/readyz",
+    response_model=ReadinessStatusResponse,
+    summary="Deterministic readiness probe",
+)
+def get_readyz(
+    settings: Annotated[BackendSettings, Depends(get_request_settings)],
+) -> ReadinessStatusResponse:
+    return ReadinessStatusResponse(
+        status="ready",
+        service=settings.app_name,
+        environment=settings.environment,
+        version=settings.api_version,
+    )

--- a/src/supportdoc_rag_chatbot/app/api/schemas.py
+++ b/src/supportdoc_rag_chatbot/app/api/schemas.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class QueryRequest(BaseModel):
+    """Minimal request contract for the first /query API shell."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    question: str = Field(description="End-user question text.")
+
+    @field_validator("question")
+    @classmethod
+    def _validate_question(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("question must not be blank")
+        return normalized
+
+
+class HealthStatusResponse(BaseModel):
+    """Minimal liveness payload returned by /healthz."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["ok"]
+
+
+class ReadinessStatusResponse(BaseModel):
+    """Deterministic readiness payload returned by /readyz."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["ready"]
+    service: str
+    environment: str
+    version: str
+    query_contract: Literal["QueryResponse"] = "QueryResponse"
+
+
+class ApiError(BaseModel):
+    """Machine-readable API error payload."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: str
+    message: str
+    details: list[dict[str, Any]] | None = None
+
+    @field_validator("code", "message")
+    @classmethod
+    def _validate_non_blank(cls, value: str, info) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{info.field_name} must not be blank")
+        return normalized
+
+
+class ApiErrorResponse(BaseModel):
+    """Envelope for API error responses."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    error: ApiError
+
+
+__all__ = [
+    "ApiError",
+    "ApiErrorResponse",
+    "HealthStatusResponse",
+    "QueryRequest",
+    "ReadinessStatusResponse",
+]

--- a/src/supportdoc_rag_chatbot/config.py
+++ b/src/supportdoc_rag_chatbot/config.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
+from typing import Mapping
+
+from dotenv import load_dotenv
+from fastapi import Request
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+DEFAULT_API_TITLE = "SupportDoc RAG Chatbot API"
+DEFAULT_API_ENVIRONMENT = "local"
+DEFAULT_API_DOCS_URL = "/docs"
+DEFAULT_API_REDOC_URL = "/redoc"
+
+
+class BackendSettings(BaseModel):
+    """Boot-time settings shared by the backend API."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    app_name: str = Field(default=DEFAULT_API_TITLE)
+    environment: str = Field(default=DEFAULT_API_ENVIRONMENT)
+    api_version: str = Field(default_factory=lambda: _default_api_version())
+    docs_url: str = Field(default=DEFAULT_API_DOCS_URL)
+    redoc_url: str = Field(default=DEFAULT_API_REDOC_URL)
+
+    @field_validator("app_name", "environment", "api_version", "docs_url", "redoc_url")
+    @classmethod
+    def _validate_non_blank(cls, value: str, info) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{info.field_name} must not be blank")
+        return normalized
+
+
+@lru_cache(maxsize=1)
+def get_backend_settings() -> BackendSettings:
+    """Return cached backend settings loaded from the process environment."""
+
+    return load_backend_settings()
+
+
+def load_backend_settings(environ: Mapping[str, str] | None = None) -> BackendSettings:
+    """Load backend settings from a mapping or the current process environment."""
+
+    load_dotenv()
+    source = os.environ if environ is None else environ
+    return BackendSettings(
+        app_name=_read_env_string(source, "SUPPORTDOC_API_TITLE", default=DEFAULT_API_TITLE),
+        environment=_read_env_string(source, "SUPPORTDOC_ENV", default=DEFAULT_API_ENVIRONMENT),
+        api_version=_read_env_string(
+            source,
+            "SUPPORTDOC_API_VERSION",
+            default=_default_api_version(),
+        ),
+        docs_url=_read_env_string(source, "SUPPORTDOC_API_DOCS_URL", default=DEFAULT_API_DOCS_URL),
+        redoc_url=_read_env_string(
+            source,
+            "SUPPORTDOC_API_REDOC_URL",
+            default=DEFAULT_API_REDOC_URL,
+        ),
+    )
+
+
+def clear_backend_settings_cache() -> None:
+    """Clear the cached backend settings instance."""
+
+    get_backend_settings.cache_clear()
+
+
+def get_request_settings(request: Request) -> BackendSettings:
+    """Resolve request-scoped settings from app state, falling back to cached defaults."""
+
+    settings = getattr(request.app.state, "settings", None)
+    if isinstance(settings, BackendSettings):
+        return settings
+    return get_backend_settings()
+
+
+def _default_api_version() -> str:
+    try:
+        return version("supportdoc-rag-chatbot")
+    except PackageNotFoundError:
+        return "0.1.0"
+
+
+def _read_env_string(source: Mapping[str, str], key: str, *, default: str) -> str:
+    value = source.get(key)
+    if value is None:
+        return default
+    normalized = value.strip()
+    if not normalized:
+        return default
+    return normalized
+
+
+__all__ = [
+    "BackendSettings",
+    "DEFAULT_API_DOCS_URL",
+    "DEFAULT_API_ENVIRONMENT",
+    "DEFAULT_API_REDOC_URL",
+    "DEFAULT_API_TITLE",
+    "clear_backend_settings_cache",
+    "get_backend_settings",
+    "get_request_settings",
+    "load_backend_settings",
+]

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from supportdoc_rag_chatbot.app.api import app, create_app
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+from supportdoc_rag_chatbot.config import BackendSettings, load_backend_settings
+
+TEST_SETTINGS = BackendSettings(
+    app_name="SupportDoc Test API",
+    environment="test",
+    api_version="9.9.9",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+
+def build_test_client() -> TestClient:
+    return TestClient(create_app(settings=TEST_SETTINGS))
+
+
+def test_module_exports_bootable_fastapi_apps() -> None:
+    assert isinstance(app, FastAPI)
+    assert isinstance(create_app(), FastAPI)
+
+
+def test_load_backend_settings_reads_env_mapping() -> None:
+    settings = load_backend_settings(
+        {
+            "SUPPORTDOC_API_TITLE": "Local API",
+            "SUPPORTDOC_ENV": "dev",
+            "SUPPORTDOC_API_VERSION": "1.2.3",
+            "SUPPORTDOC_API_DOCS_URL": "/docs-local",
+            "SUPPORTDOC_API_REDOC_URL": "/redoc-local",
+        }
+    )
+
+    assert settings == BackendSettings(
+        app_name="Local API",
+        environment="dev",
+        api_version="1.2.3",
+        docs_url="/docs-local",
+        redoc_url="/redoc-local",
+    )
+
+
+def test_healthz_returns_ok_json() -> None:
+    with build_test_client() as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_readyz_returns_deterministic_json_without_external_dependencies() -> None:
+    with build_test_client() as client:
+        response = client.get("/readyz")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "service": "SupportDoc Test API",
+        "environment": "test",
+        "version": "9.9.9",
+        "query_contract": "QueryResponse",
+    }
+
+
+def test_query_returns_canonical_query_response_placeholder() -> None:
+    with build_test_client() as client:
+        response = client.post("/query", json={"question": "What is a Pod?"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    validated = QueryResponse.model_validate(payload)
+
+    assert validated.refusal.is_refusal is True
+    assert validated.refusal.reason_code is RefusalReasonCode.NO_RELEVANT_DOCS
+    assert validated.citations == []
+    assert payload["final_answer"] == "I can’t answer that from the approved support corpus."
+
+
+def test_query_validation_errors_return_json_error_response() -> None:
+    with build_test_client() as client:
+        response = client.post("/query", json={"question": "   "})
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "error": {
+            "code": "request_validation_error",
+            "message": "Request validation failed.",
+            "details": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", "question"],
+                    "msg": "Value error, question must not be blank",
+                    "input": "   ",
+                }
+            ],
+        }
+    }
+
+
+def test_http_errors_use_json_error_response_envelope() -> None:
+    with build_test_client() as client:
+        response = client.get("/missing")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "http_404",
+            "message": "Not Found",
+            "details": None,
+        }
+    }


### PR DESCRIPTION
Closes #61
---
This change turns the backend placeholders into a bootable FastAPI application shell for EPIC 6.

It exports `create_app()` plus the module-level `app` target at `supportdoc_rag_chatbot.app.api:app`, adds deterministic health/readiness routes, and introduces the first `/query` HTTP contract using the existing canonical `QueryResponse` model.

The implementation stays intentionally small: `/query` currently validates the request body and returns a canonical refusal placeholder until later orchestration tasks connect retrieval and generation.

Added a real API entrypoint under `src/supportdoc_rag_chatbot/app/api/__init__.py` that:

- exports `create_app()`
- exports module-level `app`
- preserves the default Uvicorn target `supportdoc_rag_chatbot.app.api:app`
- registers the initial route set and exception handlers
- stores resolved backend settings on app state

Implemented `src/supportdoc_rag_chatbot/config.py` as the single backend settings bootstrap.

It now provides:

- `BackendSettings`
- cached `get_backend_settings()`
- `load_backend_settings()` for deterministic test loading
- `get_request_settings()` for request-scoped route access

This keeps environment access out of individual route files.

Added API-local schemas for:

- `QueryRequest`
- `HealthStatusResponse`
- `ReadinessStatusResponse`
- `ApiErrorResponse`

Request validation is strict (`extra="forbid"`) and blank questions are rejected with a deterministic JSON error payload.

Added route modules and router registration for:

- `GET /healthz`
- `GET /readyz`
- `POST /query`

`/readyz` is deterministic and does not depend on external model infrastructure.

`/query` reuses the existing canonical `QueryResponse` response contract and currently returns a canonical refusal placeholder via the existing refusal builder.

Added initial JSON exception handlers for:

- request validation failures
- HTTP exceptions
- unexpected server exceptions

This gives the API shell a stable response shape before later orchestration and logging work lands.

Added `tests/test_api_app.py` covering:

- module exports and app boot
- config loading from a mapping
- `GET /healthz`
- `GET /readyz`
- `POST /query`
- JSON validation error handling
- JSON HTTP error handling

Updated `README.md` with a minimal API startup section and example curl commands.

This establishes the first real backend surface for EPIC 6 without inventing parallel contracts.

Later tasks can now plug orchestration logic into a stable FastAPI shell while continuing to reuse the existing trust-layer `QueryResponse` model, refusal builder, and smoke/test workflow already present in the repo.

---
Changes to be committed:
	modified:   README.md
	modified:   src/supportdoc_rag_chatbot/app/api/__init__.py
	new file:   src/supportdoc_rag_chatbot/app/api/errors.py
	new file:   src/supportdoc_rag_chatbot/app/api/routes/__init__.py
	new file:   src/supportdoc_rag_chatbot/app/api/routes/query.py
	new file:   src/supportdoc_rag_chatbot/app/api/routes/system.py
	new file:   src/supportdoc_rag_chatbot/app/api/schemas.py
	modified:   src/supportdoc_rag_chatbot/config.py
	new file:   tests/test_api_app.py