### PR TITLE
On branch doc/63-pipeline-integration

### DIFF
--- a/src/supportdoc_rag_chatbot/app/api/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/api/__init__.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
+from supportdoc_rag_chatbot.app.core import close_cached_query_orchestrator
 from supportdoc_rag_chatbot.config import BackendSettings, get_backend_settings
 
 from .errors import register_exception_handlers
 from .routes import query_router, system_router
+
+
+@asynccontextmanager
+async def _app_lifespan(app: FastAPI):
+    try:
+        yield
+    finally:
+        close_cached_query_orchestrator(app)
 
 
 def create_app(*, settings: BackendSettings | None = None) -> FastAPI:
@@ -17,6 +28,7 @@ def create_app(*, settings: BackendSettings | None = None) -> FastAPI:
         version=resolved_settings.api_version,
         docs_url=resolved_settings.docs_url,
         redoc_url=resolved_settings.redoc_url,
+        lifespan=_app_lifespan,
     )
     app.state.settings = resolved_settings
 

--- a/src/supportdoc_rag_chatbot/app/api/errors.py
+++ b/src/supportdoc_rag_chatbot/app/api/errors.py
@@ -8,6 +8,8 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from supportdoc_rag_chatbot.app.core import QueryPipelineError
+
 from .schemas import ApiError, ApiErrorResponse
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,23 @@ def register_exception_handlers(app: FastAPI) -> None:
             )
         )
         return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+    @app.exception_handler(QueryPipelineError)
