### PR TITLE
On branch doc/62-generation-client-abstraction-plus-deterministic-dev…

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,23 +304,38 @@ uv run python -m supportdoc_rag_chatbot smoke-retrieval-sufficiency \
   --config src/supportdoc_rag_chatbot/resources/default_config.yaml
 ```
 
-### Run the local API skeleton
+### Generation backend modes for local development
 
-The backend now exports the default Uvicorn target `supportdoc_rag_chatbot.app.api:app` with three bootable endpoints:
+The generation client abstraction now lives under `src/supportdoc_rag_chatbot/app/client/` and supports two deterministic modes:
 
-- `GET /healthz`
-- `GET /readyz`
-- `POST /query`
+- `fixture`: local smoke mode that reads the checked-in trust contract fixtures from `docs/contracts/`
+- `http`: thin `httpx` client mode for future remote model endpoints that return the canonical `QueryResponse` payload
 
-The `/query` route currently validates the request body and returns a canonical `QueryResponse` refusal placeholder until orchestration work is wired in.
+Use fixture mode when you want repeatable local behavior without any external model infrastructure:
 
-```bash
-uv run uvicorn supportdoc_rag_chatbot.app.api:app --host 127.0.0.1 --port 9001
-curl http://127.0.0.1:9001/healthz
-curl http://127.0.0.1:9001/readyz
-curl -X POST http://127.0.0.1:9001/query \
-  -H 'content-type: application/json' \
-  -d '{"question":"What is a Pod?"}'
+```python
+from supportdoc_rag_chatbot.app.client import GenerationRequest, create_generation_client
+
+client = create_generation_client(mode="fixture")
+result = client.generate(GenerationRequest(question="What is a Pod?"))
+response = result.require_response()
+print(response.final_answer)
+```
+
+Use HTTP mode when you want to point backend orchestration at a remote model-serving endpoint:
+
+```python
+from supportdoc_rag_chatbot.app.client import GenerationRequest, create_generation_client
+
+client = create_generation_client(
+    mode="http",
+    base_url="http://127.0.0.1:8080",
+    endpoint_path="/query",
+    timeout_seconds=30.0,
+)
+result = client.generate(GenerationRequest(question="What is a Pod?"))
+print(result.is_success)
+client.close()
 ```
 
 ---

--- a/src/supportdoc_rag_chatbot/app/client/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/client/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from .factory import create_generation_client
+from .fixture import DEFAULT_FIXTURE_SUPPORTED_QUESTIONS, FixtureGenerationClient
+from .http import (
+    DEFAULT_GENERATION_HTTP_ENDPOINT_PATH,
+    DEFAULT_GENERATION_TIMEOUT_SECONDS,
+    HttpGenerationClient,
+)
+from .types import (
+    GenerationBackendMode,
+    GenerationClient,
+    GenerationFailure,
+    GenerationFailureCode,
+    GenerationRequest,
+    GenerationResult,
+)
+
+__all__ = [
+    "DEFAULT_FIXTURE_SUPPORTED_QUESTIONS",
+    "DEFAULT_GENERATION_HTTP_ENDPOINT_PATH",
+    "DEFAULT_GENERATION_TIMEOUT_SECONDS",
+    "FixtureGenerationClient",
+    "GenerationBackendMode",
+    "GenerationClient",
+    "GenerationFailure",
+    "GenerationFailureCode",
+    "GenerationRequest",
+    "GenerationResult",
+    "HttpGenerationClient",
+    "create_generation_client",
+]

