### PR TITLE
On branch infra/75-fix-lockfile-and-local_startup_docs_drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,7 @@ uv sync --locked --extra dev-tools --extra faiss
 
 That command:
 
-- loads `.env` values automatically when present,
-- defaults to `SUPPORTDOC_RAG_CHATBOT_API_MODE=fixture`,
+- defaults to `SUPPORTDOC_LOCAL_API_MODE=fixture`,
 - runs a startup preflight before launching Uvicorn, and
 - starts `supportdoc_rag_chatbot.app.api:app` on `127.0.0.1:9001` by default.
 
@@ -352,35 +351,47 @@ curl -X POST http://127.0.0.1:9001/query \
 Artifact mode is for local users who already generated `chunks.jsonl` plus the FAISS artifact set. The startup script fails fast with clear guidance when any required files are missing.
 
 ```bash
-SUPPORTDOC_RAG_CHATBOT_API_MODE=artifact ./scripts/run-api-local.sh
+SUPPORTDOC_LOCAL_API_MODE=artifact ./scripts/run-api-local.sh
 ```
 
-Required artifact paths default to:
+Required artifact paths currently use the fixed local defaults from the retrieval modules:
 
 - `data/processed/chunks.jsonl`
 - `data/processed/indexes/faiss/chunk_index.faiss`
 - `data/processed/indexes/faiss/chunk_index.metadata.json`
 - `data/processed/indexes/faiss/chunk_index.row_mapping.json`
 
-You can override those paths in `.env` or with exported environment variables. See `.env.example` for the supported local startup settings.
+Artifact path overrides are not currently supported by `./scripts/run-api-local.sh` or `BackendSettings`, so local artifact-mode startup expects those default locations.
 
 ### Optional local configuration
 
-Copy `.env.example` to `.env` when you want to switch modes or override host / port / artifact paths:
+Set shell-wrapper options with flags or exported environment variables:
+
+- `SUPPORTDOC_LOCAL_API_MODE=fixture|artifact`
+- `SUPPORTDOC_LOCAL_API_HOST=127.0.0.1`
+- `SUPPORTDOC_LOCAL_API_PORT=9001`
+- `SUPPORTDOC_LOCAL_API_RELOAD=true|false`
+
+Backend settings are loaded by `src/supportdoc_rag_chatbot/config.py` and use these environment variable names:
+
+- `SUPPORTDOC_API_TITLE=SupportDoc RAG Chatbot API`
+- `SUPPORTDOC_ENV=local`
+- `SUPPORTDOC_API_VERSION=0.1.0`
+- `SUPPORTDOC_API_DOCS_URL=/docs`
+- `SUPPORTDOC_API_REDOC_URL=/redoc`
+- `SUPPORTDOC_QUERY_RETRIEVAL_MODE=fixture|artifact`
+- `SUPPORTDOC_QUERY_GENERATION_MODE=fixture|http`
+- `SUPPORTDOC_QUERY_GENERATION_BASE_URL=http://127.0.0.1:8080`
+- `SUPPORTDOC_QUERY_GENERATION_TIMEOUT_SECONDS=30`
+- `SUPPORTDOC_QUERY_TOP_K=3`
+
+For example, to point the API at an HTTP generation backend:
 
 ```bash
-cp .env.example .env
+SUPPORTDOC_QUERY_GENERATION_MODE=http \
+SUPPORTDOC_QUERY_GENERATION_BASE_URL=http://127.0.0.1:8080 \
+./scripts/run-api-local.sh
 ```
-
-The most useful variables are:
-
-- `SUPPORTDOC_RAG_CHATBOT_API_MODE=fixture|artifact`
-- `SUPPORTDOC_RAG_CHATBOT_API_HOST=127.0.0.1`
-- `SUPPORTDOC_RAG_CHATBOT_API_PORT=9001`
-- `SUPPORTDOC_RAG_CHATBOT_CHUNKS_PATH=...`
-- `SUPPORTDOC_RAG_CHATBOT_FAISS_INDEX_PATH=...`
-- `SUPPORTDOC_RAG_CHATBOT_FAISS_INDEX_METADATA_PATH=...`
-- `SUPPORTDOC_RAG_CHATBOT_FAISS_ROW_MAPPING_PATH=...`
 
 ---
 

--- a/src/supportdoc_rag_chatbot/app/core/local_workflow.py
+++ b/src/supportdoc_rag_chatbot/app/core/local_workflow.py
@@ -60,9 +60,13 @@ def evaluate_local_api_readiness(settings: BackendSettings) -> LocalApiPreflight
         ]
 
     if settings.query_generation_mode is GenerationBackendMode.HTTP:
-        base_url = settings.query_generation_base_url.strip() if settings.query_generation_base_url else ""
+        base_url = (
+            settings.query_generation_base_url.strip() if settings.query_generation_base_url else ""
+        )
         if not base_url:
