### PR TITLE
On branch doc/65-API-smoke-and-integration-tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+
+import pytest
+from fastapi import FastAPI
+
+from supportdoc_rag_chatbot.app.api import create_app
+from supportdoc_rag_chatbot.app.client import GenerationClient
+from supportdoc_rag_chatbot.app.core import (
+    QueryOrchestrator,
+    QueryRetriever,
+    get_request_query_orchestrator,
+)
+from supportdoc_rag_chatbot.config import BackendSettings
+
+API_TEST_SETTINGS = BackendSettings(
+    app_name="SupportDoc API Test App",
+    environment="test",
+    api_version="9.9.9",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    query_retrieval_mode="fixture",
+    query_generation_mode="fixture",
+)
+
+
+@pytest.fixture()
+def api_test_settings() -> BackendSettings:
+    return API_TEST_SETTINGS
+
+
+@pytest.fixture()
+def api_app(api_test_settings: BackendSettings) -> FastAPI:
+    return create_app(settings=api_test_settings)
+
+
+@pytest.fixture()
+def override_query_orchestrator(
+    api_app: FastAPI,
+) -> Iterator[Callable[..., QueryOrchestrator]]:
+    created_orchestrators: list[QueryOrchestrator] = []
+
+    def _override(
+        *,
+        retriever: QueryRetriever,
+        generation_client: GenerationClient,
+        top_k: int = 3,
+        max_generation_attempts: int = 2,
+    ) -> QueryOrchestrator:
+        orchestrator = QueryOrchestrator(
+            retriever=retriever,
+            generation_client=generation_client,
+            top_k=top_k,
+            max_generation_attempts=max_generation_attempts,
+        )
+        api_app.dependency_overrides[get_request_query_orchestrator] = lambda: orchestrator
+        created_orchestrators.append(orchestrator)
+        return orchestrator
+
+    try:
+        yield _override
+    finally:
+        api_app.dependency_overrides.pop(get_request_query_orchestrator, None)
+        for orchestrator in reversed(created_orchestrators):
+            orchestrator.close()

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from supportdoc_rag_chatbot.app.client import (
+    FixtureGenerationClient,
+    GenerationBackendMode,
+    GenerationFailure,
+    GenerationFailureCode,
+    GenerationRequest,
+    GenerationResult,
+)
+from supportdoc_rag_chatbot.app.core import FixtureQueryRetriever
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+from supportdoc_rag_chatbot.logging_conf import REQUEST_ID_HEADER
+
+
+@dataclass(slots=True)
+class FailIfCalledGenerationClient:
+    backend_mode: GenerationBackendMode = GenerationBackendMode.FIXTURE
+    backend_name: str = "fail-if-called"
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        raise AssertionError(f"generation should not be called for request {request!r}")
+
+    def close(self) -> None:
+        return None
+
+
+@dataclass(slots=True)
+class BackendErrorGenerationClient:
+    backend_mode: GenerationBackendMode = GenerationBackendMode.FIXTURE
+    backend_name: str = "backend-error-fixture"
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        del request
+        return GenerationResult.from_failure(
+            GenerationFailure(
+                code=GenerationFailureCode.BACKEND_ERROR,
+                message="Simulated backend failure.",
+                backend_name=self.backend_name,
+                retryable=False,
+            )
+        )
+
+    def close(self) -> None:
+        return None
+
+
+def test_query_success_path_supports_dependency_overrides_with_fixture_backends(
+    api_app: FastAPI,
+    override_query_orchestrator,
+) -> None:
+    override_query_orchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=FixtureGenerationClient(),
+    )
+
+    with TestClient(api_app) as client:
+        response = client.post(
+            "/query",
+            json={"question": "What is a Pod?"},
+            headers={REQUEST_ID_HEADER: "req-api-query-success-001"},
+        )
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "req-api-query-success-001"
+    payload = QueryResponse.model_validate(response.json())
+
+    assert payload.refusal.is_refusal is False
+    assert payload.citations[0].marker == "[1]"
+    assert payload.final_answer.startswith("A Pod is the smallest deployable unit")
+
+
+def test_query_refusal_path_supports_dependency_overrides_without_generation(
+    api_app: FastAPI,
+    override_query_orchestrator,
+) -> None:
+    override_query_orchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=FailIfCalledGenerationClient(),
+    )
+
+    with TestClient(api_app) as client:
+        response = client.post(
+            "/query",
+            json={"question": "How do I reset my laptop BIOS?"},
+        )
+
+    assert response.status_code == 200
+    payload = QueryResponse.model_validate(response.json())
+
+    assert payload.refusal.is_refusal is True
+    assert payload.refusal.reason_code is RefusalReasonCode.NO_RELEVANT_DOCS
+    assert payload.citations == []
+
+
+def test_query_invalid_request_returns_stable_422_error_shape(api_app: FastAPI) -> None:
+    with TestClient(api_app) as client:
+        response = client.post("/query", json={"question": "   "})
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "error": {
+            "code": "request_validation_error",
+            "message": "Request validation failed.",
+            "details": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", "question"],
+                    "msg": "Value error, question must not be blank",
+                    "input": "   ",
+                }
+            ],
+        }
+    }
+
+
+def test_query_backend_error_returns_json_error_envelope(
+    api_app: FastAPI,
+    override_query_orchestrator,
+) -> None:
+    override_query_orchestrator(
+        retriever=FixtureQueryRetriever(),
+        generation_client=BackendErrorGenerationClient(),
+    )
+
+    with TestClient(api_app) as client:
+        response = client.post(
+            "/query",
+            json={"question": "What is a Pod?"},
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "code": "backend_runtime_error",
+            "message": (
+                "Generation backend failed with backend_error: Simulated backend failure. "
+                "(backend=backend-error-fixture)"
+            ),
+            "details": None,
+        }
+    }