+    async def _handle_query_pipeline_error(
+        request: Request,
+        exc: QueryPipelineError,
+    ) -> JSONResponse:
+        logger.exception(
+            "Backend query pipeline error",
+            extra={"path": str(request.url.path), "error_code": exc.code},
+        )
+        payload = ApiErrorResponse(
+            error=ApiError(
+                code=exc.code,
+                message=str(exc),
+            )
+        )
+        return JSONResponse(status_code=500, content=payload.model_dump())
 
     @app.exception_handler(Exception)
     async def _handle_unexpected_exception(

--- a/src/supportdoc_rag_chatbot/app/api/routes/query.py
+++ b/src/supportdoc_rag_chatbot/app/api/routes/query.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from typing import Annotated
 
-from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
-from supportdoc_rag_chatbot.app.services import build_refusal_response
+from fastapi import APIRouter, Depends
+
+from supportdoc_rag_chatbot.app.core import QueryOrchestrator, get_request_query_orchestrator
+from supportdoc_rag_chatbot.app.schemas import QueryResponse
 
 from ..schemas import QueryRequest
 
@@ -13,8 +15,10 @@ router = APIRouter(tags=["query"])
 @router.post(
     "/query",
     response_model=QueryResponse,
-    summary="Validate a query request and return the canonical response envelope",
+    summary="Run backend retrieval, gating, generation, and validation for one question",
 )
-def post_query(payload: QueryRequest) -> QueryResponse:
-    del payload
-    return build_refusal_response(RefusalReasonCode.NO_RELEVANT_DOCS)
+def post_query(
+    payload: QueryRequest,
+    orchestrator: Annotated[QueryOrchestrator, Depends(get_request_query_orchestrator)],
+) -> QueryResponse:
+    return orchestrator.run(payload.question)

--- a/src/supportdoc_rag_chatbot/app/core/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/core/__init__.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from .errors import (
+    QueryPipelineConfigurationError,
+    QueryPipelineError,
+    QueryPipelineRuntimeError,
+)
+from .query_service import (
+    DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS,
+    QueryOrchestrator,
+    close_cached_query_orchestrator,
+    create_query_orchestrator,
+    get_request_query_orchestrator,
+)
+from .retrieval import (
+    ArtifactDenseQueryRetriever,
+    FixtureQueryRetriever,
+    QueryRetriever,
+    RetrievalBackendMode,
+    RetrievedEvidenceBundle,
+    RetrievedEvidenceChunk,
+    create_query_retriever,
+)
+
+__all__ = [
+    "ArtifactDenseQueryRetriever",
+    "DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS",
+    "FixtureQueryRetriever",
+    "QueryOrchestrator",
+    "QueryPipelineConfigurationError",
+    "QueryPipelineError",
+    "QueryPipelineRuntimeError",
+    "QueryRetriever",
+    "RetrievalBackendMode",
+    "RetrievedEvidenceBundle",
+    "RetrievedEvidenceChunk",
+    "close_cached_query_orchestrator",
+    "create_query_orchestrator",
+    "create_query_retriever",
+    "get_request_query_orchestrator",
+]

--- a/src/supportdoc_rag_chatbot/app/core/errors.py
+++ b/src/supportdoc_rag_chatbot/app/core/errors.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+class QueryPipelineError(RuntimeError):
+    """Base error raised when backend query orchestration cannot complete."""
+
+    code = "backend_runtime_error"
+
+    def __init__(self, message: str) -> None:
+        normalized = message.strip()
+        if not normalized:
+            raise ValueError("message must not be blank")
+        super().__init__(normalized)
+
+
+class QueryPipelineConfigurationError(QueryPipelineError):
+    """Raised when backend orchestration is misconfigured."""
+
+    code = "backend_configuration_error"
+
+
+class QueryPipelineRuntimeError(QueryPipelineError):
+    """Raised when backend orchestration fails at runtime."""
+
+    code = "backend_runtime_error"
+
+
+__all__ = [
+    "QueryPipelineConfigurationError",
+    "QueryPipelineError",
+    "QueryPipelineRuntimeError",
+]

--- a/src/supportdoc_rag_chatbot/app/core/query_service.py
+++ b/src/supportdoc_rag_chatbot/app/core/query_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import Request
+
+from supportdoc_rag_chatbot.app.client import (
+    GenerationClient,
+    GenerationFailureCode,
+    GenerationRequest,
+    create_generation_client,
+)
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+from supportdoc_rag_chatbot.app.services import (
+    RetrievalSufficiencyThresholds,
+    build_refusal_from_citation_validation,
+    build_refusal_from_retrieval_decision,
+    build_refusal_response,
+    build_trust_prompt,
+    evaluate_retrieval_sufficiency,
+    load_retrieval_sufficiency_thresholds,
+    validate_query_response_citations,
+)
+from supportdoc_rag_chatbot.config import BackendSettings, get_request_settings
+
+from .errors import QueryPipelineConfigurationError, QueryPipelineRuntimeError
+from .retrieval import QueryRetriever, create_query_retriever
+
+DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS = 2
+
+
+@dataclass(slots=True)
+class QueryOrchestrator:
+    """Canonical backend orchestration service behind POST /query."""
+
+    retriever: QueryRetriever
+    generation_client: GenerationClient
+    thresholds: RetrievalSufficiencyThresholds = field(
+        default_factory=load_retrieval_sufficiency_thresholds
+    )
+    top_k: int = 3
+    max_generation_attempts: int = DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS
+
+    def __post_init__(self) -> None:
+        if self.top_k <= 0:
+            raise ValueError("top_k must be > 0")
+        if self.max_generation_attempts <= 0:
+            raise ValueError("max_generation_attempts must be > 0")
+
+    def run(self, question: str) -> QueryResponse:
+        validated_question = _validate_required_string(question, field_name="question")
+        retrieved = self.retriever.retrieve(validated_question, top_k=self.top_k)
+        decision = evaluate_retrieval_sufficiency(
+            _build_sufficiency_request(validated_question, retrieved),
+            thresholds=self.thresholds,
+        )
+        if decision.should_refuse:
+            return build_refusal_from_retrieval_decision(decision)
+
+        prompt = build_trust_prompt(
+            question=validated_question,
+            retrieved_chunks=retrieved.to_prompt_chunks(),
+        )
+        return self._run_generation_loop(
+            question=validated_question,
+            retrieved=retrieved,
+            prompt=prompt,
+            max_answer_sentences=decision.max_answer_sentences,
+        )
+
+    def close(self) -> None:
+        self.generation_client.close()
+
+    def _run_generation_loop(
+        self,
+        *,
+        question: str,
+        retrieved,
+        prompt,
+        max_answer_sentences: int | None,
+    ) -> QueryResponse:
+        for attempt in range(1, self.max_generation_attempts + 1):
+            result = self.generation_client.generate(
+                GenerationRequest(
+                    question=question,
+                    system_prompt=prompt.system_prompt,
+                    user_prompt=prompt.user_prompt,
+                    metadata={
+                        "attempt": attempt,
+                        "retriever_name": retrieved.retriever_name,
+                        "retriever_type": retrieved.retriever_type,
+                        "retrieved_chunk_ids": [chunk.chunk_id for chunk in retrieved.chunks],
+                        "max_answer_sentences": max_answer_sentences,
+                    },
+                )
+            )
+            if result.is_failure:
+                assert result.failure is not None
+                if (
+                    result.failure.code is GenerationFailureCode.PARSE_ERROR
+                    and attempt < self.max_generation_attempts
+                ):
+                    continue
+                if result.failure.code is GenerationFailureCode.PARSE_ERROR:
+                    return build_refusal_response(RefusalReasonCode.CITATION_VALIDATION_FAILED)
+                raise QueryPipelineRuntimeError(_render_generation_failure(result.failure))
+
+            response = result.require_response()
+            validation = validate_query_response_citations(
+                response,
+                retrieved_chunks=retrieved.to_citation_contexts(),
+            )
+            if validation.is_valid:
+                return response
+            if validation.should_retry and attempt < self.max_generation_attempts:
+                continue
+            return build_refusal_from_citation_validation(validation)
+
+        return build_refusal_response(RefusalReasonCode.CITATION_VALIDATION_FAILED)
+
+
+def create_query_orchestrator(*, settings: BackendSettings) -> QueryOrchestrator:
+    """Create the canonical backend query orchestrator from backend settings."""
+
+    try:
+        retriever = create_query_retriever(mode=settings.query_retrieval_mode)
+    except ValueError as exc:
+        raise QueryPipelineConfigurationError(
+            f"Invalid retrieval backend configuration: {exc}"
+        ) from exc
+
+    try:
+        generation_client = create_generation_client(
+            mode=settings.query_generation_mode,
+            base_url=settings.query_generation_base_url,
+            timeout_seconds=settings.query_generation_timeout_seconds,
+        )
+    except ValueError as exc:
+        raise QueryPipelineConfigurationError(
+            f"Invalid generation backend configuration: {exc}"
+        ) from exc
+
+    return QueryOrchestrator(
+        retriever=retriever,
+        generation_client=generation_client,
+        top_k=settings.query_top_k,
+    )
+
+
+def get_request_query_orchestrator(request: Request) -> QueryOrchestrator:
+    """Resolve and cache the request-scoped query orchestrator on app state."""
+
+    cached = getattr(request.app.state, "query_orchestrator", None)
+    if isinstance(cached, QueryOrchestrator):
+        return cached
+
+    settings = get_request_settings(request)
+    orchestrator = create_query_orchestrator(settings=settings)
+    request.app.state.query_orchestrator = orchestrator
+    return orchestrator
+
+
+def close_cached_query_orchestrator(app: Any) -> None:
+    """Close and clear any cached query orchestrator stored on app state."""
+
+    cached = getattr(app.state, "query_orchestrator", None)
+    if isinstance(cached, QueryOrchestrator):
+        cached.close()
+        delattr(app.state, "query_orchestrator")
+
+
+def _build_sufficiency_request(question: str, retrieved) -> Any:
+    from supportdoc_rag_chatbot.app.services import RetrievalSufficiencyRequest
+
+    return RetrievalSufficiencyRequest.from_retrieval_hits(
+        retrieved.to_retrieval_hits(),
+        score_normalization=retrieved.score_normalization,
+        retriever_name=retrieved.retriever_name,
+        retriever_type=retrieved.retriever_type,
+        metadata={
+            "question": question,
+            "retriever_config": dict(retrieved.config),
+        },
+    )
+
+
+def _render_generation_failure(failure) -> str:
+    return (
+        f"Generation backend failed with {failure.code.value}: {failure.message} "
+        f"(backend={failure.backend_name})"
+    )
+
+
+def _validate_required_string(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
+
+
+__all__ = [
+    "DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS",
+    "QueryOrchestrator",
+    "close_cached_query_orchestrator",
+    "create_query_orchestrator",
+    "get_request_query_orchestrator",
+]

--- a/src/supportdoc_rag_chatbot/app/core/retrieval.py
+++ b/src/supportdoc_rag_chatbot/app/core/retrieval.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from math import isfinite
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+from supportdoc_rag_chatbot.app.services import RetrievedChunkCitationContext, RetrievedContextChunk
+from supportdoc_rag_chatbot.app.services.policy_types import RetrievalScoreNormalization
+from supportdoc_rag_chatbot.evaluation import RetrievalHit
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import DEFAULT_BATCH_SIZE, DEFAULT_DEVICE
+from supportdoc_rag_chatbot.retrieval.embeddings.job import load_chunk_records
+from supportdoc_rag_chatbot.retrieval.embeddings.models import DenseEmbedder, create_local_embedder
+from supportdoc_rag_chatbot.retrieval.indexes import (
+    DEFAULT_FAISS_INDEX_PATH,
+    DEFAULT_FAISS_METADATA_PATH,
+    DEFAULT_FAISS_ROW_MAPPING_PATH,
+    FaissDenseIndexBackend,
+    load_faiss_index_backend,
+    read_index_metadata,
+)
+
+from .errors import QueryPipelineConfigurationError, QueryPipelineRuntimeError
+
+_DEFAULT_FIXTURE_SECTION_PATH = ("Concepts", "Workloads", "Pods")
+_DEFAULT_FIXTURE_SOURCE_PATH = "content/en/docs/concepts/workloads/pods/pods.md"
+_DEFAULT_FIXTURE_SOURCE_URL = "https://kubernetes.io/docs/concepts/workloads/pods/"
+_DEFAULT_FIXTURE_POD_DOC_ID = "content-en-docs-concepts-workloads-pods-pods"
+
+
+class RetrievalBackendMode(StrEnum):
+    """Supported backend retrieval modes for query orchestration."""
+
+    FIXTURE = "fixture"
+    ARTIFACT = "artifact"
+
+
+@dataclass(slots=True, frozen=True)
+class RetrievedEvidenceChunk:
+    """Minimal retrieval result shape consumed by prompting and validation."""
+
+    doc_id: str
+    chunk_id: str
+    text: str
+    score: float
+    rank: int
+    section_id: str | None = None
+    section_path: tuple[str, ...] = ()
+    source_path: str | None = None
+    source_url: str | None = None
+    start_offset: int = 0
+    end_offset: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "doc_id",
+            _validate_required_string(self.doc_id, field_name="doc_id"),
+        )
+        object.__setattr__(
+            self,
+            "chunk_id",
+            _validate_required_string(self.chunk_id, field_name="chunk_id"),
+        )
+        object.__setattr__(self, "text", _validate_required_string(self.text, field_name="text"))
+        object.__setattr__(self, "score", _validate_unit_interval_score(self.score))
+        if self.rank <= 0:
+            raise ValueError("rank must be > 0")
+        object.__setattr__(self, "section_id", _normalize_optional_string(self.section_id))
+        normalized_section_path = tuple(part.strip() for part in self.section_path if part.strip())
+        object.__setattr__(self, "section_path", normalized_section_path)
+        object.__setattr__(self, "source_path", _normalize_optional_string(self.source_path))
+        object.__setattr__(self, "source_url", _normalize_optional_string(self.source_url))
+        if self.start_offset < 0:
+            raise ValueError("start_offset must be >= 0")
+        resolved_end_offset = len(self.text) if self.end_offset is None else int(self.end_offset)
+        if resolved_end_offset <= self.start_offset:
+            raise ValueError("end_offset must be greater than start_offset")
+        object.__setattr__(self, "end_offset", resolved_end_offset)
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @classmethod
+    def from_chunk_record(
+        cls,
+        chunk: ChunkRecord,
+        *,
+        score: float,
+        rank: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> "RetrievedEvidenceChunk":
+        return cls(
+            doc_id=chunk.doc_id,
+            chunk_id=chunk.chunk_id,
+            text=chunk.text,
+            score=score,
+            rank=rank,
+            section_id=chunk.section_id,
+            section_path=tuple(chunk.section_path),
+            source_path=chunk.source_path,
+            source_url=chunk.source_url,
+            start_offset=chunk.start_offset,
+            end_offset=chunk.end_offset,
+            metadata=(dict(metadata) if metadata is not None else {}),
+        )
+
+    def to_retrieval_hit(self) -> RetrievalHit:
+        return RetrievalHit(
+            chunk_id=self.chunk_id,
+            score=self.score,
+            rank=self.rank,
+            doc_id=self.doc_id,
+            section_id=self.section_id,
+            metadata=dict(self.metadata),
+        )
+
+    def to_prompt_chunk(self) -> RetrievedContextChunk:
+        return RetrievedContextChunk(
+            doc_id=self.doc_id,
+            chunk_id=self.chunk_id,
+            text=self.text,
+            section_path=self.section_path,
+            source_path=self.source_path,
+            source_url=self.source_url,
+        )
+
+    def to_citation_context(self) -> RetrievedChunkCitationContext:
+        assert self.end_offset is not None
+        return RetrievedChunkCitationContext(
+            doc_id=self.doc_id,
+            chunk_id=self.chunk_id,
+            start_offset=self.start_offset,
+            end_offset=self.end_offset,
+            text=self.text,
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class RetrievedEvidenceBundle:
+    """Request-scoped retrieval evidence emitted by the backend adapter."""
+
+    chunks: tuple[RetrievedEvidenceChunk, ...]
+    retriever_name: str
+    retriever_type: str
+    config: dict[str, Any] = field(default_factory=dict)
+    score_normalization: RetrievalScoreNormalization = RetrievalScoreNormalization.UNIT_INTERVAL
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "retriever_name",
+            _validate_required_string(self.retriever_name, field_name="retriever_name"),
+        )
+        object.__setattr__(
+            self,
+            "retriever_type",
+            _validate_required_string(self.retriever_type, field_name="retriever_type"),
+        )
+        object.__setattr__(self, "config", dict(self.config))
+
+    def to_retrieval_hits(self) -> list[RetrievalHit]:
+        return [chunk.to_retrieval_hit() for chunk in self.chunks]
+
+    def to_prompt_chunks(self) -> list[RetrievedContextChunk]:
+        return [chunk.to_prompt_chunk() for chunk in self.chunks]
+
+    def to_citation_contexts(self) -> list[RetrievedChunkCitationContext]:
+        return [chunk.to_citation_context() for chunk in self.chunks]
+
+
+def _normalize_question(question: str) -> str:
+    return _validate_required_string(question, field_name="question").casefold()
+
+
+def _normalize_ranked_chunks(
+    chunks: Sequence[RetrievedEvidenceChunk],
+) -> tuple[RetrievedEvidenceChunk, ...]:
+    sorted_chunks = sorted(chunks, key=lambda chunk: (chunk.rank, chunk.chunk_id))
+    return _rerank_chunks(sorted_chunks)
+
+
+def _rerank_chunks(chunks: Sequence[RetrievedEvidenceChunk]) -> tuple[RetrievedEvidenceChunk, ...]:
+    reranked: list[RetrievedEvidenceChunk] = []
+    for rank, chunk in enumerate(chunks, start=1):
+        reranked.append(
+            RetrievedEvidenceChunk(
+                doc_id=chunk.doc_id,
+                chunk_id=chunk.chunk_id,
+                text=chunk.text,
+                score=chunk.score,
+                rank=rank,
+                section_id=chunk.section_id,
+                section_path=chunk.section_path,
+                source_path=chunk.source_path,
+                source_url=chunk.source_url,
+                start_offset=chunk.start_offset,
+                end_offset=chunk.end_offset,
+                metadata=chunk.metadata,
+            )
+        )
+    return tuple(reranked)
+
+
+def _normalize_cosine_similarity(score: float) -> float:
+    if not isfinite(score):
+        raise QueryPipelineRuntimeError("Artifact retrieval backend returned a non-finite score.")
+    normalized = (float(score) + 1.0) / 2.0
+    if normalized < 0.0:
+        return 0.0
+    if normalized > 1.0:
+        return 1.0
+    return normalized
+
+
+def _validate_required_string(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
+
+
+def _normalize_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _validate_unit_interval_score(value: float) -> float:
+    normalized = float(value)
+    if not isfinite(normalized):
+        raise ValueError("score must be a finite float")
+    if not 0.0 <= normalized <= 1.0:
+        raise ValueError("score must be between 0.0 and 1.0")
+    return normalized
+
+
+def _require_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise QueryPipelineConfigurationError(f"{label} not found: {path}")
+    if not path.is_file():
+        raise QueryPipelineConfigurationError(f"{label} is not a file: {path}")
+
+
+_DEFAULT_FIXTURE_CONTEXT = (
+    RetrievedEvidenceChunk(
+        doc_id=_DEFAULT_FIXTURE_POD_DOC_ID,
+        chunk_id=f"{_DEFAULT_FIXTURE_POD_DOC_ID}__chunk-0001",
+        text=(
+            "A Pod is the smallest deployable unit in Kubernetes and can run one or more "
+            "containers that share network and storage resources."
+        ),
+        score=0.97,
+        rank=1,
+        section_id=f"{_DEFAULT_FIXTURE_POD_DOC_ID}__section-0001",
+        section_path=_DEFAULT_FIXTURE_SECTION_PATH,
+        source_path=_DEFAULT_FIXTURE_SOURCE_PATH,
+        source_url=_DEFAULT_FIXTURE_SOURCE_URL,
+        start_offset=0,
+        end_offset=128,
+    ),
+    RetrievedEvidenceChunk(
+        doc_id=_DEFAULT_FIXTURE_POD_DOC_ID,
+        chunk_id=f"{_DEFAULT_FIXTURE_POD_DOC_ID}__chunk-0002",
+        text=(
+            "Pods can also group closely related containers so they share the same network "
+            "identity and can coordinate storage resources."
+        ),
+        score=0.83,
+        rank=2,
+        section_id=f"{_DEFAULT_FIXTURE_POD_DOC_ID}__section-0001",
+        section_path=_DEFAULT_FIXTURE_SECTION_PATH,
+        source_path=_DEFAULT_FIXTURE_SOURCE_PATH,
+        source_url=_DEFAULT_FIXTURE_SOURCE_URL,
+        start_offset=0,
+    ),
+)
+_DEFAULT_FIXTURE_QUESTION_MAP = {"what is a pod?": _DEFAULT_FIXTURE_CONTEXT}
+
+
+@runtime_checkable
+class QueryRetriever(Protocol):
+    """Backend-agnostic retrieval adapter used by the API orchestration service."""
+
+    backend_mode: RetrievalBackendMode
+    name: str
+    retriever_type: str
+
+    @property
+    def config(self) -> dict[str, Any]:
+        """Return a deterministic retriever configuration payload."""
+
+    def retrieve(self, question: str, *, top_k: int) -> RetrievedEvidenceBundle:
+        """Return request-scoped retrieved evidence for one user question."""
+
+
+@dataclass(slots=True)
+class FixtureQueryRetriever:
+    """Deterministic retrieval adapter for repo-only local smoke testing."""
+
+    hits_by_question: Mapping[str, Sequence[RetrievedEvidenceChunk]] | None = None
+    name: str = "fixture-retriever"
+    retriever_type: str = "fixture"
+
+    def __post_init__(self) -> None:
+        normalized_hits: dict[str, tuple[RetrievedEvidenceChunk, ...]] = {}
+        source = self.hits_by_question or _DEFAULT_FIXTURE_QUESTION_MAP
+        for question, chunks in source.items():
+            normalized_hits[_normalize_question(question)] = _normalize_ranked_chunks(chunks)
+        self.hits_by_question = normalized_hits
+
+    @property
+    def backend_mode(self) -> RetrievalBackendMode:
+        return RetrievalBackendMode.FIXTURE
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return {
+            "fixture_questions": sorted(self.hits_by_question),
+            "score_normalization": RetrievalScoreNormalization.UNIT_INTERVAL.value,
+        }
+
+    def retrieve(self, question: str, *, top_k: int) -> RetrievedEvidenceBundle:
+        normalized_question = _normalize_question(question)
+        if top_k <= 0:
+            raise ValueError("top_k must be > 0")
+        chunks = tuple(self.hits_by_question.get(normalized_question, ()))
+        selected = _rerank_chunks(chunks[:top_k])
+        return RetrievedEvidenceBundle(
+            chunks=selected,
+            retriever_name=self.name,
+            retriever_type=self.retriever_type,
+            config=self.config,
+        )
+
+
+@dataclass(slots=True)
+class ArtifactDenseQueryRetriever:
+    """Artifact-backed dense retrieval adapter for the backend query pipeline."""
+
+    index_path: Path = DEFAULT_FAISS_INDEX_PATH
+    metadata_path: Path = DEFAULT_FAISS_METADATA_PATH
+    row_mapping_path: Path | None = DEFAULT_FAISS_ROW_MAPPING_PATH
+    chunks_path: Path | None = None
+    model_name: str | None = None
+    device: str = DEFAULT_DEVICE
+    batch_size: int = DEFAULT_BATCH_SIZE
+    name: str = "dense-artifact-retriever"
+    retriever_type: str = "dense-artifact"
+    embedder: DenseEmbedder | None = None
+    backend: FaissDenseIndexBackend | None = None
+    _resolved_backend: FaissDenseIndexBackend | None = field(default=None, init=False, repr=False)
+    _resolved_embedder: DenseEmbedder | None = field(default=None, init=False, repr=False)
+    _chunk_map: dict[str, ChunkRecord] = field(default_factory=dict, init=False, repr=False)
+
+    @property
+    def backend_mode(self) -> RetrievalBackendMode:
+        return RetrievalBackendMode.ARTIFACT
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return {
+            "index_path": str(self.index_path),
+            "metadata_path": str(self.metadata_path),
+            "row_mapping_path": (str(self.row_mapping_path) if self.row_mapping_path else None),
+            "chunks_path": (str(self.chunks_path) if self.chunks_path else None),
+            "model_name": self.model_name,
+            "device": self.device,
+            "batch_size": self.batch_size,
+            "score_normalization": RetrievalScoreNormalization.UNIT_INTERVAL.value,
+        }
+
+    def retrieve(self, question: str, *, top_k: int) -> RetrievedEvidenceBundle:
+        if top_k <= 0:
+            raise ValueError("top_k must be > 0")
+        normalized_question = _validate_required_string(question, field_name="question")
+        backend = self._ensure_backend_loaded()
+        embedder = self._ensure_embedder_loaded(backend)
+        vectors = embedder.embed_texts([normalized_question])
+        if len(vectors) != 1:
+            raise QueryPipelineRuntimeError(
+                "Artifact retrieval backend did not produce exactly one query embedding."
+            )
+
+        raw_results = backend.search(vectors[0], top_k=top_k)
+        chunks: list[RetrievedEvidenceChunk] = []
+        for rank, raw_result in enumerate(raw_results, start=1):
+            chunk = self._chunk_map.get(raw_result.chunk_id)
+            if chunk is None:
+                raise QueryPipelineRuntimeError(
+                    "Artifact retrieval backend returned a chunk_id that is missing from the "
+                    f"resolved chunks artifact: {raw_result.chunk_id}"
+                )
+            chunks.append(
+                RetrievedEvidenceChunk.from_chunk_record(
+                    chunk,
+                    score=_normalize_cosine_similarity(raw_result.score),
+                    rank=rank,
+                    metadata={
+                        "raw_score": float(raw_result.score),
+                        "row_index": raw_result.row_index,
+                        "source_chunks_path": raw_result.source_chunks_path,
+                    },
+                )
+            )
+
+        return RetrievedEvidenceBundle(
+            chunks=tuple(chunks),
+            retriever_name=self.name,
+            retriever_type=self.retriever_type,
+            config=self.config,
+        )
+
+    def _ensure_backend_loaded(self) -> FaissDenseIndexBackend:
+        if self._resolved_backend is not None:
+            return self._resolved_backend
+
+        metadata_path = Path(self.metadata_path)
+        index_path = Path(self.index_path)
+        _require_file(metadata_path, label="artifact retrieval metadata")
+        _require_file(index_path, label="artifact retrieval index")
+
+        metadata = read_index_metadata(metadata_path)
+        resolved_row_mapping_path = self.row_mapping_path
+        if resolved_row_mapping_path is None:
+            if not metadata.row_mapping_path:
+                raise QueryPipelineConfigurationError(
+                    "Artifact retrieval mode requires a FAISS row-mapping artifact path."
+                )
+            resolved_row_mapping_path = Path(metadata.row_mapping_path)
+        _require_file(Path(resolved_row_mapping_path), label="artifact retrieval row mapping")
+
+        resolved_chunks_path = self.chunks_path or Path(metadata.source_chunks_path)
+        _require_file(Path(resolved_chunks_path), label="artifact retrieval chunks")
+
+        try:
+            backend = self.backend or load_faiss_index_backend(
+                index_path=index_path,
+                metadata_path=metadata_path,
+                row_mapping_path=Path(resolved_row_mapping_path),
+            )
+        except FileNotFoundError as exc:
+            raise QueryPipelineConfigurationError(str(exc)) from exc
+        except ValueError as exc:
+            raise QueryPipelineConfigurationError(
+                f"Artifact retrieval metadata is invalid: {exc}"
+            ) from exc
+        except RuntimeError as exc:
+            raise QueryPipelineRuntimeError(
+                f"Artifact retrieval backend could not be loaded: {exc}"
+            ) from exc
+
+        try:
+            chunks = load_chunk_records(Path(resolved_chunks_path))
+        except FileNotFoundError as exc:
+            raise QueryPipelineConfigurationError(str(exc)) from exc
+        except ValueError as exc:
+            raise QueryPipelineConfigurationError(
+                f"Artifact retrieval chunks are invalid: {exc}"
+            ) from exc
+
+        self._resolved_backend = backend
+        self._chunk_map = {chunk.chunk_id: chunk for chunk in chunks}
+        return backend
+
+    def _ensure_embedder_loaded(self, backend: FaissDenseIndexBackend) -> DenseEmbedder:
+        if self._resolved_embedder is not None:
+            return self._resolved_embedder
+        try:
+            self._resolved_embedder = self.embedder or create_local_embedder(
+                model_name=(self.model_name or backend.metadata.embedding_model_name),
+                device=self.device,
+                batch_size=self.batch_size,
+            )
+        except RuntimeError as exc:
+            raise QueryPipelineRuntimeError(
+                f"Artifact retrieval embedder could not be created: {exc}"
+            ) from exc
+        return self._resolved_embedder
+
+
+def create_query_retriever(
+    *,
+    mode: RetrievalBackendMode | str,
+    **kwargs: Any,
+) -> QueryRetriever:
+    """Create the canonical query retriever for the requested backend mode."""
+
+    resolved_mode = RetrievalBackendMode(mode)
+    if resolved_mode is RetrievalBackendMode.FIXTURE:
+        return FixtureQueryRetriever(**kwargs)
+    return ArtifactDenseQueryRetriever(**kwargs)
+
+
+__all__ = [
+    "ArtifactDenseQueryRetriever",
+    "FixtureQueryRetriever",
+    "QueryRetriever",
+    "RetrievalBackendMode",
+    "RetrievedEvidenceBundle",
+    "RetrievedEvidenceChunk",
+    "create_query_retriever",
+]

--- a/src/supportdoc_rag_chatbot/config.py
+++ b/src/supportdoc_rag_chatbot/config.py
@@ -9,10 +9,19 @@ from dotenv import load_dotenv
 from fastapi import Request
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from supportdoc_rag_chatbot.app.client import (
+    DEFAULT_GENERATION_TIMEOUT_SECONDS,
+    GenerationBackendMode,
+)
+from supportdoc_rag_chatbot.app.core.retrieval import RetrievalBackendMode
+
 DEFAULT_API_TITLE = "SupportDoc RAG Chatbot API"
 DEFAULT_API_ENVIRONMENT = "local"
 DEFAULT_API_DOCS_URL = "/docs"
 DEFAULT_API_REDOC_URL = "/redoc"
+DEFAULT_QUERY_RETRIEVAL_MODE = RetrievalBackendMode.FIXTURE
+DEFAULT_QUERY_GENERATION_MODE = GenerationBackendMode.FIXTURE
+DEFAULT_QUERY_TOP_K = 3
 
 
 class BackendSettings(BaseModel):
@@ -25,13 +34,48 @@ class BackendSettings(BaseModel):
     api_version: str = Field(default_factory=lambda: _default_api_version())
     docs_url: str = Field(default=DEFAULT_API_DOCS_URL)
     redoc_url: str = Field(default=DEFAULT_API_REDOC_URL)
+    query_retrieval_mode: RetrievalBackendMode = Field(default=DEFAULT_QUERY_RETRIEVAL_MODE)
+    query_generation_mode: GenerationBackendMode = Field(default=DEFAULT_QUERY_GENERATION_MODE)
+    query_generation_base_url: str | None = None
+    query_generation_timeout_seconds: float = Field(default=DEFAULT_GENERATION_TIMEOUT_SECONDS)
+    query_top_k: int = Field(default=DEFAULT_QUERY_TOP_K)
 
-    @field_validator("app_name", "environment", "api_version", "docs_url", "redoc_url")
+    @field_validator(
+        "app_name",
+        "environment",
+        "api_version",
+        "docs_url",
+        "redoc_url",
+    )
     @classmethod
     def _validate_non_blank(cls, value: str, info) -> str:
         normalized = value.strip()
         if not normalized:
             raise ValueError(f"{info.field_name} must not be blank")
+        return normalized
+
+    @field_validator("query_generation_base_url")
+    @classmethod
+    def _validate_optional_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    @field_validator("query_generation_timeout_seconds")
+    @classmethod
+    def _validate_generation_timeout(cls, value: float) -> float:
+        normalized = float(value)
+        if normalized <= 0:
+            raise ValueError("query_generation_timeout_seconds must be > 0")
+        return normalized
+
+    @field_validator("query_top_k")
+    @classmethod
+    def _validate_query_top_k(cls, value: int) -> int:
+        normalized = int(value)
+        if normalized <= 0:
+            raise ValueError("query_top_k must be > 0")
         return normalized
 
 
@@ -60,6 +104,34 @@ def load_backend_settings(environ: Mapping[str, str] | None = None) -> BackendSe
             source,
             "SUPPORTDOC_API_REDOC_URL",
             default=DEFAULT_API_REDOC_URL,
+        ),
+        query_retrieval_mode=RetrievalBackendMode(
+            _read_env_string(
+                source,
+                "SUPPORTDOC_QUERY_RETRIEVAL_MODE",
+                default=DEFAULT_QUERY_RETRIEVAL_MODE.value,
+            )
+        ),
+        query_generation_mode=GenerationBackendMode(
+            _read_env_string(
+                source,
+                "SUPPORTDOC_QUERY_GENERATION_MODE",
+                default=DEFAULT_QUERY_GENERATION_MODE.value,
+            )
+        ),
+        query_generation_base_url=_read_env_optional_string(
+            source,
+            "SUPPORTDOC_QUERY_GENERATION_BASE_URL",
+        ),
+        query_generation_timeout_seconds=_read_env_float(
+            source,
+            "SUPPORTDOC_QUERY_GENERATION_TIMEOUT_SECONDS",
+            default=DEFAULT_GENERATION_TIMEOUT_SECONDS,
+        ),
+        query_top_k=_read_env_int(
+            source,
+            "SUPPORTDOC_QUERY_TOP_K",
+            default=DEFAULT_QUERY_TOP_K,
         ),
     )
 
@@ -96,12 +168,37 @@ def _read_env_string(source: Mapping[str, str], key: str, *, default: str) -> st
     return normalized
 
 
+def _read_env_optional_string(source: Mapping[str, str], key: str) -> str | None:
+    value = source.get(key)
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _read_env_int(source: Mapping[str, str], key: str, *, default: int) -> int:
+    value = source.get(key)
+    if value is None or not value.strip():
+        return default
+    return int(value)
+
+
+def _read_env_float(source: Mapping[str, str], key: str, *, default: float) -> float:
+    value = source.get(key)
+    if value is None or not value.strip():
+        return default
+    return float(value)
+
+
 __all__ = [
     "BackendSettings",
     "DEFAULT_API_DOCS_URL",
     "DEFAULT_API_ENVIRONMENT",
     "DEFAULT_API_REDOC_URL",
     "DEFAULT_API_TITLE",
+    "DEFAULT_QUERY_GENERATION_MODE",
+    "DEFAULT_QUERY_RETRIEVAL_MODE",
+    "DEFAULT_QUERY_TOP_K",
     "clear_backend_settings_cache",
     "get_backend_settings",
     "get_request_settings",

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -13,11 +13,22 @@ TEST_SETTINGS = BackendSettings(
     api_version="9.9.9",
     docs_url="/docs",
     redoc_url="/redoc",
+    query_retrieval_mode="fixture",
+    query_generation_mode="fixture",
+)
+ARTIFACT_SETTINGS = BackendSettings(
+    app_name="SupportDoc Artifact API",
+    environment="test",
+    api_version="9.9.9",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    query_retrieval_mode="artifact",
+    query_generation_mode="fixture",
 )
 
 
-def build_test_client() -> TestClient:
-    return TestClient(create_app(settings=TEST_SETTINGS))
+def build_test_client(*, settings: BackendSettings = TEST_SETTINGS) -> TestClient:
+    return TestClient(create_app(settings=settings))
 
 
 def test_module_exports_bootable_fastapi_apps() -> None:
@@ -33,6 +44,11 @@ def test_load_backend_settings_reads_env_mapping() -> None:
             "SUPPORTDOC_API_VERSION": "1.2.3",
             "SUPPORTDOC_API_DOCS_URL": "/docs-local",
             "SUPPORTDOC_API_REDOC_URL": "/redoc-local",
+            "SUPPORTDOC_QUERY_RETRIEVAL_MODE": "artifact",
+            "SUPPORTDOC_QUERY_GENERATION_MODE": "http",
+            "SUPPORTDOC_QUERY_GENERATION_BASE_URL": "https://model.example.test",
+            "SUPPORTDOC_QUERY_GENERATION_TIMEOUT_SECONDS": "12.5",
+            "SUPPORTDOC_QUERY_TOP_K": "7",
         }
     )
 