-            checks.append(PreflightCheck(name="generation_base_url", path=Path("(unset)"), exists=False))
+            checks.append(
+                PreflightCheck(name="generation_base_url", path=Path("(unset)"), exists=False)
+            )
 
     return LocalApiPreflightReport(
         mode=settings.query_retrieval_mode.value,
@@ -77,7 +81,9 @@ def ensure_local_api_ready(settings: BackendSettings) -> LocalApiPreflightReport
     if report.is_ready:
         return report
 
-    missing_lines = "\n".join(f"- {check.name}: {check.path}" for check in report.checks if not check.exists)
+    missing_lines = "\n".join(
+        f"- {check.name}: {check.path}" for check in report.checks if not check.exists
+    )
     if settings.query_retrieval_mode is RetrievalBackendMode.ARTIFACT:
         raise LocalWorkflowError(
             "Artifact mode requires local retrieval artifacts before the API can start.\n"
@@ -86,7 +92,10 @@ def ensure_local_api_ready(settings: BackendSettings) -> LocalApiPreflightReport
             "SUPPORTDOC_QUERY_RETRIEVAL_MODE=fixture for repo-only smoke testing."
         )
 
-    if settings.query_generation_mode is GenerationBackendMode.HTTP and not settings.query_generation_base_url:
+    if (
+        settings.query_generation_mode is GenerationBackendMode.HTTP
+        and not settings.query_generation_base_url
+    ):
         raise LocalWorkflowError(
             "HTTP generation mode requires SUPPORTDOC_QUERY_GENERATION_BASE_URL to be set.\n"
             f"Missing inputs:\n{missing_lines}"

--- a/tests/test_local_api_workflow.py
+++ b/tests/test_local_api_workflow.py
@@ -7,8 +7,12 @@ from fastapi.testclient import TestClient
 
 from supportdoc_rag_chatbot.app.api import create_app
 from supportdoc_rag_chatbot.app.client import GenerationBackendMode
-from supportdoc_rag_chatbot.app.core import LocalWorkflowError, ensure_local_api_ready, evaluate_local_api_readiness
-from supportdoc_rag_chatbot.app.core import RetrievalBackendMode
+from supportdoc_rag_chatbot.app.core import (
+    LocalWorkflowError,
+    RetrievalBackendMode,
+    ensure_local_api_ready,
+    evaluate_local_api_readiness,
+)
 from supportdoc_rag_chatbot.config import BackendSettings
 
 FIXTURE_SETTINGS = BackendSettings(
@@ -36,7 +40,9 @@ def test_fixture_mode_local_smoke_api_returns_health_ready_and_query() -> None:
         assert payload["citations"][0]["marker"] == "[1]"
 
 
-def test_artifact_mode_preflight_reports_missing_files_from_clean_checkout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_artifact_mode_preflight_reports_missing_files_from_clean_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     report = evaluate_local_api_readiness(ARTIFACT_SETTINGS)
@@ -46,7 +52,9 @@ def test_artifact_mode_preflight_reports_missing_files_from_clean_checkout(tmp_p
     assert report.missing_paths
 
 
-def test_artifact_mode_preflight_fails_fast_with_clear_guidance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_artifact_mode_preflight_fails_fast_with_clear_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(LocalWorkflowError, match="SUPPORTDOC_QUERY_RETRIEVAL_MODE=fixture"):


### PR DESCRIPTION
Close #75
---

This PR brings the repo back to a clean-checkout state for the local API smoke workflow. It refreshes the locked dependency set, fixes the remaining Ruff drift in the local workflow module/tests, and updates the README so the documented startup/config environment variables match the code that is actually present in the repo.

- Refreshed `uv.lock` so locked sync works again from a clean checkout.
- Fixed the outstanding Ruff lint/format drift in:
  - `tests/test_local_api_workflow.py`
  - `src/supportdoc_rag_chatbot/app/core/local_workflow.py`
- Updated the README local API section to match the real startup/config surface:
  - `SUPPORTDOC_LOCAL_API_*` for the shell wrapper
  - `SUPPORTDOC_API_*` and `SUPPORTDOC_QUERY_*` for backend settings
- Removed stale `.env.example` / artifact-path-override guidance that is not implemented by the current local startup path.

- `uv sync --locked` is aligned with the committed project metadata again.
- Repo docs now match the actual startup/config names in `scripts/run-api-local.sh` and `src/supportdoc_rag_chatbot/config.py`.
- CI commands remain valid without introducing a parallel config pattern.
- Existing public exports, CLI commands, schemas, fixtures, and snapshots remain unchanged.

- Ordered task verification completed:
  - `uv run pytest -q tests/test_local_api_workflow.py`
  - `uv run pytest -q tests/test_api_app.py tests/test_api_query.py tests/test_api_logging.py`
  - `uv run pytest -q`
- Required repo verification completed:
  - `uv sync --locked --extra dev-tools --extra faiss --extra bm25`
  - `uv run ruff check . --fix`
  - `uv run ruff format .`
  - `uv run ruff format --check .`
  - `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py`
  - `uv run pytest -q`
  - `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...`
- Overlay validation completed on a fresh unzip of the provided repo ZIP:
  - applied the changed-files ZIP
  - ran `uv run pytest -q`
  - ran CLI smoke checks
  - booted `./scripts/run-api-local.sh` in fixture mode and verified `/healthz`, `/readyz`, and `/query`

---

Changes to be committed:
	modified:   README.md
	modified:   src/supportdoc_rag_chatbot/app/core/local_workflow.py
	modified:   tests/test_local_api_workflow.py