### PR DESCRIPTION
Closes #65
---

This change adds the first real API-level smoke and integration tests for the EPIC 6 backend surface.

It exercises the FastAPI app end to end with deterministic local backends and FastAPI dependency overrides instead of any live model service.

- Added `tests/conftest.py` with a canonical API test app fixture and a reusable `override_query_orchestrator` helper.
- Added `tests/test_api_query.py` covering:
  - `/query` success path with fixture retrieval and fixture generation
  - `/query` refusal path that proves generation is skipped when retrieval sufficiency refuses
  - stable `422` request validation behavior
  - backend runtime error behavior with a deterministic failing generation backend
- Preserved and replayed the existing API app, generation client, query pipeline, and structured logging surfaces required by these tests.
- Kept the API contract deterministic and local-only for test execution.

- Proves the FastAPI layer works end to end without external model infrastructure.
- Establishes the canonical dependency override pattern for future API tests.
- Covers stable request validation and backend error envelopes at the HTTP boundary.
- Gives EPIC 6 a deterministic local `POST /query` round trip for smoke coverage.

- Scoped API tests:
  - `uv run pytest -q tests/test_api_app.py tests/test_api_query.py tests/test_api_logging.py`
  - Result: `17 passed`
- Dependent shared-module tests:
  - `uv run pytest -q tests/test_query_pipeline.py tests/test_generation_client.py tests/test_inference.py`
  - Result: `18 passed, 3 warnings`
- Full suite:
  - `uv run pytest -q`
  - Result: `130 passed, 3 warnings`
- Trust schema smoke:
  - `uv run python -m supportdoc_rag_chatbot smoke-trust-schema --schema docs/contracts/query_response.schema.json --answer-fixture docs/contracts/query_response.answer.example.json --refusal-fixture docs/contracts/query_response.refusal.example.json`
  - Result: `ok`

---

Changes to be committed:
	new file:   tests/conftest.py
	new file:   tests/test_api_query.py