@@ -42,6 +58,11 @@ def test_load_backend_settings_reads_env_mapping() -> None:
         api_version="1.2.3",
         docs_url="/docs-local",
         redoc_url="/redoc-local",
+        query_retrieval_mode="artifact",
+        query_generation_mode="http",
+        query_generation_base_url="https://model.example.test",
+        query_generation_timeout_seconds=12.5,
+        query_top_k=7,
     )
 
 
@@ -67,9 +88,22 @@ def test_readyz_returns_deterministic_json_without_external_dependencies() -> No
     }
 
 
-def test_query_returns_canonical_query_response_placeholder() -> None:
+def test_query_returns_supported_answer_from_backend_orchestration() -> None:
     with build_test_client() as client:
         response = client.post("/query", json={"question": "What is a Pod?"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    validated = QueryResponse.model_validate(payload)
+
+    assert validated.refusal.is_refusal is False
+    assert validated.citations[0].marker == "[1]"
+    assert payload["final_answer"].startswith("A Pod is the smallest deployable unit")
+
+
+def test_query_returns_canonical_no_relevant_docs_refusal_for_unknown_question() -> None:
+    with build_test_client() as client:
+        response = client.post("/query", json={"question": "How do I reset my laptop BIOS?"})
 
     assert response.status_code == 200
     payload = response.json()
@@ -78,7 +112,17 @@ def test_query_returns_canonical_query_response_placeholder() -> None:
     assert validated.refusal.is_refusal is True
     assert validated.refusal.reason_code is RefusalReasonCode.NO_RELEVANT_DOCS
     assert validated.citations == []
-    assert payload["final_answer"] == "I can’t answer that from the approved support corpus."
+
+
+def test_query_returns_json_config_error_when_artifact_retrieval_is_enabled_without_artifacts() -> (
+    None
+):
+    with build_test_client(settings=ARTIFACT_SETTINGS) as client:
+        response = client.post("/query", json={"question": "What is a Pod?"})
+
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "backend_configuration_error"
+    assert "chunk_index.metadata.json" in response.json()["error"]["message"]
 
 
 def test_query_validation_errors_return_json_error_response() -> None:

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from supportdoc_rag_chatbot.app.client import (
+    FixtureGenerationClient,
+    GenerationBackendMode,
+    GenerationFailure,
+    GenerationFailureCode,
+    GenerationRequest,
+    GenerationResult,
+)
+from supportdoc_rag_chatbot.app.core import (
+    ArtifactDenseQueryRetriever,
+    FixtureQueryRetriever,
+    QueryOrchestrator,
+    QueryPipelineConfigurationError,
+    RetrievedEvidenceChunk,
+)
+from supportdoc_rag_chatbot.app.schemas import (
+    CitationRecord,
+    RefusalReasonCode,
+    build_example_answer_response,
+)
+from supportdoc_rag_chatbot.ingestion.jsonl import write_jsonl
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import build_embedding_artifacts
+from supportdoc_rag_chatbot.retrieval.indexes import build_faiss_index_artifacts
+
+
+@dataclass(slots=True)
+class SequenceGenerationClient:
+    responses: Sequence[GenerationResult]
+    backend_mode: GenerationBackendMode = GenerationBackendMode.FIXTURE
+    backend_name: str = "sequence-test"
+    requests: list[GenerationRequest] = field(default_factory=list)
+    _responses: list[GenerationResult] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._responses = list(self.responses)
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        self.requests.append(request)
+        if not self._responses:
+            raise AssertionError("SequenceGenerationClient received more calls than expected")
+        return self._responses.pop(0)
+
+    def close(self) -> None:
+        return None
+
+
+@dataclass(slots=True)
+class FailIfCalledGenerationClient:
+    backend_mode: GenerationBackendMode = GenerationBackendMode.FIXTURE
+    backend_name: str = "fail-if-called"
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        raise AssertionError(f"generation should not be called for request {request!r}")
+
+    def close(self) -> None:
+        return None
+
+
+@dataclass(slots=True)
+class FakeEmbedder:
+    vectors_by_text: dict[str, list[float]]
+    model_name: str = "fake-embedder"
+
+    def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+        return [list(self.vectors_by_text[text]) for text in texts]
+
+
+def test_query_orchestrator_returns_supported_answer_with_fixture_retrieval_and_generation() -> (
+    None
+):
+    orchestrator = QueryOrchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=FixtureGenerationClient(),
+        top_k=3,
+    )
+
+    response = orchestrator.run("What is a Pod?")
+
+    assert response.refusal.is_refusal is False
+    assert (
+        response.citations[0].chunk_id == "content-en-docs-concepts-workloads-pods-pods__chunk-0001"
+    )
+    assert response.final_answer.startswith("A Pod is the smallest deployable unit")
+
+
+def test_query_orchestrator_returns_insufficient_evidence_refusal_without_generation() -> None:
+    single_support_chunk = RetrievedEvidenceChunk(
+        doc_id="content-en-docs-concepts-workloads-pods-pods",
+        chunk_id="content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+        text=(
+            "A Pod is the smallest deployable unit in Kubernetes and can run one or more "
+            "containers that share network and storage resources."
+        ),
+        score=0.97,
+        rank=1,
+        start_offset=0,
+        end_offset=128,
+    )
+    orchestrator = QueryOrchestrator(
+        retriever=FixtureQueryRetriever(
+            hits_by_question={
+                "What is a Pod?": (single_support_chunk,),
+            }
+        ),
+        generation_client=FailIfCalledGenerationClient(),
+        top_k=3,
+    )
+
+    response = orchestrator.run("What is a Pod?")
+
+    assert response.refusal.is_refusal is True
+    assert response.refusal.reason_code is RefusalReasonCode.INSUFFICIENT_EVIDENCE
+    assert response.citations == []
+
+
+def test_query_orchestrator_retries_parse_failure_once_then_refuses() -> None:
+    parse_failure = GenerationResult.from_failure(
+        GenerationFailure(
+            code=GenerationFailureCode.PARSE_ERROR,
+            message="Generation backend returned malformed JSON.",
+            backend_name="sequence-test",
+        )
+    )
+    generation_client = SequenceGenerationClient([parse_failure, parse_failure])
+    orchestrator = QueryOrchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=generation_client,
+        top_k=3,
+    )
+
+    response = orchestrator.run("What is a Pod?")
+
+    assert len(generation_client.requests) == 2
+    assert response.refusal.is_refusal is True
+    assert response.refusal.reason_code is RefusalReasonCode.CITATION_VALIDATION_FAILED
+
+
+def test_query_orchestrator_retries_citation_invalid_output_once_then_refuses() -> None:
+    invalid_response = build_example_answer_response().model_copy(
+        update={
+            "final_answer": (
+                "A Pod is the smallest deployable unit in Kubernetes and can run one or more "
+                "containers that share network and storage resources."
+            )
+        }
+    )
+    generation_client = SequenceGenerationClient(
+        [
+            GenerationResult.success(invalid_response),
+            GenerationResult.success(invalid_response),
+        ]
+    )
+    orchestrator = QueryOrchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=generation_client,
+        top_k=3,
+    )
+
+    response = orchestrator.run("What is a Pod?")
+
+    assert len(generation_client.requests) == 2
+    assert response.refusal.is_refusal is True
+    assert response.refusal.reason_code is RefusalReasonCode.CITATION_VALIDATION_FAILED
+
+
+def test_artifact_dense_query_retriever_returns_ranked_chunks_when_artifacts_exist(
+    tmp_path: Path,
+) -> None:
+    chunks_path = tmp_path / "chunks.jsonl"
+    embedding_metadata_path = tmp_path / "chunk_embeddings.metadata.json"
+    vectors_path = tmp_path / "chunk_embeddings.f32"
+    index_path = tmp_path / "chunk_index.faiss"
+    index_metadata_path = tmp_path / "chunk_index.metadata.json"
+    row_mapping_path = tmp_path / "chunk_index.row_mapping.json"
+    chunk_one = ChunkRecord(
+        snapshot_id="snap-1",
+        doc_id="doc-pods",
+        chunk_id="doc-pods__chunk-0001",
+        section_id="doc-pods__section-0001",
+        section_index=0,
+        chunk_index=0,
+        doc_title="Pods",
+        section_path=["Concepts", "Pods"],
+        source_path="pods.md",
+        source_url="https://example.test/pods",
+        license="CC-BY",
+        attribution="Kubernetes",
+        language="en",
+        start_offset=0,
+        end_offset=24,
+        token_count=4,
+        text="Pod basics and lifecycle.",
+    )
+    chunk_two = ChunkRecord(
+        snapshot_id="snap-1",
+        doc_id="doc-services",
+        chunk_id="doc-services__chunk-0001",
+        section_id="doc-services__section-0001",
+        section_index=0,
+        chunk_index=0,
+        doc_title="Services",
+        section_path=["Concepts", "Services"],
+        source_path="services.md",
+        source_url="https://example.test/services",
+        license="CC-BY",
+        attribution="Kubernetes",
+        language="en",
+        start_offset=0,
+        end_offset=20,
+        token_count=3,
+        text="Service networking overview.",
+    )
+    write_jsonl(chunks_path, [chunk_one, chunk_two])
+    embedder = FakeEmbedder(
+        {
+            chunk_one.text: [1.0, 0.0],
+            chunk_two.text: [0.0, 1.0],
+            "What is a Pod?": [1.0, 0.0],
+        }
+    )
+    build_embedding_artifacts(
+        chunks_path=chunks_path,
+        vectors_path=vectors_path,
+        metadata_path=embedding_metadata_path,
+        embedder=embedder,
+        batch_size=2,
+    )
+    build_faiss_index_artifacts(
+        embedding_metadata_path=embedding_metadata_path,
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+    )
+    retriever = ArtifactDenseQueryRetriever(
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+        embedder=embedder,
+    )
+
+    bundle = retriever.retrieve("What is a Pod?", top_k=2)
+
+    assert [chunk.chunk_id for chunk in bundle.chunks] == [
+        "doc-pods__chunk-0001",
+        "doc-services__chunk-0001",
+    ]
+    assert bundle.chunks[0].score > bundle.chunks[1].score
+    assert bundle.score_normalization.value == "unit_interval"
+
+
+def test_query_orchestrator_raises_clear_error_when_artifact_retrieval_artifacts_are_missing(
+    tmp_path: Path,
+) -> None:
+    orchestrator = QueryOrchestrator(
+        retriever=ArtifactDenseQueryRetriever(
+            index_path=tmp_path / "missing.faiss",
+            metadata_path=tmp_path / "missing.metadata.json",
+            row_mapping_path=tmp_path / "missing.row_mapping.json",
+        ),
+        generation_client=FixtureGenerationClient(),
+        top_k=3,
+    )
+
+    with pytest.raises(
+        QueryPipelineConfigurationError, match="artifact retrieval metadata not found"
+    ):
+        orchestrator.run("What is a Pod?")
+
+
+def test_supported_orchestration_can_validate_custom_artifact_citations() -> None:
+    custom_response = build_example_answer_response().model_copy(
+        update={
+            "citations": [
+                CitationRecord(
+                    marker="[1]",
+                    doc_id="content-en-docs-concepts-workloads-pods-pods",
+                    chunk_id="content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+                    start_offset=0,
+                    end_offset=118,
+                )
+            ]
+        }
+    )
+    generation_client = SequenceGenerationClient([GenerationResult.success(custom_response)])
+    orchestrator = QueryOrchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=generation_client,
+        top_k=3,
+    )
+
+    response = orchestrator.run("What is a Pod?")
+
+    assert response.refusal.is_refusal is False
+    assert len(generation_client.requests) == 1


