### PR TITLE
On branch infra/87-add-container-runtime-smoke-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,19 @@ The image:
 - defines a `/healthz` container healthcheck, and
 - runs as the non-root `supportdoc` user.
 
+### Canonical runtime smoke command
+
+The CI build smoke proves that `docker/backend.Dockerfile` still builds. The runtime smoke below is the canonical **packaged-runtime** proof: it builds the checked-in image, starts it in fixture mode with `docker run`, waits for the container healthcheck, validates `GET /healthz` and `GET /readyz`, then checks one supported and one refusal `POST /query` response against the canonical `QueryResponse` contract.
+
+```bash
+./scripts/smoke-container-runtime.sh
+```
+
+The runtime smoke always removes the container on exit and prints container logs plus `docker inspect` state/port details when a check fails. It stays intentionally fixture-mode only and does not reopen artifact-mode-in-container scope.
+
 ### Run the backend container directly
+
+If you only want to boot the container manually without the full runtime validation wrapper, you can still run:
 
 ```bash
 docker run --rm -p 9001:9001 supportdoc-rag-chatbot-api:local
@@ -422,12 +434,14 @@ docker run --rm -p 9001:9001 supportdoc-rag-chatbot-api:local
 
 ### Run the local smoke stack with Docker Compose
 
+`docker compose` remains optional for manual local stack management, but the canonical runtime smoke path for MVP validation is the script above.
+
 ```bash
 docker compose up --build -d
 docker compose ps
 ```
 
-Example smoke calls against the running container:
+Example manual smoke calls against the running container:
 
 ```bash
 curl http://127.0.0.1:9001/healthz