--- a/src/supportdoc_rag_chatbot/app/client/factory.py
+++ b/src/supportdoc_rag_chatbot/app/client/factory.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import httpx
+
+from .fixture import FixtureGenerationClient
+from .http import (
+    DEFAULT_GENERATION_HTTP_ENDPOINT_PATH,
+    DEFAULT_GENERATION_TIMEOUT_SECONDS,
+    HttpGenerationClient,
+)
+from .types import GenerationBackendMode, GenerationClient
+
+
+def create_generation_client(
+    *,
+    mode: GenerationBackendMode | str,
+    answer_fixture_path: Path | None = None,
+    refusal_fixture_path: Path | None = None,
+    answer_questions: Iterable[str] | None = None,
+    base_url: str | None = None,
+    endpoint_path: str = DEFAULT_GENERATION_HTTP_ENDPOINT_PATH,
+    timeout_seconds: float = DEFAULT_GENERATION_TIMEOUT_SECONDS,
+    headers: dict[str, str] | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> GenerationClient:
+    """Create the canonical generation client for the requested backend mode."""
+
+    resolved_mode = GenerationBackendMode(mode)
+    if resolved_mode is GenerationBackendMode.FIXTURE:
+        kwargs: dict[str, object] = {}
+        if answer_fixture_path is not None:
+            kwargs["answer_fixture_path"] = answer_fixture_path
+        if refusal_fixture_path is not None:
+            kwargs["refusal_fixture_path"] = refusal_fixture_path
+        if answer_questions is not None:
+            kwargs["answer_questions"] = tuple(answer_questions)
+        return FixtureGenerationClient(**kwargs)
+
+    if base_url is None:
+        raise ValueError("base_url is required when mode='http'")
+    return HttpGenerationClient(
+        base_url=base_url,
+        endpoint_path=endpoint_path,
+        timeout_seconds=timeout_seconds,
+        headers=(headers or {}),
+        transport=transport,
+    )
+
+
+__all__ = ["create_generation_client"]

--- a/src/supportdoc_rag_chatbot/app/client/fixture.py
+++ b/src/supportdoc_rag_chatbot/app/client/fixture.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Iterable
+
+from pydantic import ValidationError
+
+from supportdoc_rag_chatbot.app.schemas import (
+    DEFAULT_TRUST_ANSWER_FIXTURE_PATH,
+    DEFAULT_TRUST_REFUSAL_FIXTURE_PATH,
+    QueryResponse,
+)
+
+from .types import (
+    GenerationBackendMode,
+    GenerationFailure,
+    GenerationFailureCode,
+    GenerationRequest,
+    GenerationResult,
+)
+
+DEFAULT_FIXTURE_SUPPORTED_QUESTIONS = ("What is a Pod?",)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _resolve_repo_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return _repo_root() / path
+
+
+def _default_answer_fixture_path() -> Path:
+    return _resolve_repo_path(DEFAULT_TRUST_ANSWER_FIXTURE_PATH)
+
+
+def _default_refusal_fixture_path() -> Path:
+    return _resolve_repo_path(DEFAULT_TRUST_REFUSAL_FIXTURE_PATH)
+
+
+def _normalize_question(question: str) -> str:
+    return question.strip().casefold()
+
+
+def _normalize_answer_questions(answer_questions: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted({_normalize_question(question) for question in answer_questions}))
+
+
+@dataclass(slots=True)
+class FixtureGenerationClient:
+    """Deterministic generation backend backed by checked-in JSON fixtures."""
+
+    answer_fixture_path: Path = field(default_factory=_default_answer_fixture_path)
+    refusal_fixture_path: Path = field(default_factory=_default_refusal_fixture_path)
+    answer_questions: Iterable[str] = DEFAULT_FIXTURE_SUPPORTED_QUESTIONS
+
+    def __post_init__(self) -> None:
+        self.answer_fixture_path = _resolve_repo_path(Path(self.answer_fixture_path))
+        self.refusal_fixture_path = _resolve_repo_path(Path(self.refusal_fixture_path))
+        self.answer_questions = _normalize_answer_questions(self.answer_questions)
+        if not self.answer_questions:
+            raise ValueError("answer_questions must contain at least one supported question")
+
+    @property
+    def backend_mode(self) -> GenerationBackendMode:
+        return GenerationBackendMode.FIXTURE
+
+    @property
+    def backend_name(self) -> str:
+        return self.backend_mode.value
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        fixture_path = self._select_fixture_path(request)
+        return _load_query_response_fixture(fixture_path, backend_name=self.backend_name)
+
+    def close(self) -> None:
+        return None
+
+    def _select_fixture_path(self, request: GenerationRequest) -> Path:
+        normalized_question = _normalize_question(request.question)
+        if normalized_question in self.answer_questions:
+            return self.answer_fixture_path
+        return self.refusal_fixture_path
+
+
+def _load_query_response_fixture(path: Path, *, backend_name: str) -> GenerationResult:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return GenerationResult.success(QueryResponse.model_validate(payload))
+    except (JSONDecodeError, ValidationError) as exc:
+        return GenerationResult.from_failure(
+            GenerationFailure(
+                code=GenerationFailureCode.PARSE_ERROR,
+                message=f"Failed to parse generation fixture: {path}",
+                backend_name=backend_name,
+                retryable=False,
+                details={"error": str(exc), "path": str(path)},
+            )
+        )
+    except OSError as exc:
+        return GenerationResult.from_failure(
+            GenerationFailure(
+                code=GenerationFailureCode.BACKEND_ERROR,
+                message=f"Failed to load generation fixture: {path}",
+                backend_name=backend_name,
+                retryable=False,
+                details={"error": str(exc), "path": str(path)},
+            )
+        )
+
+
+__all__ = [
+    "DEFAULT_FIXTURE_SUPPORTED_QUESTIONS",
+    "FixtureGenerationClient",
+]

--- a/src/supportdoc_rag_chatbot/app/client/http.py
+++ b/src/supportdoc_rag_chatbot/app/client/http.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+import httpx
+from pydantic import ValidationError
+
+from supportdoc_rag_chatbot.app.schemas import QueryResponse
+
+from .types import (
+    GenerationBackendMode,
+    GenerationFailure,
+    GenerationFailureCode,
+    GenerationRequest,
+    GenerationResult,
+)
+
+DEFAULT_GENERATION_HTTP_ENDPOINT_PATH = "/query"
+DEFAULT_GENERATION_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(slots=True)
+class HttpGenerationClient:
+    """Thin HTTP generation client for future remote model endpoints."""
+
+    base_url: str
+    endpoint_path: str = DEFAULT_GENERATION_HTTP_ENDPOINT_PATH
+    timeout_seconds: float = DEFAULT_GENERATION_TIMEOUT_SECONDS
+    headers: Mapping[str, str] = field(default_factory=dict)
+    transport: httpx.BaseTransport | None = None
+    _client: httpx.Client = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.base_url = _normalize_base_url(self.base_url)
+        self.endpoint_path = _normalize_endpoint_path(self.endpoint_path)
+        self.timeout_seconds = _validate_timeout_seconds(self.timeout_seconds)
+        self.headers = dict(self.headers)
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            headers=self.headers,
+            transport=self.transport,
+        )
+
+    @property
+    def backend_mode(self) -> GenerationBackendMode:
+        return GenerationBackendMode.HTTP
+
+    @property
+    def backend_name(self) -> str:
+        return self.backend_mode.value
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        timeout_seconds = request.timeout_seconds or self.timeout_seconds
+        try:
+            response = self._client.post(
+                self.endpoint_path,
+                json=request.to_payload(),
+                timeout=timeout_seconds,
+            )
+        except httpx.TimeoutException as exc:
+            return GenerationResult.from_failure(
+                GenerationFailure(
+                    code=GenerationFailureCode.TIMEOUT,
+                    message="Generation backend request timed out.",
+                    backend_name=self.backend_name,
+                    retryable=True,
+                    details={"error": str(exc), "timeout_seconds": timeout_seconds},
+                )
+            )
+        except httpx.TransportError as exc:
+            return GenerationResult.from_failure(
+                GenerationFailure(
+                    code=GenerationFailureCode.TRANSPORT_ERROR,
+                    message="Generation backend transport error.",
+                    backend_name=self.backend_name,
+                    retryable=True,
+                    details={"error": str(exc)},
+                )
+            )
+
+        if response.is_error:
+            return GenerationResult.from_failure(
+                GenerationFailure(
+                    code=GenerationFailureCode.BACKEND_ERROR,
+                    message=f"Generation backend returned HTTP {response.status_code}.",
+                    backend_name=self.backend_name,
+                    retryable=response.status_code >= 500 or response.status_code == 429,
+                    status_code=response.status_code,
+                    details={"response_text": response.text},
+                )
+            )
+
+        try:
+            payload = response.json()
+            parsed = QueryResponse.model_validate(payload)
+        except (ValueError, ValidationError) as exc:
+            return GenerationResult.from_failure(
+                GenerationFailure(
+                    code=GenerationFailureCode.PARSE_ERROR,
+                    message="Generation backend returned an invalid QueryResponse payload.",
+                    backend_name=self.backend_name,
+                    retryable=False,
+                    status_code=response.status_code,
+                    details={"error": str(exc), "response_text": response.text},
+                )
+            )
+
+        return GenerationResult.success(parsed)
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def _normalize_base_url(base_url: str) -> str:
+    normalized = base_url.strip().rstrip("/")
+    if not normalized:
+        raise ValueError("base_url must not be blank")
+    return normalized
+
+
+def _normalize_endpoint_path(endpoint_path: str) -> str:
+    normalized = endpoint_path.strip()
+    if not normalized:
+        raise ValueError("endpoint_path must not be blank")
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    return normalized
+
+
+def _validate_timeout_seconds(value: float) -> float:
+    request = GenerationRequest(question="timeout validation sentinel", timeout_seconds=value)
+    assert request.timeout_seconds is not None
+    return request.timeout_seconds
+
+
+__all__ = [
+    "DEFAULT_GENERATION_HTTP_ENDPOINT_PATH",
+    "DEFAULT_GENERATION_TIMEOUT_SECONDS",
+    "HttpGenerationClient",
+]

