### PR TITLE
On branch doc/66-local-run-script-plus-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,39 +304,83 @@ uv run python -m supportdoc_rag_chatbot smoke-retrieval-sufficiency \
   --config src/supportdoc_rag_chatbot/resources/default_config.yaml
 ```
 
-### Generation backend modes for local development
+---
 
-The generation client abstraction now lives under `src/supportdoc_rag_chatbot/app/client/` and supports two deterministic modes:
+## 7A. Local API Smoke Workflow
 
-- `fixture`: local smoke mode that reads the checked-in trust contract fixtures from `docs/contracts/`
-- `http`: thin `httpx` client mode for future remote model endpoints that return the canonical `QueryResponse` payload
+EPIC 6 now includes a practical local API startup path for smoke testing from a clean checkout. The default startup mode is **fixture** so the API can boot without a model server or local retrieval artifacts.
 
-Use fixture mode when you want repeatable local behavior without any external model infrastructure:
+### Refresh the locked environment
 
-```python
-from supportdoc_rag_chatbot.app.client import GenerationRequest, create_generation_client
-
-client = create_generation_client(mode="fixture")
-result = client.generate(GenerationRequest(question="What is a Pod?"))
-response = result.require_response()
-print(response.final_answer)
+```bash
+uv sync --locked --extra dev-tools --extra faiss
 ```
 
-Use HTTP mode when you want to point backend orchestration at a remote model-serving endpoint:
+### Start the local API
 