--- a/scripts/smoke-container-runtime.sh
+++ b/scripts/smoke-container-runtime.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IMAGE_TAG="${SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_IMAGE:-supportdoc-rag-chatbot-api:local}"
+CONTAINER_NAME="${SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_NAME:-supportdoc-api-runtime-smoke}"
+HOST_PORT="${SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_PORT:-9001}"
+TIMEOUT_SECONDS="${SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_TIMEOUT_SECONDS:-90}"
+SKIP_BUILD="${SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_SKIP_BUILD:-false}"
+
+usage() {
+  cat <<EOF_USAGE
+Usage: ./scripts/smoke-container-runtime.sh [options]
+
+Validate the backend container runtime in fixture mode end to end.
+The script builds the checked-in backend image by default, starts it with docker run,
+waits for the container healthcheck, validates /healthz and /readyz, then checks
+supported-answer and refusal responses against the canonical QueryResponse contract.
+
+Options:
+  --image-tag TAG          Docker image tag to build/run (default: ${IMAGE_TAG})
+  --container-name NAME    Container name to use during the smoke run (default: ${CONTAINER_NAME})
+  --host-port PORT         Host port to bind to container port 9001 (default: ${HOST_PORT})
+  --timeout-seconds N      Max seconds to wait for container health (default: ${TIMEOUT_SECONDS})
+  --skip-build             Reuse an already-built image instead of rebuilding it
+  -h, --help               Show this help text
+
+Environment overrides:
+  SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_IMAGE
+  SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_NAME
+  SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_PORT
+  SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_TIMEOUT_SECONDS
+  SUPPORTDOC_CONTAINER_RUNTIME_SMOKE_SKIP_BUILD=true|false
+EOF_USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image-tag)
+      IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --container-name)
+      CONTAINER_NAME="$2"
+      shift 2
+      ;;
+    --host-port)
+      HOST_PORT="$2"
+      shift 2
+      ;;
+    --timeout-seconds)
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+cleanup() {
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Required command not found: ${command_name}" >&2
+    exit 1
+  fi
+}
+
+print_diagnostics() {
+  echo ""
+  echo "Container runtime smoke diagnostics"
+  echo "container: ${CONTAINER_NAME}"
+  echo "image: ${IMAGE_TAG}"
+  echo "host port: ${HOST_PORT}"
+  echo ""
+  echo "docker ps -a --filter name=${CONTAINER_NAME}"
+  docker ps -a --filter "name=^/${CONTAINER_NAME}$" || true
+  echo ""
+  echo "docker inspect state"
+  docker inspect "${CONTAINER_NAME}" --format '{{json .State}}' || true
+  echo ""
+  echo "docker inspect ports"
+  docker inspect "${CONTAINER_NAME}" --format '{{json .NetworkSettings.Ports}}' || true
+  echo ""
+  echo "docker logs"
+  docker logs "${CONTAINER_NAME}" || true
+}
+
+fail() {
+  echo "$*" >&2
+  print_diagnostics
+  exit 1
+}
+
+wait_for_container_health() {
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  local health_status=""
+
+  while (( SECONDS < deadline )); do
+    health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing-healthcheck{{end}}' "${CONTAINER_NAME}" 2>/dev/null || true)"
+    case "${health_status}" in
+      healthy)
+        return 0
+        ;;
+      unhealthy)
+        echo "Container reported unhealthy status." >&2
+        return 1
+        ;;
+    esac
+    sleep 2
+  done
+
+  echo "Container did not reach healthy status within ${TIMEOUT_SECONDS} seconds." >&2
+  return 1
+}
+
+validate_http_contract() {
+  local base_url="http://127.0.0.1:${HOST_PORT}"
+  BASE_URL="${base_url}" uv run python - <<'PY'
+import json
+import os
+import urllib.request
+
+from supportdoc_rag_chatbot.app.api.schemas import HealthStatusResponse, ReadinessStatusResponse
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+
+base_url = os.environ["BASE_URL"].rstrip("/")
+
+
+def request_json(method: str, path: str, payload: dict[str, str] | None = None):
+    data = None
+    headers = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["content-type"] = "application/json"
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return response.status, json.load(response)
+
+
+status, health_payload = request_json("GET", "/healthz")
+if status != 200:
+    raise SystemExit(f"Unexpected /healthz status: {status}")
+HealthStatusResponse.model_validate(health_payload)
+if health_payload != {"status": "ok"}:
+    raise SystemExit(f"Unexpected /healthz payload: {health_payload!r}")
+
+status, ready_payload = request_json("GET", "/readyz")
+if status != 200:
+    raise SystemExit(f"Unexpected /readyz status: {status}")
+ready = ReadinessStatusResponse.model_validate(ready_payload)
+if ready.status != "ready":
+    raise SystemExit(f"Unexpected /readyz payload: {ready_payload!r}")
+
+status, supported_payload = request_json(
+    "POST",
+    "/query",
+    {"question": "What is a Pod?"},
+)
+if status != 200:
+    raise SystemExit(f"Unexpected supported /query status: {status}")
+supported = QueryResponse.model_validate(supported_payload)
+if supported.refusal.is_refusal:
+    raise SystemExit("Supported fixture question returned a refusal response.")
+if not supported.citations:
+    raise SystemExit("Supported fixture question returned no citations.")
+if supported.citations[0].marker != "[1]":
+    raise SystemExit(
+        f"Supported fixture response returned an unexpected citation marker: {supported.citations[0].marker!r}"
+    )
+
+status, refusal_payload = request_json(
+    "POST",
+    "/query",
+    {"question": "How do I reset my laptop BIOS?"},
+)
+if status != 200:
+    raise SystemExit(f"Unexpected refusal /query status: {status}")
+refusal = QueryResponse.model_validate(refusal_payload)
+if not refusal.refusal.is_refusal:
+    raise SystemExit("Refusal fixture question returned a supported answer.")
+if refusal.refusal.reason_code is not RefusalReasonCode.NO_RELEVANT_DOCS:
+    raise SystemExit(
+        "Refusal fixture response returned an unexpected reason code: "
+        f"{refusal.refusal.reason_code!r}"
+    )
+if refusal.citations:
+    raise SystemExit("Refusal fixture question returned citations.")
+
+print("Container runtime smoke: ok")
+PY
+}
+
+require_command docker
+require_command uv
+
+cd "${REPO_ROOT}"
+
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+trap cleanup EXIT
+
+if [[ "${SKIP_BUILD}" != "true" ]]; then
+  echo "Building backend image ${IMAGE_TAG} from docker/backend.Dockerfile"
+  docker build -f docker/backend.Dockerfile -t "${IMAGE_TAG}" . || fail "Backend image build failed."
+else
+  echo "Skipping image build and reusing ${IMAGE_TAG}"
+fi
+
+echo "Starting backend container ${CONTAINER_NAME} on http://127.0.0.1:${HOST_PORT}"
+docker run -d --rm \
+  --name "${CONTAINER_NAME}" \
+  -p "${HOST_PORT}:9001" \
+  -e SUPPORTDOC_LOCAL_API_MODE=fixture \
+  -e SUPPORTDOC_LOCAL_API_HOST=0.0.0.0 \
+  -e SUPPORTDOC_LOCAL_API_PORT=9001 \
+  -e SUPPORTDOC_QUERY_GENERATION_MODE=fixture \
+  "${IMAGE_TAG}" >/dev/null || fail "Failed to start backend container."
+
+wait_for_container_health || fail "Backend container did not become healthy."
+validate_http_contract || fail "Backend container did not satisfy the runtime HTTP contract."
+
+echo "Container runtime smoke completed successfully."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
+import pickle
+import sys
 from collections.abc import Callable, Iterator