### PR DESCRIPTION
Closes #63
---

This change replaces the `/query` placeholder path with a real backend orchestration flow.

It adds a single canonical query service under `app/core/` that wires retrieval, retrieval sufficiency gating, prompt rendering, generation, citation validation, retry/refusal behavior, and final `QueryResponse` serialization behind the existing FastAPI route.

The implementation keeps the local developer path deterministic by defaulting API startup to fixture-backed retrieval and fixture-backed generation, while also adding an artifact-backed dense retrieval adapter for later local index-based runs.

---

Added `src/supportdoc_rag_chatbot/app/core/query_service.py` with a `QueryOrchestrator` that:

- runs one request-scoped retrieval step
- evaluates retrieval sufficiency before generation
- builds the canonical trust prompt
- calls the generation client through the existing backend-agnostic interface
- validates returned citations against request-scoped retrieved chunks
- retries once for malformed or citation-invalid model output
- converts exhausted output-quality failures into canonical refusals

Added `src/supportdoc_rag_chatbot/app/core/retrieval.py` with:

- `FixtureQueryRetriever` for deterministic repo-only local smoke testing
- `ArtifactDenseQueryRetriever` for FAISS/chunk-artifact-backed retrieval
- shared retrieval result types for prompting, sufficiency gating, and citation validation
- a canonical `create_query_retriever()` factory