--- a/src/supportdoc_rag_chatbot/app/client/types.py
+++ b/src/supportdoc_rag_chatbot/app/client/types.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from math import isfinite
+from typing import Any, Protocol, runtime_checkable
+
+from supportdoc_rag_chatbot.app.schemas import QueryResponse
+
+
+class GenerationBackendMode(StrEnum):
+    """Supported generation backend modes for backend orchestration."""
+
+    FIXTURE = "fixture"
+    HTTP = "http"
+
+
+class GenerationFailureCode(StrEnum):
+    """Normalized failure categories emitted by generation backends."""
+
+    PARSE_ERROR = "parse_error"
+    TIMEOUT = "timeout"
+    TRANSPORT_ERROR = "transport_error"
+    BACKEND_ERROR = "backend_error"
+
+
+@dataclass(slots=True, frozen=True)
+class GenerationRequest:
+    """Backend-agnostic generation request passed into a generation client."""
+
+    question: str
+    system_prompt: str | None = None
+    user_prompt: str | None = None
+    timeout_seconds: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "question", _validate_required_string(self.question, field_name="question")
+        )
+        object.__setattr__(self, "system_prompt", _normalize_optional_string(self.system_prompt))
+        object.__setattr__(self, "user_prompt", _normalize_optional_string(self.user_prompt))
+        object.__setattr__(
+            self, "timeout_seconds", _validate_optional_timeout(self.timeout_seconds)
+        )
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a deterministic JSON-serializable request payload."""
+
+        payload: dict[str, Any] = {"question": self.question}
+        if self.system_prompt is not None:
+            payload["system_prompt"] = self.system_prompt
+        if self.user_prompt is not None:
+            payload["user_prompt"] = self.user_prompt
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class GenerationFailure:
+    """Normalized backend failure returned to the orchestration layer."""
+
+    code: GenerationFailureCode
+    message: str
+    backend_name: str
+    retryable: bool = False
+    status_code: int | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "message", _validate_required_string(self.message, field_name="message")
+        )
+        object.__setattr__(
+            self,
+            "backend_name",
+            _validate_required_string(self.backend_name, field_name="backend_name"),
+        )
+        object.__setattr__(self, "details", dict(self.details))
+        if self.status_code is not None and self.status_code <= 0:
+            raise ValueError("status_code must be > 0")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code.value,
+            "message": self.message,
+            "backend_name": self.backend_name,
+            "retryable": self.retryable,
+            "status_code": self.status_code,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class GenerationResult:
+    """Result envelope for generation clients."""
+
+    response: QueryResponse | None = None
+    failure: GenerationFailure | None = None
+
+    def __post_init__(self) -> None:
+        if (self.response is None) == (self.failure is None):
+            raise ValueError("GenerationResult must contain exactly one of response or failure")
+
+    @property
+    def is_success(self) -> bool:
+        return self.response is not None
+
+    @property
+    def is_failure(self) -> bool:
+        return self.failure is not None
+
+    def require_response(self) -> QueryResponse:
+        if self.response is None:
+            raise ValueError("GenerationResult does not contain a response")
+        return self.response
+
+    @classmethod
+    def success(cls, response: QueryResponse) -> "GenerationResult":
+        return cls(response=response)
+
+    @classmethod
+    def from_failure(cls, failure: GenerationFailure) -> "GenerationResult":
+        return cls(failure=failure)
+
+
+@runtime_checkable
+class GenerationClient(Protocol):
+    """Backend-agnostic generation client interface."""
+
+    backend_mode: GenerationBackendMode
+    backend_name: str
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        """Generate a response or return a normalized backend failure."""
+
+    def close(self) -> None:
+        """Release any backend resources held by the client."""
+
+
+def _validate_required_string(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
+
+
+def _normalize_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _validate_optional_timeout(value: float | None) -> float | None:
+    if value is None:
+        return None
+    if not isfinite(value) or value <= 0:
+        raise ValueError("timeout_seconds must be a finite value > 0")
+    return float(value)
+
+
+__all__ = [
+    "GenerationBackendMode",
+    "GenerationClient",
+    "GenerationFailure",
+    "GenerationFailureCode",
+    "GenerationRequest",
+    "GenerationResult",
+]

--- a/tests/test_generation_client.py
+++ b/tests/test_generation_client.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from supportdoc_rag_chatbot.app.client import (
+    FixtureGenerationClient,
+    GenerationFailureCode,
+    GenerationRequest,
+    HttpGenerationClient,
+)
+from supportdoc_rag_chatbot.app.schemas import build_example_answer_response
+
+
+def test_fixture_generation_client_returns_supported_answer_for_known_question() -> None:
+    client = FixtureGenerationClient()
+
+    result = client.generate(GenerationRequest(question="What is a Pod?"))
+
+    assert result.is_success is True
+    response = result.require_response()
+    assert response.refusal.is_refusal is False
+    assert len(response.citations) == 1
+    assert response.citations[0].marker == "[1]"
+
+
+def test_fixture_generation_client_returns_refusal_for_unknown_question() -> None:
+    client = FixtureGenerationClient()
+
+    result = client.generate(GenerationRequest(question="How do I reset my laptop BIOS?"))
+
+    assert result.is_success is True
+    response = result.require_response()
+    assert response.refusal.is_refusal is True
+    assert response.citations == []
+    assert response.refusal.reason_code == "no_relevant_docs"
+
+
+def test_fixture_generation_client_normalizes_invalid_fixture_payloads(tmp_path: Path) -> None:
+    invalid_fixture_path = tmp_path / "invalid_answer.json"
+    invalid_fixture_path.write_text('{"final_answer": "Pods run containers."}', encoding="utf-8")
+
+    client = FixtureGenerationClient(
+        answer_fixture_path=invalid_fixture_path,
+        answer_questions=("What is a Pod?",),
+    )
+
+    result = client.generate(GenerationRequest(question="What is a Pod?"))
+
+    assert result.is_failure is True
+    assert result.failure is not None
+    assert result.failure.code is GenerationFailureCode.PARSE_ERROR
+    assert result.failure.details["path"] == str(invalid_fixture_path)
+
+
+def test_http_generation_client_builds_request_and_parses_query_response() -> None:
+    observed: dict[str, object] = {}
+    answer_payload = build_example_answer_response().model_dump(mode="json")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        observed["method"] = request.method
+        observed["path"] = request.url.path
+        observed["json"] = json.loads(request.content.decode("utf-8"))
+        observed["timeout"] = request.extensions["timeout"]
+        return httpx.Response(200, json=answer_payload)
+
+    client = HttpGenerationClient(
+        base_url="https://model.example.test",
+        endpoint_path="/v1/generate",
+        timeout_seconds=12.5,
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        result = client.generate(
+            GenerationRequest(
+                question="What is a Pod?",
+                system_prompt="system prompt",
+                user_prompt="user prompt",
+                metadata={"request_id": "req-123"},
+            )
+        )
+    finally:
+        client.close()
+
+    assert observed == {
+        "method": "POST",
+        "path": "/v1/generate",
+        "json": {
+            "question": "What is a Pod?",
+            "system_prompt": "system prompt",
+            "user_prompt": "user prompt",
+            "metadata": {"request_id": "req-123"},
+        },
+        "timeout": {"connect": 12.5, "read": 12.5, "write": 12.5, "pool": 12.5},
+    }
+    assert result.is_success is True
+    assert result.require_response().refusal.is_refusal is False
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_code"),
+    [
+        (httpx.ReadTimeout("timed out"), GenerationFailureCode.TIMEOUT),
+        (httpx.ConnectError("boom"), GenerationFailureCode.TRANSPORT_ERROR),
+    ],
+)
+def test_http_generation_client_normalizes_timeout_and_transport_errors(
+    exception: Exception,
+    expected_code: GenerationFailureCode,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exception
+
+    client = HttpGenerationClient(
+        base_url="https://model.example.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        result = client.generate(GenerationRequest(question="What is a Pod?"))
+    finally:
+        client.close()
+
+    assert result.is_failure is True
+    assert result.failure is not None
+    assert result.failure.code is expected_code
+
+
+def test_http_generation_client_normalizes_backend_errors() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "backend unavailable"})
+
+    client = HttpGenerationClient(
+        base_url="https://model.example.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        result = client.generate(GenerationRequest(question="What is a Pod?"))
+    finally:
+        client.close()
+
+    assert result.is_failure is True
+    assert result.failure is not None
+    assert result.failure.code is GenerationFailureCode.BACKEND_ERROR
+    assert result.failure.retryable is True
+    assert result.failure.status_code == 503
+
+
+def test_http_generation_client_normalizes_invalid_response_payloads() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"final_answer": "missing trust contract fields"})
+
+    client = HttpGenerationClient(
+        base_url="https://model.example.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        result = client.generate(GenerationRequest(question="What is a Pod?"))
+    finally:
+        client.close()
+
+    assert result.is_failure is True
+    assert result.failure is not None
+    assert result.failure.code is GenerationFailureCode.PARSE_ERROR

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,6 +1,36 @@
-"""Minimal smoke tests for inference-related code paths."""
+from __future__ import annotations
+
+import pytest
+
+from supportdoc_rag_chatbot.app.client import (
+    FixtureGenerationClient,
+    GenerationBackendMode,
+    GenerationRequest,
+    HttpGenerationClient,
+    create_generation_client,
+)
 
 
-def test_inference_smoke() -> None:
-    """Placeholder test until inference functionality is implemented."""
-    assert True
+def test_create_generation_client_fixture_mode_boots_local_fixture_backend() -> None:
+    client = create_generation_client(mode="fixture")
+
+    assert isinstance(client, FixtureGenerationClient)
+    assert client.backend_mode is GenerationBackendMode.FIXTURE
+
+    result = client.generate(GenerationRequest(question="What is a Pod?"))
+    assert result.is_success is True
+    assert result.require_response().refusal.is_refusal is False
+
+
+def test_create_generation_client_http_mode_requires_base_url() -> None:
+    with pytest.raises(ValueError, match="base_url is required when mode='http'"):
+        create_generation_client(mode="http")
+
+
+def test_create_generation_client_http_mode_returns_http_client() -> None:
+    client = create_generation_client(mode="http", base_url="https://model.example.test")
+    try:
+        assert isinstance(client, HttpGenerationClient)
+        assert client.backend_mode is GenerationBackendMode.HTTP
+    finally:
+        client.close()


### PR DESCRIPTION
…-stub

Closes #62
---

This change fills the current `app/client` gap with a real generation backend abstraction for the backend layer.

It adds one canonical client interface, a deterministic fixture-backed implementation for local smoke testing, and a thin HTTP client for future remote model endpoints. It also replaces the placeholder inference test with real coverage and documents the supported backend modes for local development.

- Added a backend-agnostic generation client surface under `src/supportdoc_rag_chatbot/app/client/`:
  - `GenerationRequest`
  - `GenerationResult`
  - `GenerationFailure`
  - `GenerationFailureCode`
  - `GenerationBackendMode`
  - `GenerationClient`
- Added `FixtureGenerationClient` that reads the checked-in canonical trust fixtures and returns deterministic `QueryResponse` payloads for:
  - a supported-answer path
  - a refusal path
- Added `HttpGenerationClient` using `httpx` behind the same interface.
- Added `create_generation_client(...)` as the single factory entrypoint.
- Normalized parse failures, timeouts, transport errors, and backend HTTP errors into predictable `GenerationFailure` outcomes.
- Replaced the placeholder `tests/test_inference.py` with real factory/inference coverage.
- Added `tests/test_generation_client.py` for fixture and HTTP client behavior.
- Updated `README.md` with documented local backend modes and usage examples.

- Gives EPIC 6 a deterministic local generation mode that works without external model infrastructure.
- Establishes one reusable abstraction for later orchestration work instead of introducing parallel backend patterns.
- Reuses the existing canonical `QueryResponse` contract and checked-in trust fixtures, so later backend wiring stays aligned with the trust layer.
- Gives the orchestration layer predictable failure handling instead of backend-specific exception branching.

Executed in repo:

- `uv run pytest -q tests/test_inference.py tests/test_generation_client.py`
- `uv run pytest -q tests/test_trust_schema.py tests/test_refusal_builder.py tests/test_trust_schema_smoke_cli.py`
- `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py`
- `uv run pytest -q`
- `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...`
- `uv run python -m supportdoc_rag_chatbot --help`
- fixture smoke snippet via `create_generation_client(mode="fixture")`

---

Changes to be committed:
	modified:   README.md
	modified:   src/supportdoc_rag_chatbot/app/client/__init__.py
	new file:   src/supportdoc_rag_chatbot/app/client/factory.py
	new file:   src/supportdoc_rag_chatbot/app/client/fixture.py
	new file:   src/supportdoc_rag_chatbot/app/client/http.py
	new file:   src/supportdoc_rag_chatbot/app/client/types.py
	new file:   tests/test_generation_client.py
	modified:   tests/test_inference.py