+from pathlib import Path
+from types import ModuleType
 
 import pytest
 from fastapi import FastAPI
@@ -13,6 +19,66 @@ from supportdoc_rag_chatbot.app.core import (
     get_request_query_orchestrator,
 )
 from supportdoc_rag_chatbot.config import BackendSettings
+
+
+def _numpy():
+    import numpy
+
+    return numpy
+
+
+class _FakeFaissIndexFlatIP:
+    def __init__(self, dimension: int) -> None:
+        self.d = int(dimension)
+        self.ntotal = 0
+        self._vectors = _numpy().empty((0, self.d), dtype=_numpy().float32)
+
+    def add(self, vectors) -> None:
+        vectors_array = _numpy().asarray(vectors, dtype=_numpy().float32)
+        if vectors_array.ndim != 2 or vectors_array.shape[1] != self.d:
+            raise ValueError("_FakeFaissIndexFlatIP.add received vectors with the wrong shape")
+        self._vectors = _numpy().vstack([self._vectors, vectors_array])
+        self.ntotal = int(self._vectors.shape[0])
+
+    def search(self, queries, top_k: int):
+        queries_array = _numpy().asarray(queries, dtype=_numpy().float32)
+        scores = queries_array @ self._vectors.T
+        ranked_indexes = _numpy().argsort(-scores, axis=1, kind="stable")[:, :top_k]
+        ranked_scores = _numpy().take_along_axis(scores, ranked_indexes, axis=1)
+        return ranked_scores.astype(_numpy().float32), ranked_indexes.astype(_numpy().int64)
+
+
+def _fake_faiss_module() -> ModuleType:
+    def normalize_l2(matrix) -> None:
+        array = _numpy().asarray(matrix, dtype=_numpy().float32)
+        norms = _numpy().linalg.norm(array, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        array /= norms
+
+    def write_index(index: _FakeFaissIndexFlatIP, path: str) -> None:
+        payload = {"d": index.d, "vectors": index._vectors}
+        with Path(path).open("wb") as handle:
+            pickle.dump(payload, handle)
+
+    def read_index(path: str) -> _FakeFaissIndexFlatIP:
+        with Path(path).open("rb") as handle:
+            payload = pickle.load(handle)
+        index = _FakeFaissIndexFlatIP(payload["d"])
+        index.add(payload["vectors"])
+        return index
+
+    module = ModuleType("faiss")
+    module.__spec__ = importlib.machinery.ModuleSpec(name="faiss", loader=None)
+    module.IndexFlatIP = _FakeFaissIndexFlatIP
+    module.normalize_L2 = normalize_l2
+    module.read_index = read_index
+    module.write_index = write_index
+    return module
+
+
+if importlib.util.find_spec("faiss") is None and "faiss" not in sys.modules:
+    sys.modules["faiss"] = _fake_faiss_module()
+
 
 API_TEST_SETTINGS = BackendSettings(
     app_name="SupportDoc API Test App",

--- a/tests/test_container_runtime_smoke.py
+++ b/tests/test_container_runtime_smoke.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_container_runtime_smoke_script_has_help_and_primary_docker_run_path() -> None:
+    script = Path("scripts/smoke-container-runtime.sh")
+    assert script.is_file()
+
+    help_result = subprocess.run(
+        ["bash", str(script), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Usage: ./scripts/smoke-container-runtime.sh" in help_result.stdout
+    assert "--skip-build" in help_result.stdout
+    assert "--host-port" in help_result.stdout
+
+    content = script.read_text(encoding="utf-8")
+    assert "docker build -f docker/backend.Dockerfile" in content
+    assert "docker run -d --rm" in content
+    assert "SUPPORTDOC_LOCAL_API_MODE=fixture" in content
+    assert "SUPPORTDOC_QUERY_GENERATION_MODE=fixture" in content
+    assert "wait_for_container_health" in content
+    assert '"/healthz"' in content
+    assert '"/readyz"' in content
+    assert "What is a Pod?" in content
+    assert "How do I reset my laptop BIOS?" in content
+
+
+def test_container_runtime_smoke_script_validates_query_contract_and_failure_diagnostics() -> None:
+    content = Path("scripts/smoke-container-runtime.sh").read_text(encoding="utf-8")
+
+    assert "QueryResponse.model_validate" in content
+    assert "RefusalReasonCode.NO_RELEVANT_DOCS" in content
+    assert "docker inspect" in content
+    assert "docker logs" in content
+    assert "trap cleanup EXIT" in content
+    assert "docker rm -f" in content
+
+
+def test_readme_documents_canonical_container_runtime_smoke_command() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+
+    assert "### Canonical runtime smoke command" in content
+    assert "./scripts/smoke-container-runtime.sh" in content
+    assert "CI build smoke proves" in content
+    assert "docker run" in content
+    assert "fixture-mode only" in content
+    assert "`docker compose` remains optional" in content


### PR DESCRIPTION
---

This change adds the canonical backend container **runtime smoke** path for MVP validation. The repo already had the backend image packaging baseline and the fixture-mode local API startup wrapper; this task adds the missing runtime proof that the built image can start, reach health, and serve the expected HTTP contract in fixture mode.

- Added `scripts/smoke-container-runtime.sh` as the single canonical runtime smoke command.
  - Builds `docker/backend.Dockerfile` by default.
  - Starts the backend with `docker run` in fixture mode.
  - Waits for the container healthcheck to report healthy.
  - Validates `GET /healthz` and `GET /readyz`.
  - Sends one supported and one refusal `POST /query` request.
  - Validates both query responses against the canonical `QueryResponse` contract.
  - Dumps `docker logs` plus `docker inspect` state/port details on failure.
  - Always removes the container on exit.
- Updated `README.md` section `7B. Containerized Local API Smoke Workflow` to document the new canonical runtime smoke command and clarify that:
  - `docker run` is the primary runtime validation path,
  - `docker compose` remains optional for manual local stack management, and
  - artifact-mode-in-container scope remains deferred.
- Added `tests/test_container_runtime_smoke.py` to cover the new script and README documentation.
- Updated `tests/conftest.py` with a **test-only** fake-FAISS shim so the committed pytest suite can run in this offline execution environment without changing application runtime behavior.

The build gate only proves that the image still builds. This task adds the missing runtime proof that the packaged backend can actually boot and respond with the stable HTTP contract the MVP depends on.

Executed against a fresh unzip of the provided HEAD repo plus the overlay:

- `PYTHONPATH=src pytest -q tests/test_container_runtime_smoke.py`
- `PYTHONPATH=src pytest -q tests/test_container_packaging.py tests/test_local_api_workflow.py tests/test_api_app.py tests/test_api_query.py tests/test_trust_schema.py`
- `PYTHONPATH=src pytest -q`
- `./scripts/smoke-container-runtime.sh --help`
- `PYTHONPATH=src python -m supportdoc_rag_chatbot smoke-trust-schema --schema docs/contracts/query_response.schema.json --answer-fixture docs/contracts/query_response.answer.example.json --refusal-fixture docs/contracts/query_response.refusal.example.json`
- `./scripts/smoke-container-runtime.sh` ---
Changes to be committed:
	modified:   README.md
	new file:   scripts/smoke-container-runtime.sh
	modified:   tests/conftest.py
	new file:   tests/test_container_runtime_smoke.py