The artifact retriever loads the saved FAISS backend, resolves chunk metadata, normalizes cosine scores into the unit interval expected by the existing sufficiency policy, and fails fast with clear configuration/runtime errors when artifacts are missing or invalid.

Added `src/supportdoc_rag_chatbot/app/core/errors.py` with explicit pipeline exceptions:

- `QueryPipelineConfigurationError`
- `QueryPipelineRuntimeError`

These are now surfaced through the API as deterministic JSON errors instead of being collapsed into a generic placeholder path.

Updated `src/supportdoc_rag_chatbot/app/api/routes/query.py` to use the orchestration service rather than returning a hard-coded refusal.

The FastAPI app now:

- lazily resolves and caches the query orchestrator on app state
- keeps `supportdoc_rag_chatbot.app.api:app` bootable
- closes cached backend resources through the app lifespan handler

Updated `src/supportdoc_rag_chatbot/config.py` so the API can load backend query settings from one place:

- retrieval mode (`fixture` or `artifact`)
- generation mode (`fixture` or `http`)
- optional generation base URL
- generation timeout
- query top-k

Defaults remain deterministic for local smoke runs:

- retrieval mode: `fixture`
- generation mode: `fixture`

Updated `tests/test_api_app.py` and added `tests/test_query_pipeline.py` to cover:

- supported answer path
- `no_relevant_docs` refusal path
- `insufficient_evidence` refusal path
- parse-failure retry then refusal
- citation-validation retry then refusal
- artifact-backed retriever success
- clear artifact-missing failure behavior
- API error envelope behavior for backend configuration errors

---

This is the first end-to-end backend path behind `POST /query`.

It gives the repo a real orchestration seam for later EPIC 6 work without introducing parallel patterns:

- routes stay thin
- orchestration lives in one service
- retrieval remains backend-agnostic
- generation still uses the existing client abstraction
- trust-layer validation remains authoritative before final response emission

It also preserves a deterministic local development path that works without external model infrastructure or committed retrieval artifacts.

---

Executed in repo:

- `uv run pytest -q tests/test_api_app.py tests/test_query_pipeline.py` → **16 passed**
- `uv run pytest -q tests/test_generation_client.py tests/test_inference.py tests/test_prompting.py tests/test_citation_validator.py tests/test_refusal_builder.py tests/test_refusal_policy.py tests/test_trust_schema.py` → **62 passed**
- `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py` → **5 passed**
- `uv run pytest -q` → **122 passed, 3 warnings**
- `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...` → **pass**

---

Changes to be committed:
	modified:   src/supportdoc_rag_chatbot/app/api/__init__.py
	modified:   src/supportdoc_rag_chatbot/app/api/errors.py
	modified:   src/supportdoc_rag_chatbot/app/api/routes/query.py
	modified:   src/supportdoc_rag_chatbot/app/core/__init__.py
	new file:   src/supportdoc_rag_chatbot/app/core/errors.py
	new file:   src/supportdoc_rag_chatbot/app/core/query_service.py
	new file:   src/supportdoc_rag_chatbot/app/core/retrieval.py
	modified:   src/supportdoc_rag_chatbot/config.py
	modified:   tests/test_api_app.py
	new file:   tests/test_query_pipeline.py