### PR TITLE
On branch infra/79-add-container-build-smoke-check-to-CI

### DIFF
--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,0 +1,60 @@
+name: container-smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  container-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      # Local equivalent:
+      #   docker compose up --build -d
+      #   curl http://127.0.0.1:9001/healthz
+      #   curl http://127.0.0.1:9001/readyz
+      - name: Build backend image
+        run: docker build -f docker/backend.Dockerfile -t supportdoc-rag-chatbot-api:ci .
+
+      - name: Start backend container in fixture mode
+        run: |
+          docker run -d --rm \
+            --name supportdoc-api \
+            -p 9001:9001 \
+            -e SUPPORTDOC_LOCAL_API_MODE=fixture \
+            -e SUPPORTDOC_LOCAL_API_HOST=0.0.0.0 \
+            -e SUPPORTDOC_LOCAL_API_PORT=9001 \
+            -e SUPPORTDOC_QUERY_GENERATION_MODE=fixture \
+            supportdoc-rag-chatbot-api:ci
+
+      - name: Wait for /healthz
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:9001/healthz; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Container did not become healthy in time." >&2
+          docker logs supportdoc-api || true
+          exit 1
+
+      - name: Smoke /readyz
+        run: curl --fail --silent --show-error http://127.0.0.1:9001/readyz
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs supportdoc-api || true
+
+      - name: Stop backend container
+        if: always()
+        run: docker rm -f supportdoc-api || true

--- a/tests/test_container_ci_workflow.py
+++ b/tests/test_container_ci_workflow.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_container_smoke_workflow_builds_fixture_image_and_probes_health_endpoints() -> None:
+    workflow = Path(".github/workflows/container-smoke.yml")
+    assert workflow.is_file()
+
+    content = workflow.read_text(encoding="utf-8")
+    assert "name: container-smoke" in content
+    assert "pull_request:" in content
+    assert "docker build -f docker/backend.Dockerfile" in content
+    assert "--name supportdoc-api" in content
+    assert "SUPPORTDOC_LOCAL_API_MODE=fixture" in content
+    assert "SUPPORTDOC_QUERY_GENERATION_MODE=fixture" in content
+    assert "http://127.0.0.1:9001/healthz" in content
+    assert "http://127.0.0.1:9001/readyz" in content
+    assert "docker logs supportdoc-api" in content
+
+
+def test_container_smoke_workflow_documents_local_equivalent_commands() -> None:
+    workflow = Path(".github/workflows/container-smoke.yml")
+    content = workflow.read_text(encoding="utf-8")
+
+    assert "Local equivalent:" in content
+    assert "docker compose up --build -d" in content
+    assert "curl http://127.0.0.1:9001/healthz" in content


### PR DESCRIPTION
Closes #79
---

Add a lightweight GitHub Actions workflow that builds the committed backend container image and runs a minimal fixture-mode smoke check against the local API endpoints. This keeps the container packaging path exercised alongside the existing lint and pytest workflows without introducing a second boot path.

- Added `.github/workflows/container-smoke.yml`
  - runs on pull requests and pushes to `main`
  - builds `docker/backend.Dockerfile`
  - starts the backend container in fixture mode
  - waits for `http://127.0.0.1:9001/healthz`
  - probes `http://127.0.0.1:9001/readyz`
  - dumps container logs on failure
  - always cleans up the container
- Added `tests/test_container_ci_workflow.py`
  - verifies the workflow file exists
  - verifies the workflow builds the committed Dockerfile
  - verifies fixture-mode startup and health endpoint probes are present
  - verifies the workflow comments include the local-equivalent smoke commands

The repo already has Docker packaging for the backend API, but CI only covered Python lint/test paths. This workflow closes that gap by validating that the container image still builds and that the API actually boots far enough to serve health endpoints in the same fixture-mode path used for local smoke testing.

- `uv run pytest -q tests/test_container_ci_workflow.py`
- `uv run pytest -q tests/test_container_packaging.py`
- `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py`
- `uv run pytest -q`
- `uv run python -m supportdoc_rag_chatbot smoke-trust-schema --schema docs/contracts/query_response.schema.json --answer-fixture docs/contracts/query_response.answer.example.json --refusal-fixture docs/contracts/query_response.refusal.example.json`
- `uv run python -m supportdoc_rag_chatbot --help`
- local fixture-mode API smoke via `./scripts/run-api-local.sh` with `/healthz`, `/readyz`, and `/query`

---
Changes to be committed:
	new file:   .github/workflows/container-smoke.yml
	new file:   tests/test_container_ci_workflow.py