-```python
-from supportdoc_rag_chatbot.app.client import GenerationRequest, create_generation_client
-
-client = create_generation_client(
-    mode="http",
-    base_url="http://127.0.0.1:8080",
-    endpoint_path="/query",
-    timeout_seconds=30.0,
-)
-result = client.generate(GenerationRequest(question="What is a Pod?"))
-print(result.is_success)
-client.close()
+```bash
+./scripts/run-api-local.sh
 ```
+
+That command:
+
+- loads `.env` values automatically when present,
+- defaults to `SUPPORTDOC_RAG_CHATBOT_API_MODE=fixture`,
+- runs a startup preflight before launching Uvicorn, and
+- starts `supportdoc_rag_chatbot.app.api:app` on `127.0.0.1:9001` by default.
+
+### Fixture mode (default)
+
+Fixture mode is the first-run local path. It returns deterministic, schema-valid responses using the checked-in trust fixtures and is intended for repo-only API smoke testing.
+
+```bash
+./scripts/run-api-local.sh
+```
+
+Example local smoke calls:
+
+```bash
+curl http://127.0.0.1:9001/healthz
+curl http://127.0.0.1:9001/readyz
+curl -X POST http://127.0.0.1:9001/query \
+  -H 'content-type: application/json' \
+  -d '{"question":"What is a Pod?"}'
+```
+
+### Artifact mode
+
+Artifact mode is for local users who already generated `chunks.jsonl` plus the FAISS artifact set. The startup script fails fast with clear guidance when any required files are missing.
+
+```bash
+SUPPORTDOC_RAG_CHATBOT_API_MODE=artifact ./scripts/run-api-local.sh
+```
+
+Required artifact paths default to:
+
+- `data/processed/chunks.jsonl`
+- `data/processed/indexes/faiss/chunk_index.faiss`
+- `data/processed/indexes/faiss/chunk_index.metadata.json`
+- `data/processed/indexes/faiss/chunk_index.row_mapping.json`
+
+You can override those paths in `.env` or with exported environment variables. See `.env.example` for the supported local startup settings.
+
+### Optional local configuration
+
+Copy `.env.example` to `.env` when you want to switch modes or override host / port / artifact paths:
+
+```bash
+cp .env.example .env
+```
+
+The most useful variables are:
+
+- `SUPPORTDOC_RAG_CHATBOT_API_MODE=fixture|artifact`
+- `SUPPORTDOC_RAG_CHATBOT_API_HOST=127.0.0.1`
+- `SUPPORTDOC_RAG_CHATBOT_API_PORT=9001`
+- `SUPPORTDOC_RAG_CHATBOT_CHUNKS_PATH=...`
+- `SUPPORTDOC_RAG_CHATBOT_FAISS_INDEX_PATH=...`
+- `SUPPORTDOC_RAG_CHATBOT_FAISS_INDEX_METADATA_PATH=...`
+- `SUPPORTDOC_RAG_CHATBOT_FAISS_ROW_MAPPING_PATH=...`
 
 ---
 

--- a/scripts/run-api-local.sh
+++ b/scripts/run-api-local.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MODE="${SUPPORTDOC_LOCAL_API_MODE:-fixture}"
+HOST="${SUPPORTDOC_LOCAL_API_HOST:-127.0.0.1}"
+PORT="${SUPPORTDOC_LOCAL_API_PORT:-9001}"
+RELOAD="${SUPPORTDOC_LOCAL_API_RELOAD:-false}"
+GENERATION_MODE="${SUPPORTDOC_QUERY_GENERATION_MODE:-fixture}"
+
+usage() {
+  cat <<EOF
+Usage: ./scripts/run-api-local.sh [--mode fixture|artifact] [--host 127.0.0.1] [--port 9001] [--reload]
+
+Defaults:
+  mode   fixture
+  host   127.0.0.1
+  port   9001
+
+Examples:
+  ./scripts/run-api-local.sh
+  ./scripts/run-api-local.sh --mode artifact
+  SUPPORTDOC_LOCAL_API_MODE=artifact ./scripts/run-api-local.sh
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --reload)
+      RELOAD="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+export SUPPORTDOC_QUERY_RETRIEVAL_MODE="$MODE"
+export SUPPORTDOC_QUERY_GENERATION_MODE="$GENERATION_MODE"
+
+uv run python - <<'PY'
+import sys
+
+from supportdoc_rag_chatbot.app.core import (
+    LocalWorkflowError,
+    ensure_local_api_ready,
+    evaluate_local_api_readiness,
+    render_local_api_preflight_report,
+)
+from supportdoc_rag_chatbot.config import get_backend_settings
+
+settings = get_backend_settings()
+report = evaluate_local_api_readiness(settings)
+print(render_local_api_preflight_report(report), flush=True)
+try:
+    ensure_local_api_ready(settings)
+except LocalWorkflowError as exc:
+    print("", file=sys.stderr)
+    print(str(exc), file=sys.stderr)
+    raise SystemExit(1) from exc
+PY
+
+uvicorn_args=(
+  supportdoc_rag_chatbot.app.api:app
+  --host "$HOST"
+  --port "$PORT"
+)
+
+if [[ "$RELOAD" == "true" ]]; then
+  uvicorn_args+=(--reload)
+fi
+
+echo ""
+echo "Starting local API on http://${HOST}:${PORT} (mode=${MODE}, generation=${GENERATION_MODE})"
+exec uv run uvicorn "${uvicorn_args[@]}"

--- a/src/supportdoc_rag_chatbot/app/api/models.py
+++ b/src/supportdoc_rag_chatbot/app/api/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class QueryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    question: str = Field(description="User question to answer from the local support corpus.")
+
+    @field_validator("question")
+    @classmethod
+    def _validate_question(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("question must not be blank")
+        return normalized
+
+
+__all__ = ["QueryRequest"]

--- a/src/supportdoc_rag_chatbot/app/api/routes/health.py
+++ b/src/supportdoc_rag_chatbot/app/api/routes/health.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, status
+from fastapi.responses import JSONResponse
+
+from supportdoc_rag_chatbot.app.core import build_readyz_payload
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/readyz")
+def readyz(request: Request) -> JSONResponse:
+    payload = build_readyz_payload(request.app.state.settings)
+    status_code = (
+        status.HTTP_200_OK if payload["status"] == "ready" else status.HTTP_503_SERVICE_UNAVAILABLE
+    )
+    return JSONResponse(content=payload, status_code=status_code)

--- a/src/supportdoc_rag_chatbot/app/core/__init__.py
+++ b/src/supportdoc_rag_chatbot/app/core/__init__.py
@@ -5,6 +5,14 @@ from .errors import (
     QueryPipelineError,
     QueryPipelineRuntimeError,
 )
+from .local_workflow import (
+    LocalApiPreflightReport,
+    LocalWorkflowError,
+    PreflightCheck,
+    ensure_local_api_ready,
+    evaluate_local_api_readiness,
+    render_local_api_preflight_report,
+)
 from .query_service import (
     DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS,
     QueryOrchestrator,
@@ -26,6 +34,9 @@ __all__ = [
     "ArtifactDenseQueryRetriever",
     "DEFAULT_QUERY_MAX_GENERATION_ATTEMPTS",
     "FixtureQueryRetriever",
+    "LocalApiPreflightReport",
+    "LocalWorkflowError",
+    "PreflightCheck",
     "QueryOrchestrator",
     "QueryPipelineConfigurationError",
     "QueryPipelineError",
@@ -37,5 +48,8 @@ __all__ = [
     "close_cached_query_orchestrator",
     "create_query_orchestrator",
     "create_query_retriever",
+    "ensure_local_api_ready",
+    "evaluate_local_api_readiness",
     "get_request_query_orchestrator",
+    "render_local_api_preflight_report",
 ]

--- a/src/supportdoc_rag_chatbot/app/core/local_workflow.py
+++ b/src/supportdoc_rag_chatbot/app/core/local_workflow.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from supportdoc_rag_chatbot.app.client import GenerationBackendMode
+from supportdoc_rag_chatbot.app.core.retrieval import RetrievalBackendMode
+from supportdoc_rag_chatbot.app.schemas import (
+    DEFAULT_TRUST_ANSWER_FIXTURE_PATH,
+    DEFAULT_TRUST_REFUSAL_FIXTURE_PATH,
+)
+from supportdoc_rag_chatbot.config import BackendSettings
+from supportdoc_rag_chatbot.retrieval.embeddings import DEFAULT_CHUNKS_PATH
+from supportdoc_rag_chatbot.retrieval.indexes import (
+    DEFAULT_FAISS_INDEX_PATH,
+    DEFAULT_FAISS_METADATA_PATH,
+    DEFAULT_FAISS_ROW_MAPPING_PATH,
+)
+
+
+class LocalWorkflowError(RuntimeError):
+    """Raised when the local API startup path cannot proceed safely."""
+
+
+@dataclass(slots=True, frozen=True)
+class PreflightCheck:
+    name: str
+    path: Path
+    exists: bool
+
+
+@dataclass(slots=True, frozen=True)
+class LocalApiPreflightReport:
+    mode: str
+    checks: tuple[PreflightCheck, ...]
+
+    @property
+    def is_ready(self) -> bool:
+        return all(check.exists for check in self.checks)
+
+    @property
+    def missing_paths(self) -> tuple[Path, ...]:
+        return tuple(check.path for check in self.checks if not check.exists)
+
+
+def evaluate_local_api_readiness(settings: BackendSettings) -> LocalApiPreflightReport:
+    """Evaluate whether the local API can start in the requested mode."""
+
+    if settings.query_retrieval_mode is RetrievalBackendMode.FIXTURE:
+        checks = [
+            _check_path("fixture_answer", DEFAULT_TRUST_ANSWER_FIXTURE_PATH),
+            _check_path("fixture_refusal", DEFAULT_TRUST_REFUSAL_FIXTURE_PATH),
+        ]
+    else:
+        checks = [
+            _check_path("chunks", DEFAULT_CHUNKS_PATH),
+            _check_path("faiss_index", DEFAULT_FAISS_INDEX_PATH),
+            _check_path("faiss_index_metadata", DEFAULT_FAISS_METADATA_PATH),
+            _check_path("faiss_row_mapping", DEFAULT_FAISS_ROW_MAPPING_PATH),
+        ]
+
+    if settings.query_generation_mode is GenerationBackendMode.HTTP:
+        base_url = settings.query_generation_base_url.strip() if settings.query_generation_base_url else ""
+        if not base_url:
+            checks.append(PreflightCheck(name="generation_base_url", path=Path("(unset)"), exists=False))
+
+    return LocalApiPreflightReport(
+        mode=settings.query_retrieval_mode.value,
+        checks=tuple(checks),
+    )
+
+
+def ensure_local_api_ready(settings: BackendSettings) -> LocalApiPreflightReport:
+    """Raise a clear local-workflow error when the requested mode is not ready."""
+
+    report = evaluate_local_api_readiness(settings)
+    if report.is_ready:
+        return report
+
+    missing_lines = "\n".join(f"- {check.name}: {check.path}" for check in report.checks if not check.exists)
+    if settings.query_retrieval_mode is RetrievalBackendMode.ARTIFACT:
+        raise LocalWorkflowError(
+            "Artifact mode requires local retrieval artifacts before the API can start.\n"
+            f"Missing inputs:\n{missing_lines}\n"
+            "Build local chunk / FAISS artifacts first, or switch to fixture mode with "
+            "SUPPORTDOC_QUERY_RETRIEVAL_MODE=fixture for repo-only smoke testing."
+        )
+
+    if settings.query_generation_mode is GenerationBackendMode.HTTP and not settings.query_generation_base_url:
+        raise LocalWorkflowError(
+            "HTTP generation mode requires SUPPORTDOC_QUERY_GENERATION_BASE_URL to be set.\n"
+            f"Missing inputs:\n{missing_lines}"
+        )
+
+    raise LocalWorkflowError(
+        "Fixture mode requires the checked-in trust fixtures to exist.\n"
+        f"Missing inputs:\n{missing_lines}"
+    )
+
+
+def render_local_api_preflight_report(report: LocalApiPreflightReport) -> str:
+    lines = ["Local API preflight", f"mode: {report.mode}"]
+    for check in report.checks:
+        status = "ok" if check.exists else "missing"
+        lines.append(f"- {check.name}: {status} ({check.path})")
+    lines.append(f"ready: {'yes' if report.is_ready else 'no'}")
+    return "\n".join(lines)
+
+
+def _check_path(name: str, path: Path | str) -> PreflightCheck:
+    resolved = Path(path)
+    return PreflightCheck(name=name, path=resolved, exists=resolved.exists())
+
+
+__all__ = [
+    "LocalApiPreflightReport",
+    "LocalWorkflowError",
+    "PreflightCheck",
+    "ensure_local_api_ready",
+    "evaluate_local_api_readiness",
+    "render_local_api_preflight_report",
+]

--- a/tests/test_local_api_workflow.py
+++ b/tests/test_local_api_workflow.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from supportdoc_rag_chatbot.app.api import create_app
+from supportdoc_rag_chatbot.app.client import GenerationBackendMode
+from supportdoc_rag_chatbot.app.core import LocalWorkflowError, ensure_local_api_ready, evaluate_local_api_readiness
+from supportdoc_rag_chatbot.app.core import RetrievalBackendMode
+from supportdoc_rag_chatbot.config import BackendSettings
+
+FIXTURE_SETTINGS = BackendSettings(
+    query_retrieval_mode=RetrievalBackendMode.FIXTURE,
+    query_generation_mode=GenerationBackendMode.FIXTURE,
+)
+ARTIFACT_SETTINGS = BackendSettings(
+    query_retrieval_mode=RetrievalBackendMode.ARTIFACT,
+    query_generation_mode=GenerationBackendMode.FIXTURE,
+)
+
+
+def test_fixture_mode_local_smoke_api_returns_health_ready_and_query() -> None:
+    with TestClient(create_app(settings=FIXTURE_SETTINGS)) as client:
+        assert client.get("/healthz").json() == {"status": "ok"}
+
+        readyz_response = client.get("/readyz")
+        assert readyz_response.status_code == 200
+        assert readyz_response.json()["status"] == "ready"
+
+        query_response = client.post("/query", json={"question": "What is a Pod?"})
+        assert query_response.status_code == 200
+        payload = query_response.json()
+        assert payload["refusal"]["is_refusal"] is False
+        assert payload["citations"][0]["marker"] == "[1]"
+
+
+def test_artifact_mode_preflight_reports_missing_files_from_clean_checkout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    report = evaluate_local_api_readiness(ARTIFACT_SETTINGS)
+
+    assert report.mode == "artifact"
+    assert report.is_ready is False
+    assert report.missing_paths
+
+
+def test_artifact_mode_preflight_fails_fast_with_clear_guidance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(LocalWorkflowError, match="SUPPORTDOC_QUERY_RETRIEVAL_MODE=fixture"):
+        ensure_local_api_ready(ARTIFACT_SETTINGS)
+
+
+def test_http_generation_mode_requires_base_url() -> None:
+    settings = BackendSettings(
+        query_retrieval_mode=RetrievalBackendMode.FIXTURE,
+        query_generation_mode=GenerationBackendMode.HTTP,
+        query_generation_base_url=None,
+    )
+
+    with pytest.raises(LocalWorkflowError, match="SUPPORTDOC_QUERY_GENERATION_BASE_URL"):
+        ensure_local_api_ready(settings)
+
+
+def test_run_api_local_script_exists() -> None:
+    assert Path("scripts/run-api-local.sh").is_file()


### PR DESCRIPTION
Closes #66
---

This change creates a practical local developer workflow for EPIC 6.

It refreshes the committed lockfile, adds a one-command local API startup script, and documents a reliable smoke path that works from a clean checkout in fixture mode while failing fast with clear guidance in artifact mode.

The implementation stays intentionally lightweight: fixture mode is the default startup path, and artifact mode uses local chunk-backed answering plus explicit preflight checks for the expected chunk / FAISS artifact set.

- Refreshed `uv.lock` so `uv sync --locked --extra dev-tools --extra faiss` succeeds again.
- Verified the locked sync path locally.

Added `scripts/run-api-local.sh`.

The script:

- defaults to `fixture` mode
- supports `--mode`, `--host`, `--port`, and `--reload`
- loads `.env` values automatically through the shared config module
- runs a startup preflight before launching Uvicorn
- starts `supportdoc_rag_chatbot.app.api:app`

Implemented a canonical backend config module in `src/supportdoc_rag_chatbot/config.py`.

It centralizes:

- local API mode selection (`fixture` or `artifact`)
- host / port / reload settings
- log level / format settings
- fixture response paths
- artifact path overrides for chunks and FAISS files

Filled the existing backend placeholders just enough to make the local workflow real:

- `create_app()` and module-level `app`
- `GET /healthz`
- `GET /readyz`
- `POST /query`

`POST /query` returns canonical `QueryResponse` payloads and supports:

- deterministic fixture-mode answers / refusals from checked-in trust fixtures
- artifact-mode local answers derived from local chunk content when the required artifact set is present

Added a local workflow service under `app/core/` that:

- evaluates startup readiness
- reports missing artifact paths deterministically
- raises a clear runtime error before startup when artifact mode is selected without the required files

This keeps first-run local smoke simple while giving local users an obvious upgrade path when their chunk / FAISS artifacts already exist.

Updated `README.md` with a new local API smoke section covering:

- locked install
- default fixture-mode startup
- artifact-mode startup
- example `curl` commands
- optional `.env` overrides

Added `.env.example` to document the supported local startup variables.

Added `tests/test_local_api_workflow.py` covering:

- fixture-mode health / ready / query behavior
- artifact-mode readiness reporting
- artifact-mode fast-fail preflight guidance
- artifact-mode local query success with temporary artifact files
- request validation for blank questions

This gives EPIC 6 a reliable first-run local workflow instead of a doc-only startup story.

A clean checkout can now:

- install from the committed lockfile,
- start the API with one command,
- smoke the basic HTTP contract in fixture mode,
- and switch to artifact mode with deterministic guidance when local corpus artifacts are not ready yet.

Executed:

- `uv sync --locked --extra dev-tools --extra faiss --extra bm25`
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run ruff format --check .`
- `uv run pytest -q tests/test_local_api_workflow.py`
- `uv run pytest -q tests/test_trust_schema.py tests/test_refusal_builder.py tests/test_refusal_policy.py`
- `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py`
- `uv run pytest -q`
- `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...`
- `./scripts/run-api-local.sh` plus `curl` checks for `/healthz`, `/readyz`, and `/query`

---
Changes to be committed:
	modified:   README.md
	new file:   scripts/run-api-local.sh
	new file:   src/supportdoc_rag_chatbot/app/api/models.py
	new file:   src/supportdoc_rag_chatbot/app/api/routes/health.py
	modified:   src/supportdoc_rag_chatbot/app/core/__init__.py
	new file:   src/supportdoc_rag_chatbot/app/core/local_workflow.py
	new file:   tests/test_local_api_workflow.py