### PR TITLE
On branch docs/88-add-artifact-mode-API-E2E-smoke-suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,20 +348,52 @@ curl -X POST http://127.0.0.1:9001/query \
 
 ### Artifact mode
 
-Artifact mode is for local users who already generated `chunks.jsonl` plus the FAISS artifact set. The startup script fails fast with clear guidance when any required files are missing.
+Artifact mode is for local users who already generated `chunks.jsonl` plus the FAISS artifact set. The startup script still fails fast with clear guidance when any required files are missing, but the backend now also supports explicit artifact-path overrides so smoke fixtures can stay isolated from a developer's `data/processed/` state.
 
 ```bash
 SUPPORTDOC_LOCAL_API_MODE=artifact ./scripts/run-api-local.sh
 ```
 
-Required artifact paths currently use the fixed local defaults from the retrieval modules:
+Default artifact locations remain:
 
 - `data/processed/chunks.jsonl`
 - `data/processed/indexes/faiss/chunk_index.faiss`
 - `data/processed/indexes/faiss/chunk_index.metadata.json`
 - `data/processed/indexes/faiss/chunk_index.row_mapping.json`
 
-Artifact path overrides are not currently supported by `./scripts/run-api-local.sh` or `BackendSettings`, so local artifact-mode startup expects those default locations.
+Optional artifact override environment variables:
+
+- `SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH`
+- `SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH`
+- `SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH`
+- `SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH`
+
+By default, artifact mode uses the local embedding model recorded in the FAISS metadata. For the deterministic smoke suite only, the backend also supports a lightweight fixture embedder override:
+
+- `SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE=local|fixture`
+- `SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_FIXTURE_PATH=/absolute/path/to/query_embedding_fixture.json`
+
+### Canonical artifact-mode smoke command
+
+Run the artifact-backed local API smoke path with a tiny deterministic fixture:
+
+```bash
+./scripts/smoke-artifact-api.sh
+```
+
+That command:
+
+- creates a temporary `chunks.jsonl` + FAISS fixture,
+- starts `./scripts/run-api-local.sh --mode artifact` with explicit artifact-path overrides,
+- uses the smoke-only fixture embedder so no long-running model server or local embedding stack is required,
+- validates `GET /healthz`, `GET /readyz`, and supported + refusal `POST /query` responses against the canonical `QueryResponse` contract, and
+- removes the temporary fixture and background API process on exit.
+
+Prerequisite:
+
+```bash
+uv sync --locked --extra dev-tools --extra faiss
+```
 
 ### Optional local configuration
 
@@ -384,6 +416,12 @@ Backend settings are loaded by `src/supportdoc_rag_chatbot/config.py` and use th
 - `SUPPORTDOC_QUERY_GENERATION_BASE_URL=http://127.0.0.1:8080`
 - `SUPPORTDOC_QUERY_GENERATION_TIMEOUT_SECONDS=30`
 - `SUPPORTDOC_QUERY_TOP_K=3`
+- `SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH=/absolute/path/to/chunks.jsonl`
+- `SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH=/absolute/path/to/chunk_index.faiss`
+- `SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH=/absolute/path/to/chunk_index.metadata.json`
+- `SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH=/absolute/path/to/chunk_index.row_mapping.json`
+- `SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE=local|fixture`
+- `SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_FIXTURE_PATH=/absolute/path/to/query_embedding_fixture.json`
 
 For example, to point the API at an HTTP generation backend:
 
@@ -414,7 +452,19 @@ The image:
 - defines a `/healthz` container healthcheck, and
 - runs as the non-root `supportdoc` user.
 
+### Canonical runtime smoke command
+
+The CI build smoke proves that `docker/backend.Dockerfile` still builds. The runtime smoke below is the canonical **packaged-runtime** proof: it builds the checked-in image, starts it in fixture mode with `docker run`, waits for the container healthcheck, validates `GET /healthz` and `GET /readyz`, then checks one supported and one refusal `POST /query` response against the canonical `QueryResponse` contract.
+
+```bash
+./scripts/smoke-container-runtime.sh
+```
+
+The runtime smoke always removes the container on exit and prints container logs plus `docker inspect` state/port details when a check fails. It stays intentionally fixture-mode only and does not reopen artifact-mode-in-container scope.
+
 ### Run the backend container directly
+
+If you only want to boot the container manually without the full runtime validation wrapper, you can still run:
 
 ```bash
 docker run --rm -p 9001:9001 supportdoc-rag-chatbot-api:local
@@ -422,12 +472,14 @@ docker run --rm -p 9001:9001 supportdoc-rag-chatbot-api:local
 
 ### Run the local smoke stack with Docker Compose
 
+`docker compose` remains optional for manual local stack management, but the canonical runtime smoke path for MVP validation is the script above.
+
 ```bash
 docker compose up --build -d
 docker compose ps
 ```
 
-Example smoke calls against the running container:
+Example manual smoke calls against the running container:
 
 ```bash
 curl http://127.0.0.1:9001/healthz

--- a/scripts/smoke-artifact-api.sh
+++ b/scripts/smoke-artifact-api.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+HOST="${SUPPORTDOC_ARTIFACT_API_SMOKE_HOST:-127.0.0.1}"
+PORT="${SUPPORTDOC_ARTIFACT_API_SMOKE_PORT:-9002}"
+TIMEOUT_SECONDS="${SUPPORTDOC_ARTIFACT_API_SMOKE_TIMEOUT_SECONDS:-90}"
+KEEP_TEMP="${SUPPORTDOC_ARTIFACT_API_SMOKE_KEEP_TEMP:-false}"
+
+TEMP_DIR=""
+LOG_PATH=""
+SERVER_PID=""
+
+usage() {
+  cat <<EOF_USAGE
+Usage: ./scripts/smoke-artifact-api.sh [options]
+
+Validate the artifact-backed local API path end to end using a deterministic smoke fixture.
+The script materializes a tiny chunks + FAISS fixture in a temporary directory, starts the
+backend in artifact mode with explicit artifact-path overrides, waits for /readyz, then
+validates supported-answer and refusal responses against the canonical QueryResponse contract.
+
+Options:
+  --host HOST             Bind host for the local API server (default: ${HOST})
+  --port PORT             Bind port for the local API server (default: ${PORT})
+  --timeout-seconds N     Max seconds to wait for API readiness (default: ${TIMEOUT_SECONDS})
+  --keep-temp             Keep the generated temporary fixture directory after the run
+  -h, --help              Show this help text
+
+Environment overrides:
+  SUPPORTDOC_ARTIFACT_API_SMOKE_HOST
+  SUPPORTDOC_ARTIFACT_API_SMOKE_PORT
+  SUPPORTDOC_ARTIFACT_API_SMOKE_TIMEOUT_SECONDS
+  SUPPORTDOC_ARTIFACT_API_SMOKE_KEEP_TEMP=true|false
+
+Prerequisite:
+  uv sync --locked --extra dev-tools --extra faiss
+EOF_USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --timeout-seconds)
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --keep-temp)
+      KEEP_TEMP="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Required command not found: ${command_name}" >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
+    kill "${SERVER_PID}" >/dev/null 2>&1 || true
+    wait "${SERVER_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${KEEP_TEMP}" != "true" ]] && [[ -n "${TEMP_DIR}" ]] && [[ -d "${TEMP_DIR}" ]]; then
+    rm -rf "${TEMP_DIR}" >/dev/null 2>&1 || true
+  fi
+}
+
+print_diagnostics() {
+  echo ""
+  echo "Artifact-mode API smoke diagnostics"
+  echo "host: ${HOST}"
+  echo "port: ${PORT}"
+  echo "timeout: ${TIMEOUT_SECONDS}"
+  if [[ -n "${TEMP_DIR}" ]]; then
+    echo "fixture dir: ${TEMP_DIR}"
+    if [[ -d "${TEMP_DIR}" ]]; then
+      echo "generated files:"
+      find "${TEMP_DIR}" -maxdepth 2 -type f | sort || true
+    fi
+  fi
+  if [[ -n "${SERVER_PID}" ]]; then
+    echo "server pid: ${SERVER_PID}"
+    if kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
+      echo "server state: running"
+    else
+      echo "server state: exited"
+    fi
+  fi
+  if [[ -n "${LOG_PATH}" ]] && [[ -f "${LOG_PATH}" ]]; then
+    echo ""
+    echo "API log output"
+    cat "${LOG_PATH}" || true
+  fi
+}
+
+fail() {
+  echo "$*" >&2
+  print_diagnostics
+  exit 1
+}
+
+build_fixture() {
+  TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/supportdoc-artifact-api-smoke.XXXXXX")"
+  LOG_PATH="${TEMP_DIR}/artifact-api-smoke.log"
+  ARTIFACT_SMOKE_OUTPUT_DIR="${TEMP_DIR}" uv run python - <<'PY'
+import os
+from pathlib import Path
+
+from supportdoc_rag_chatbot.app.core.artifact_smoke import (
+    build_artifact_smoke_fixture,
+    render_artifact_smoke_fixture_report,
+)
+
+output_dir = Path(os.environ["ARTIFACT_SMOKE_OUTPUT_DIR"])
+fixture = build_artifact_smoke_fixture(output_dir)
+print(render_artifact_smoke_fixture_report(fixture))
+PY
+}
+
+wait_for_api_ready() {
+  local base_url="http://${HOST}:${PORT}"
+  BASE_URL="${base_url}" TIMEOUT_SECONDS="${TIMEOUT_SECONDS}" uv run python - <<'PY'
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+base_url = os.environ["BASE_URL"].rstrip("/")
+deadline = time.monotonic() + float(os.environ["TIMEOUT_SECONDS"])
+last_error = "artifact-mode API never became ready"
+
+while time.monotonic() < deadline:
+    try:
+        with urllib.request.urlopen(f"{base_url}/readyz", timeout=2) as response:
+            payload = json.load(response)
+        if response.status == 200 and payload.get("status") == "ready":
+            raise SystemExit(0)
+        last_error = f"Unexpected /readyz payload: {payload!r}"
+    except urllib.error.URLError as exc:
+        last_error = str(exc)
+    except TimeoutError as exc:  # pragma: no cover - platform-specific network timing
+        last_error = str(exc)
+    time.sleep(1)
+
+raise SystemExit(last_error)
+PY
+}
+
+validate_http_contract() {
+  local base_url="http://${HOST}:${PORT}"
+  BASE_URL="${base_url}" FIXTURE_DIR="${TEMP_DIR}" uv run python - <<'PY'
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+from supportdoc_rag_chatbot.app.api.schemas import HealthStatusResponse, ReadinessStatusResponse
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+
+base_url = os.environ["BASE_URL"].rstrip("/")
+fixture_dir = Path(os.environ["FIXTURE_DIR"])
+chunks_path = fixture_dir / "chunks.jsonl"
+with chunks_path.open("r", encoding="utf-8") as handle:
+    chunk_ids = {json.loads(line)["chunk_id"] for line in handle if line.strip()}
+
+
+def request_json(method: str, path: str, payload: dict[str, str] | None = None):
+    data = None
+    headers = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["content-type"] = "application/json"
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return response.status, json.load(response)
+
+
+status, health_payload = request_json("GET", "/healthz")
+if status != 200:
+    raise SystemExit(f"Unexpected /healthz status: {status}")
+HealthStatusResponse.model_validate(health_payload)
+if health_payload != {"status": "ok"}:
+    raise SystemExit(f"Unexpected /healthz payload: {health_payload!r}")
+
+status, ready_payload = request_json("GET", "/readyz")
+if status != 200:
+    raise SystemExit(f"Unexpected /readyz status: {status}")
+ready = ReadinessStatusResponse.model_validate(ready_payload)
+if ready.status != "ready":
+    raise SystemExit(f"Unexpected /readyz payload: {ready_payload!r}")
+
+status, supported_payload = request_json(
+    "POST",
+    "/query",
+    {"question": "What is a Pod?"},
+)
+if status != 200:
+    raise SystemExit(f"Unexpected supported /query status: {status}")
+supported = QueryResponse.model_validate(supported_payload)
+if supported.refusal.is_refusal:
+    raise SystemExit("Supported artifact smoke question returned a refusal response.")
+if not supported.citations:
+    raise SystemExit("Supported artifact smoke question returned no citations.")
+returned_chunk_ids = {citation.chunk_id for citation in supported.citations}
+if not returned_chunk_ids.issubset(chunk_ids):
+    raise SystemExit(
+        "Supported artifact smoke response cited chunk IDs outside the loaded fixture: "
+        f"{sorted(returned_chunk_ids - chunk_ids)!r}"
+    )
+
+status, refusal_payload = request_json(
+    "POST",
+    "/query",
+    {"question": "How do I reset my laptop BIOS?"},
+)
+if status != 200:
+    raise SystemExit(f"Unexpected refusal /query status: {status}")
+refusal = QueryResponse.model_validate(refusal_payload)
+if not refusal.refusal.is_refusal:
+    raise SystemExit("Refusal artifact smoke question returned a supported answer.")
+if refusal.refusal.reason_code is not RefusalReasonCode.NO_RELEVANT_DOCS:
+    raise SystemExit(
+        "Refusal artifact smoke response returned an unexpected reason code: "
+        f"{refusal.refusal.reason_code!r}"
+    )
+if refusal.citations:
+    raise SystemExit("Refusal artifact smoke question returned citations.")
+
+print("Artifact-mode API smoke: ok")
+PY
+}
+
+start_api_server() {
+  (
+    export SUPPORTDOC_LOCAL_API_MODE=artifact
+    export SUPPORTDOC_LOCAL_API_HOST="${HOST}"
+    export SUPPORTDOC_LOCAL_API_PORT="${PORT}"
+    export SUPPORTDOC_QUERY_GENERATION_MODE=fixture
+    export SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH="${TEMP_DIR}/chunks.jsonl"
+    export SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH="${TEMP_DIR}/chunk_index.faiss"
+    export SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH="${TEMP_DIR}/chunk_index.metadata.json"
+    export SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH="${TEMP_DIR}/chunk_index.row_mapping.json"
+    export SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE=fixture
+    export SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_FIXTURE_PATH="${TEMP_DIR}/query_embedding_fixture.json"
+    ./scripts/run-api-local.sh --mode artifact --host "${HOST}" --port "${PORT}"
+  ) >"${LOG_PATH}" 2>&1 &
+  SERVER_PID="$!"
+}
+
+require_command uv
+
+cd "${REPO_ROOT}"
+trap cleanup EXIT
+
+build_fixture || fail "Artifact smoke fixture build failed."
+start_api_server || fail "Artifact-mode API server failed to start."
+wait_for_api_ready || fail "Artifact-mode API did not become ready."
+validate_http_contract || fail "Artifact-mode API did not satisfy the HTTP smoke contract."
+
+echo "Artifact-mode API smoke completed successfully."

--- a/src/supportdoc_rag_chatbot/app/core/artifact_smoke.py
+++ b/src/supportdoc_rag_chatbot/app/core/artifact_smoke.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from supportdoc_rag_chatbot.ingestion.jsonl import write_jsonl
+from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
+from supportdoc_rag_chatbot.retrieval.embeddings import build_embedding_artifacts
+from supportdoc_rag_chatbot.retrieval.embeddings.fixture import (
+    DEFAULT_FIXTURE_EMBEDDER_MODEL_NAME,
+    create_fixture_embedder,
+    write_fixture_embedding_map,
+)
+from supportdoc_rag_chatbot.retrieval.indexes import build_faiss_index_artifacts
+
+ARTIFACT_SMOKE_SUPPORTED_QUESTION = "What is a Pod?"
+ARTIFACT_SMOKE_REFUSAL_QUESTION = "How do I reset my laptop BIOS?"
+ARTIFACT_SMOKE_FIXTURE_MODEL_NAME = DEFAULT_FIXTURE_EMBEDDER_MODEL_NAME
+
+
+@dataclass(slots=True, frozen=True)
+class ArtifactApiSmokeFixturePaths:
+    root_dir: Path
+    chunks_path: Path
+    vectors_path: Path
+    embedding_metadata_path: Path
+    index_path: Path
+    index_metadata_path: Path
+    row_mapping_path: Path
+    embedder_fixture_path: Path
+    supported_question: str
+    refusal_question: str
+    chunk_ids: tuple[str, ...]
+
+
+def build_artifact_smoke_fixture(root_dir: Path) -> ArtifactApiSmokeFixturePaths:
+    resolved_root = root_dir.resolve()
+    resolved_root.mkdir(parents=True, exist_ok=True)
+
+    chunks_path = resolved_root / "chunks.jsonl"
+    vectors_path = resolved_root / "chunk_embeddings.f32"
+    embedding_metadata_path = resolved_root / "chunk_embeddings.metadata.json"
+    index_path = resolved_root / "chunk_index.faiss"
+    index_metadata_path = resolved_root / "chunk_index.metadata.json"
+    row_mapping_path = resolved_root / "chunk_index.row_mapping.json"
+    embedder_fixture_path = resolved_root / "query_embedding_fixture.json"
+
+    chunks = _build_artifact_smoke_chunks()
+    vectors_by_text = _build_artifact_smoke_vectors(chunks)
+    embedder = create_fixture_embedder(
+        model_name=ARTIFACT_SMOKE_FIXTURE_MODEL_NAME,
+        vectors_by_text=vectors_by_text,
+    )
+
+    write_jsonl(chunks_path, chunks)
+    build_embedding_artifacts(
+        chunks_path=chunks_path,
+        vectors_path=vectors_path,
+        metadata_path=embedding_metadata_path,
+        embedder=embedder,
+        batch_size=2,
+    )
+    build_faiss_index_artifacts(
+        embedding_metadata_path=embedding_metadata_path,
+        index_path=index_path,
+        metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+    )
+    write_fixture_embedding_map(
+        embedder_fixture_path,
+        model_name=embedder.model_name,
+        vectors_by_text=vectors_by_text,
+    )
+
+    return ArtifactApiSmokeFixturePaths(
+        root_dir=resolved_root,
+        chunks_path=chunks_path,
+        vectors_path=vectors_path,
+        embedding_metadata_path=embedding_metadata_path,
+        index_path=index_path,
+        index_metadata_path=index_metadata_path,
+        row_mapping_path=row_mapping_path,
+        embedder_fixture_path=embedder_fixture_path,
+        supported_question=ARTIFACT_SMOKE_SUPPORTED_QUESTION,
+        refusal_question=ARTIFACT_SMOKE_REFUSAL_QUESTION,
+        chunk_ids=tuple(chunk.chunk_id for chunk in chunks),
+    )
+
+
+def render_artifact_smoke_fixture_report(fixture: ArtifactApiSmokeFixturePaths) -> str:
+    lines = [
+        "Artifact API smoke fixture",
+        f"root: {fixture.root_dir}",
+        f"chunks: {fixture.chunks_path}",
+        f"index: {fixture.index_path}",
+        f"index metadata: {fixture.index_metadata_path}",
+        f"row mapping: {fixture.row_mapping_path}",
+        f"embedder fixture: {fixture.embedder_fixture_path}",
+        f"supported question: {fixture.supported_question}",
+        f"refusal question: {fixture.refusal_question}",
+        f"chunk_ids: {', '.join(fixture.chunk_ids)}",
+    ]
+    return "\n".join(lines)
+
+
+def _build_artifact_smoke_chunks() -> tuple[ChunkRecord, ChunkRecord]:
+    return (
+        ChunkRecord(
+            snapshot_id="artifact-smoke-k8s-9e1e32b",
+            doc_id="content-en-docs-concepts-workloads-pods-pods",
+            chunk_id="content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+            section_id="content-en-docs-concepts-workloads-pods-pods__section-0001",
+            section_index=0,
+            chunk_index=0,
+            doc_title="Pods",
+            section_path=["Concepts", "Workloads", "Pods"],
+            source_path="content/en/docs/concepts/workloads/pods/pods.md",
+            source_url="https://kubernetes.io/docs/concepts/workloads/pods/",
+            license="CC BY 4.0",
+            attribution="Kubernetes Documentation © The Kubernetes Authors",
+            language="en",
+            start_offset=0,
+            end_offset=128,
+            token_count=20,
+            text=(
+                "A Pod is the smallest deployable unit in Kubernetes and can run one or more "
+                "containers that share network and storage resources."
+            ),
+        ),
+        ChunkRecord(
+            snapshot_id="artifact-smoke-k8s-9e1e32b",
+            doc_id="content-en-docs-concepts-workloads-pods-pods",
+            chunk_id="content-en-docs-concepts-workloads-pods-pods__chunk-0002",
+            section_id="content-en-docs-concepts-workloads-pods-pods__section-0001",
+            section_index=0,
+            chunk_index=1,
+            doc_title="Pods",
+            section_path=["Concepts", "Workloads", "Pods"],
+            source_path="content/en/docs/concepts/workloads/pods/pods.md",
+            source_url="https://kubernetes.io/docs/concepts/workloads/pods/",
+            license="CC BY 4.0",
+            attribution="Kubernetes Documentation © The Kubernetes Authors",
+            language="en",
+            start_offset=129,
+            end_offset=248,
+            token_count=18,
+            text=(
+                "Pods can also group closely related containers so they share the same network "
+                "identity and can coordinate storage resources."
+            ),
+        ),
+    )
+
+
+def _build_artifact_smoke_vectors(
+    chunks: tuple[ChunkRecord, ChunkRecord],
+) -> dict[str, list[float]]:
+    chunk_one, chunk_two = chunks
+    return {
+        chunk_one.text: [1.0, 0.0],
+        chunk_two.text: [0.8, 0.2],
+        ARTIFACT_SMOKE_SUPPORTED_QUESTION: [1.0, 0.0],
+        ARTIFACT_SMOKE_REFUSAL_QUESTION: [-1.0, 0.0],
+    }
+
+
+__all__ = [
+    "ARTIFACT_SMOKE_FIXTURE_MODEL_NAME",
+    "ARTIFACT_SMOKE_REFUSAL_QUESTION",
+    "ARTIFACT_SMOKE_SUPPORTED_QUESTION",
+    "ArtifactApiSmokeFixturePaths",
+    "build_artifact_smoke_fixture",
+    "render_artifact_smoke_fixture_report",
+]

--- a/src/supportdoc_rag_chatbot/app/core/local_workflow.py
+++ b/src/supportdoc_rag_chatbot/app/core/local_workflow.py
@@ -53,11 +53,38 @@ def evaluate_local_api_readiness(settings: BackendSettings) -> LocalApiPreflight
         ]
     else:
         checks = [
-            _check_path("chunks", DEFAULT_CHUNKS_PATH),
-            _check_path("faiss_index", DEFAULT_FAISS_INDEX_PATH),
-            _check_path("faiss_index_metadata", DEFAULT_FAISS_METADATA_PATH),
-            _check_path("faiss_row_mapping", DEFAULT_FAISS_ROW_MAPPING_PATH),
+            _check_path(
+                "chunks", _artifact_path(settings.query_artifact_chunks_path, DEFAULT_CHUNKS_PATH)
+            ),
+            _check_path(
+                "faiss_index",
+                _artifact_path(settings.query_artifact_index_path, DEFAULT_FAISS_INDEX_PATH),
+            ),
+            _check_path(
+                "faiss_index_metadata",
+                _artifact_path(
+                    settings.query_artifact_index_metadata_path,
+                    DEFAULT_FAISS_METADATA_PATH,
+                ),
+            ),
+            _check_path(
+                "faiss_row_mapping",
+                _artifact_path(
+                    settings.query_artifact_row_mapping_path,
+                    DEFAULT_FAISS_ROW_MAPPING_PATH,
+                ),
+            ),
         ]
+        if settings.query_artifact_embedder_mode == "fixture":
+            checks.append(
+                _check_path(
+                    "artifact_embedder_fixture",
+                    _artifact_path(
+                        settings.query_artifact_embedder_fixture_path,
+                        Path("(unset)"),
+                    ),
+                )
+            )
 
     if settings.query_generation_mode is GenerationBackendMode.HTTP:
         base_url = (
@@ -119,6 +146,12 @@ def render_local_api_preflight_report(report: LocalApiPreflightReport) -> str:
 def _check_path(name: str, path: Path | str) -> PreflightCheck:
     resolved = Path(path)
     return PreflightCheck(name=name, path=resolved, exists=resolved.exists())
+
+
+def _artifact_path(value: str | None, default: Path) -> Path:
+    if value is None:
+        return default
+    return Path(value)
 
 
 __all__ = [

--- a/src/supportdoc_rag_chatbot/app/core/query_service.py
+++ b/src/supportdoc_rag_chatbot/app/core/query_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from fastapi import Request
@@ -283,8 +284,22 @@ class QueryOrchestrator:
 def create_query_orchestrator(*, settings: BackendSettings) -> QueryOrchestrator:
     """Create the canonical backend query orchestrator from backend settings."""
 
+    retriever_kwargs: dict[str, Any] = {}
+    if (
+        settings.query_retrieval_mode is not None
+        and settings.query_retrieval_mode.value == "artifact"
+    ):
+        retriever_kwargs = {
+            "chunks_path": _optional_path(settings.query_artifact_chunks_path),
+            "index_path": _optional_path(settings.query_artifact_index_path),
+            "metadata_path": _optional_path(settings.query_artifact_index_metadata_path),
+            "row_mapping_path": _optional_path(settings.query_artifact_row_mapping_path),
+            "embedder_mode": settings.query_artifact_embedder_mode,
+            "embedder_fixture_path": _optional_path(settings.query_artifact_embedder_fixture_path),
+        }
+
     try:
-        retriever = create_query_retriever(mode=settings.query_retrieval_mode)
+        retriever = create_query_retriever(mode=settings.query_retrieval_mode, **retriever_kwargs)
     except ValueError as exc:
         raise QueryPipelineConfigurationError(
             f"Invalid retrieval backend configuration: {exc}"
@@ -350,6 +365,12 @@ def _render_generation_failure(failure) -> str:
         f"Generation backend failed with {failure.code.value}: {failure.message} "
         f"(backend={failure.backend_name})"
     )
+
+
+def _optional_path(value: str | None) -> Path | None:
+    if value is None:
+        return None
+    return Path(value)
 
 
 def _validate_required_string(value: str, *, field_name: str) -> str:

--- a/src/supportdoc_rag_chatbot/app/core/retrieval.py
+++ b/src/supportdoc_rag_chatbot/app/core/retrieval.py
@@ -11,6 +11,7 @@ from supportdoc_rag_chatbot.app.services.policy_types import RetrievalScoreNorma
 from supportdoc_rag_chatbot.evaluation import RetrievalHit
 from supportdoc_rag_chatbot.ingestion.schemas import ChunkRecord
 from supportdoc_rag_chatbot.retrieval.embeddings import DEFAULT_BATCH_SIZE, DEFAULT_DEVICE
+from supportdoc_rag_chatbot.retrieval.embeddings.fixture import load_fixture_embedder
 from supportdoc_rag_chatbot.retrieval.embeddings.job import load_chunk_records
 from supportdoc_rag_chatbot.retrieval.embeddings.models import DenseEmbedder, create_local_embedder
 from supportdoc_rag_chatbot.retrieval.indexes import (
@@ -35,6 +36,10 @@ class RetrievalBackendMode(StrEnum):
 
     FIXTURE = "fixture"
     ARTIFACT = "artifact"
+
+
+_DEFAULT_ARTIFACT_EMBEDDER_MODE = "local"
+_VALID_ARTIFACT_EMBEDDER_MODES = {"local", "fixture"}
 
 
 @dataclass(slots=True, frozen=True)
@@ -168,6 +173,15 @@ class RetrievedEvidenceBundle:
 
     def to_citation_contexts(self) -> list[RetrievedChunkCitationContext]:
         return [chunk.to_citation_context() for chunk in self.chunks]
+
+
+def _normalize_artifact_embedder_mode(mode: str) -> str:
+    normalized = _validate_required_string(mode, field_name="embedder_mode").casefold()
+    if normalized not in _VALID_ARTIFACT_EMBEDDER_MODES:
+        raise ValueError(
+            "embedder_mode must be one of: " + ", ".join(sorted(_VALID_ARTIFACT_EMBEDDER_MODES))
+        )
+    return normalized
 
 
 def _normalize_question(question: str) -> str:
@@ -340,13 +354,15 @@ class FixtureQueryRetriever:
 class ArtifactDenseQueryRetriever:
     """Artifact-backed dense retrieval adapter for the backend query pipeline."""
 
-    index_path: Path = DEFAULT_FAISS_INDEX_PATH
-    metadata_path: Path = DEFAULT_FAISS_METADATA_PATH
+    index_path: Path | None = DEFAULT_FAISS_INDEX_PATH
+    metadata_path: Path | None = DEFAULT_FAISS_METADATA_PATH
     row_mapping_path: Path | None = DEFAULT_FAISS_ROW_MAPPING_PATH
     chunks_path: Path | None = None
     model_name: str | None = None
     device: str = DEFAULT_DEVICE
     batch_size: int = DEFAULT_BATCH_SIZE
+    embedder_mode: str = _DEFAULT_ARTIFACT_EMBEDDER_MODE
+    embedder_fixture_path: Path | None = None
     name: str = "dense-artifact-retriever"
     retriever_type: str = "dense-artifact"
     embedder: DenseEmbedder | None = None
@@ -354,6 +370,16 @@ class ArtifactDenseQueryRetriever:
     _resolved_backend: FaissDenseIndexBackend | None = field(default=None, init=False, repr=False)
     _resolved_embedder: DenseEmbedder | None = field(default=None, init=False, repr=False)
     _chunk_map: dict[str, ChunkRecord] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.index_path = Path(self.index_path or DEFAULT_FAISS_INDEX_PATH)
+        self.metadata_path = Path(self.metadata_path or DEFAULT_FAISS_METADATA_PATH)
+        self.row_mapping_path = Path(self.row_mapping_path or DEFAULT_FAISS_ROW_MAPPING_PATH)
+        self.chunks_path = Path(self.chunks_path) if self.chunks_path is not None else None
+        self.embedder_fixture_path = (
+            Path(self.embedder_fixture_path) if self.embedder_fixture_path is not None else None
+        )
+        self.embedder_mode = _normalize_artifact_embedder_mode(self.embedder_mode)
 
     @property
     def backend_mode(self) -> RetrievalBackendMode:
@@ -369,6 +395,10 @@ class ArtifactDenseQueryRetriever:
             "model_name": self.model_name,
             "device": self.device,
             "batch_size": self.batch_size,
+            "embedder_mode": self.embedder_mode,
+            "embedder_fixture_path": (
+                str(self.embedder_fixture_path) if self.embedder_fixture_path else None
+            ),
             "score_normalization": RetrievalScoreNormalization.UNIT_INTERVAL.value,
         }
 
@@ -468,8 +498,27 @@ class ArtifactDenseQueryRetriever:
     def _ensure_embedder_loaded(self, backend: FaissDenseIndexBackend) -> DenseEmbedder:
         if self._resolved_embedder is not None:
             return self._resolved_embedder
+        if self.embedder is not None:
+            self._resolved_embedder = self.embedder
+            return self._resolved_embedder
+
+        if self.embedder_mode == "fixture":
+            if self.embedder_fixture_path is None:
+                raise QueryPipelineConfigurationError(
+                    "Artifact retrieval fixture embedder mode requires an embedder fixture path."
+                )
+            try:
+                self._resolved_embedder = load_fixture_embedder(Path(self.embedder_fixture_path))
+            except FileNotFoundError as exc:
+                raise QueryPipelineConfigurationError(str(exc)) from exc
+            except ValueError as exc:
+                raise QueryPipelineConfigurationError(
+                    f"Artifact retrieval fixture embedder is invalid: {exc}"
+                ) from exc
+            return self._resolved_embedder
+
         try:
-            self._resolved_embedder = self.embedder or create_local_embedder(
+            self._resolved_embedder = create_local_embedder(
                 model_name=(self.model_name or backend.metadata.embedding_model_name),
                 device=self.device,
                 batch_size=self.batch_size,

--- a/src/supportdoc_rag_chatbot/config.py
+++ b/src/supportdoc_rag_chatbot/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
-from typing import Mapping
+from typing import Literal, Mapping
 
 from dotenv import load_dotenv
 from fastapi import Request
@@ -22,6 +22,7 @@ DEFAULT_API_REDOC_URL = "/redoc"
 DEFAULT_QUERY_RETRIEVAL_MODE = RetrievalBackendMode.FIXTURE
 DEFAULT_QUERY_GENERATION_MODE = GenerationBackendMode.FIXTURE
 DEFAULT_QUERY_TOP_K = 3
+DEFAULT_QUERY_ARTIFACT_EMBEDDER_MODE: Literal["local", "fixture"] = "local"
 
 
 class BackendSettings(BaseModel):
@@ -39,6 +40,14 @@ class BackendSettings(BaseModel):
     query_generation_base_url: str | None = None
     query_generation_timeout_seconds: float = Field(default=DEFAULT_GENERATION_TIMEOUT_SECONDS)
     query_top_k: int = Field(default=DEFAULT_QUERY_TOP_K)
+    query_artifact_chunks_path: str | None = None
+    query_artifact_index_path: str | None = None
+    query_artifact_index_metadata_path: str | None = None
+    query_artifact_row_mapping_path: str | None = None
+    query_artifact_embedder_mode: Literal["local", "fixture"] = Field(
+        default=DEFAULT_QUERY_ARTIFACT_EMBEDDER_MODE
+    )
+    query_artifact_embedder_fixture_path: str | None = None
 
     @field_validator(
         "app_name",
@@ -54,13 +63,28 @@ class BackendSettings(BaseModel):
             raise ValueError(f"{info.field_name} must not be blank")
         return normalized
 
-    @field_validator("query_generation_base_url")
+    @field_validator(
+        "query_generation_base_url",
+        "query_artifact_chunks_path",
+        "query_artifact_index_path",
+        "query_artifact_index_metadata_path",
+        "query_artifact_row_mapping_path",
+        "query_artifact_embedder_fixture_path",
+    )
     @classmethod
-    def _validate_optional_base_url(cls, value: str | None) -> str | None:
+    def _validate_optional_string(cls, value: str | None) -> str | None:
         if value is None:
             return None
         normalized = value.strip()
         return normalized or None
+
+    @field_validator("query_artifact_embedder_mode")
+    @classmethod
+    def _validate_artifact_embedder_mode(cls, value: str) -> str:
+        normalized = value.strip().casefold()
+        if normalized not in {"local", "fixture"}:
+            raise ValueError("query_artifact_embedder_mode must be 'local' or 'fixture'")
+        return normalized
 
     @field_validator("query_generation_timeout_seconds")
     @classmethod
@@ -133,6 +157,31 @@ def load_backend_settings(environ: Mapping[str, str] | None = None) -> BackendSe
             "SUPPORTDOC_QUERY_TOP_K",
             default=DEFAULT_QUERY_TOP_K,
         ),
+        query_artifact_chunks_path=_read_env_optional_string(
+            source,
+            "SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH",
+        ),
+        query_artifact_index_path=_read_env_optional_string(
+            source,
+            "SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH",
+        ),
+        query_artifact_index_metadata_path=_read_env_optional_string(
+            source,
+            "SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH",
+        ),
+        query_artifact_row_mapping_path=_read_env_optional_string(
+            source,
+            "SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH",
+        ),
+        query_artifact_embedder_mode=_read_env_string(
+            source,
+            "SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE",
+            default=DEFAULT_QUERY_ARTIFACT_EMBEDDER_MODE,
+        ),
+        query_artifact_embedder_fixture_path=_read_env_optional_string(
+            source,
+            "SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_FIXTURE_PATH",
+        ),
     )
 
 
@@ -196,6 +245,7 @@ __all__ = [
     "DEFAULT_API_ENVIRONMENT",
     "DEFAULT_API_REDOC_URL",
     "DEFAULT_API_TITLE",
+    "DEFAULT_QUERY_ARTIFACT_EMBEDDER_MODE",
     "DEFAULT_QUERY_GENERATION_MODE",
     "DEFAULT_QUERY_RETRIEVAL_MODE",
     "DEFAULT_QUERY_TOP_K",

--- a/src/supportdoc_rag_chatbot/retrieval/embeddings/fixture.py
+++ b/src/supportdoc_rag_chatbot/retrieval/embeddings/fixture.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+DEFAULT_FIXTURE_EMBEDDER_MODEL_NAME = "supportdoc-artifact-smoke-fixture-v1"
+
+
+@dataclass(slots=True, frozen=True)
+class FixtureEmbeddingMap:
+    model_name: str
+    vectors_by_text: dict[str, tuple[float, ...]]
+
+    @property
+    def vector_dimension(self) -> int:
+        first_vector = next(iter(self.vectors_by_text.values()))
+        return len(first_vector)
+
+
+@dataclass(slots=True)
+class FixtureDenseEmbedder:
+    model_name: str
+    vectors_by_text: dict[str, tuple[float, ...]]
+
+    def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+        rows: list[list[float]] = []
+        for text in texts:
+            try:
+                vector = self.vectors_by_text[text]
+            except KeyError as exc:
+                raise ValueError(
+                    f"Fixture embedder mapping is missing a vector for text: {text!r}"
+                ) from exc
+            rows.append([float(value) for value in vector])
+        return rows
+
+
+def create_fixture_embedder(
+    *,
+    model_name: str = DEFAULT_FIXTURE_EMBEDDER_MODEL_NAME,
+    vectors_by_text: Mapping[str, Sequence[float]],
+) -> FixtureDenseEmbedder:
+    fixture_map = FixtureEmbeddingMap(
+        model_name=_validate_model_name(model_name),
+        vectors_by_text=_normalize_vectors_by_text(vectors_by_text),
+    )
+    return FixtureDenseEmbedder(
+        model_name=fixture_map.model_name,
+        vectors_by_text=dict(fixture_map.vectors_by_text),
+    )
+
+
+def load_fixture_embedder(path: Path) -> FixtureDenseEmbedder:
+    fixture_map = read_fixture_embedding_map(path)
+    return FixtureDenseEmbedder(
+        model_name=fixture_map.model_name,
+        vectors_by_text=dict(fixture_map.vectors_by_text),
+    )
+
+
+def read_fixture_embedding_map(path: Path) -> FixtureEmbeddingMap:
+    if not path.exists():
+        raise FileNotFoundError(f"Fixture embedding map not found: {path}")
+    if not path.is_file():
+        raise FileNotFoundError(f"Fixture embedding map is not a file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Fixture embedding map is not valid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Fixture embedding map payload must be a JSON object")
+
+    model_name = _validate_model_name(payload.get("model_name"))
+    raw_vectors = payload.get("vectors_by_text")
+    if not isinstance(raw_vectors, dict):
+        raise ValueError("Fixture embedding map must define a vectors_by_text object")
+
+    return FixtureEmbeddingMap(
+        model_name=model_name,
+        vectors_by_text=_normalize_vectors_by_text(raw_vectors),
+    )
+
+
+def write_fixture_embedding_map(
+    path: Path,
+    *,
+    model_name: str = DEFAULT_FIXTURE_EMBEDDER_MODEL_NAME,
+    vectors_by_text: Mapping[str, Sequence[float]],
+) -> Path:
+    fixture_map = FixtureEmbeddingMap(
+        model_name=_validate_model_name(model_name),
+        vectors_by_text=_normalize_vectors_by_text(vectors_by_text),
+    )
+    payload = {
+        "model_name": fixture_map.model_name,
+        "vectors_by_text": {
+            text: [float(value) for value in vector]
+            for text, vector in fixture_map.vectors_by_text.items()
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def _normalize_vectors_by_text(
+    vectors_by_text: Mapping[str, Sequence[float]] | dict[str, Any],
+) -> dict[str, tuple[float, ...]]:
+    normalized: dict[str, tuple[float, ...]] = {}
+    expected_dimension: int | None = None
+    for raw_text, raw_vector in vectors_by_text.items():
+        text = _validate_required_string(raw_text, field_name="text")
+        if not isinstance(raw_vector, Sequence) or isinstance(raw_vector, (str, bytes, bytearray)):
+            raise ValueError(
+                f"Fixture embedding map vector for {text!r} must be an array of numbers"
+            )
+        vector = tuple(float(value) for value in raw_vector)
+        if not vector:
+            raise ValueError(f"Fixture embedding map vector for {text!r} must not be empty")
+        if expected_dimension is None:
+            expected_dimension = len(vector)
+        elif len(vector) != expected_dimension:
+            raise ValueError(
+                "Fixture embedding map vectors must all share the same dimension: "
+                f"expected {expected_dimension}, got {len(vector)} for {text!r}"
+            )
+        normalized[text] = vector
+
+    if not normalized:
+        raise ValueError("Fixture embedding map must define at least one text vector")
+    return normalized
+
+
+def _validate_required_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
+
+
+def _validate_model_name(value: Any) -> str:
+    return _validate_required_string(value, field_name="model_name")
+
+
+__all__ = [
+    "DEFAULT_FIXTURE_EMBEDDER_MODEL_NAME",
+    "FixtureDenseEmbedder",
+    "FixtureEmbeddingMap",
+    "create_fixture_embedder",
+    "load_fixture_embedder",
+    "read_fixture_embedding_map",
+    "write_fixture_embedding_map",
+]

--- a/tests/test_artifact_api_smoke.py
+++ b/tests/test_artifact_api_smoke.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from supportdoc_rag_chatbot.app.api import create_app
+from supportdoc_rag_chatbot.app.core.artifact_smoke import build_artifact_smoke_fixture
+from supportdoc_rag_chatbot.app.core.local_workflow import evaluate_local_api_readiness
+from supportdoc_rag_chatbot.app.schemas import QueryResponse, RefusalReasonCode
+from supportdoc_rag_chatbot.config import BackendSettings, load_backend_settings
+
+
+def _artifact_smoke_settings(fixture_dir: Path) -> BackendSettings:
+    fixture = build_artifact_smoke_fixture(fixture_dir)
+    return BackendSettings(
+        app_name="SupportDoc Artifact Smoke API",
+        environment="test",
+        api_version="9.9.9",
+        docs_url="/docs",
+        redoc_url="/redoc",
+        query_retrieval_mode="artifact",
+        query_generation_mode="fixture",
+        query_top_k=3,
+        query_artifact_chunks_path=str(fixture.chunks_path),
+        query_artifact_index_path=str(fixture.index_path),
+        query_artifact_index_metadata_path=str(fixture.index_metadata_path),
+        query_artifact_row_mapping_path=str(fixture.row_mapping_path),
+        query_artifact_embedder_mode="fixture",
+        query_artifact_embedder_fixture_path=str(fixture.embedder_fixture_path),
+    )
+
+
+def test_artifact_smoke_fixture_materializes_required_artifacts(tmp_path: Path) -> None:
+    fixture = build_artifact_smoke_fixture(tmp_path / "artifact-smoke")
+
+    assert fixture.chunks_path.is_file()
+    assert fixture.index_path.is_file()
+    assert fixture.index_metadata_path.is_file()
+    assert fixture.row_mapping_path.is_file()
+    assert fixture.embedder_fixture_path.is_file()
+    assert fixture.supported_question == "What is a Pod?"
+    assert fixture.refusal_question == "How do I reset my laptop BIOS?"
+    assert fixture.chunk_ids == (
+        "content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+        "content-en-docs-concepts-workloads-pods-pods__chunk-0002",
+    )
+
+
+def test_artifact_mode_local_api_preflight_accepts_override_paths_and_fixture_embedder(
+    tmp_path: Path,
+) -> None:
+    settings = _artifact_smoke_settings(tmp_path)
+
+    report = evaluate_local_api_readiness(settings)
+
+    assert report.mode == "artifact"
+    assert report.is_ready is True
+    assert report.missing_paths == ()
+    assert {check.name for check in report.checks} == {
+        "chunks",
+        "faiss_index",
+        "faiss_index_metadata",
+        "faiss_row_mapping",
+        "artifact_embedder_fixture",
+    }
+
+
+def test_artifact_mode_api_returns_supported_and_refusal_responses_with_override_paths(
+    tmp_path: Path,
+) -> None:
+    fixture = build_artifact_smoke_fixture(tmp_path / "artifact-api")
+    settings = BackendSettings(
+        app_name="SupportDoc Artifact Smoke API",
+        environment="test",
+        api_version="9.9.9",
+        docs_url="/docs",
+        redoc_url="/redoc",
+        query_retrieval_mode="artifact",
+        query_generation_mode="fixture",
+        query_top_k=3,
+        query_artifact_chunks_path=str(fixture.chunks_path),
+        query_artifact_index_path=str(fixture.index_path),
+        query_artifact_index_metadata_path=str(fixture.index_metadata_path),
+        query_artifact_row_mapping_path=str(fixture.row_mapping_path),
+        query_artifact_embedder_mode="fixture",
+        query_artifact_embedder_fixture_path=str(fixture.embedder_fixture_path),
+    )
+
+    with TestClient(create_app(settings=settings)) as client:
+        readyz_response = client.get("/readyz")
+        assert readyz_response.status_code == 200
+        assert readyz_response.json()["status"] == "ready"
+
+        supported_response = client.post("/query", json={"question": "What is a Pod?"})
+        assert supported_response.status_code == 200
+        supported = QueryResponse.model_validate(supported_response.json())
+        assert supported.refusal.is_refusal is False
+        assert {citation.chunk_id for citation in supported.citations}.issubset(
+            set(fixture.chunk_ids)
+        )
+        assert supported.citations[0].chunk_id == fixture.chunk_ids[0]
+
+        refusal_response = client.post(
+            "/query",
+            json={"question": "How do I reset my laptop BIOS?"},
+        )
+        assert refusal_response.status_code == 200
+        refusal = QueryResponse.model_validate(refusal_response.json())
+        assert refusal.refusal.is_refusal is True
+        assert refusal.refusal.reason_code is RefusalReasonCode.NO_RELEVANT_DOCS
+        assert refusal.citations == []
+
+
+def test_backend_settings_load_artifact_smoke_override_environment() -> None:
+    settings = load_backend_settings(
+        {
+            "SUPPORTDOC_QUERY_RETRIEVAL_MODE": "artifact",
+            "SUPPORTDOC_QUERY_GENERATION_MODE": "fixture",
+            "SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH": "/tmp/chunks.jsonl",
+            "SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH": "/tmp/chunk_index.faiss",
+            "SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH": "/tmp/chunk_index.metadata.json",
+            "SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH": "/tmp/chunk_index.row_mapping.json",
+            "SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE": "fixture",
+            "SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_FIXTURE_PATH": "/tmp/query_embedding_fixture.json",
+        }
+    )
+
+    assert settings.query_artifact_chunks_path == "/tmp/chunks.jsonl"
+    assert settings.query_artifact_index_path == "/tmp/chunk_index.faiss"
+    assert settings.query_artifact_index_metadata_path == "/tmp/chunk_index.metadata.json"
+    assert settings.query_artifact_row_mapping_path == "/tmp/chunk_index.row_mapping.json"
+    assert settings.query_artifact_embedder_mode == "fixture"
+    assert settings.query_artifact_embedder_fixture_path == "/tmp/query_embedding_fixture.json"
+
+
+def test_artifact_smoke_script_has_help_and_uses_artifact_override_path() -> None:
+    script = Path("scripts/smoke-artifact-api.sh")
+    assert script.is_file()
+
+    help_result = subprocess.run(
+        ["bash", str(script), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Usage: ./scripts/smoke-artifact-api.sh" in help_result.stdout
+    assert "--port" in help_result.stdout
+    assert "--keep-temp" in help_result.stdout
+    assert "--extra faiss" in help_result.stdout
+
+    content = script.read_text(encoding="utf-8")
+    assert "build_artifact_smoke_fixture" in content
+    assert "SUPPORTDOC_LOCAL_API_MODE=artifact" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE=fixture" in content
+    assert "QueryResponse.model_validate" in content
+    assert "RefusalReasonCode.NO_RELEVANT_DOCS" in content
+    assert "Artifact-mode API smoke diagnostics" in content
+    assert "trap cleanup EXIT" in content
+
+
+def test_readme_documents_canonical_artifact_mode_smoke_command() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+
+    assert "### Canonical artifact-mode smoke command" in content
+    assert "./scripts/smoke-artifact-api.sh" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE=local|fixture" in content
+    assert "no long-running model server or local embedding stack is required" in content


### PR DESCRIPTION
Closes #88
---

Add a deterministic artifact-mode API smoke path that boots the backend in artifact mode, points it at a tiny committed-at-runtime FAISS fixture, and validates supported + refusal `/query` responses over real HTTP without requiring a long-running model server or the local embeddings stack.

- Added `scripts/smoke-artifact-api.sh` as the canonical artifact-mode smoke command.
- Added `src/supportdoc_rag_chatbot/app/core/artifact_smoke.py` to materialize a tiny deterministic artifact fixture at runtime:
  - `chunks.jsonl`
  - `chunk_embeddings.f32`
  - `chunk_embeddings.metadata.json`
  - `chunk_index.faiss`
  - `chunk_index.metadata.json`
  - `chunk_index.row_mapping.json`
  - `query_embedding_fixture.json`
- Added `src/supportdoc_rag_chatbot/retrieval/embeddings/fixture.py` for the smoke-only fixture embedder mapping loader/writer.
- Extended `BackendSettings` with explicit artifact-path overrides and a smoke-only artifact embedder override:
  - `SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH`
  - `SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH`
  - `SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH`
  - `SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH`
  - `SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_MODE=local|fixture`
  - `SUPPORTDOC_QUERY_ARTIFACT_EMBEDDER_FIXTURE_PATH`
- Updated local API preflight to validate override paths and the fixture-embedder file when that mode is selected.
- Updated query orchestrator construction so artifact-mode startup can consume the override paths from settings.
- Updated `ArtifactDenseQueryRetriever` to support the fixture embedder path while preserving the existing local-embedder baseline as the default.
- Documented the canonical artifact smoke command and override env vars in `README.md`.
- Added `tests/test_artifact_api_smoke.py` to cover fixture generation, override-path readiness, end-to-end artifact-mode query behavior, script help/content, and README documentation.
- Updated `uv.lock` because the provided ZIP’s lockfile did not satisfy `uv sync --locked --extra dev-tools --extra faiss` during fresh overlay validation.

This closes the missing readiness gap between fixture-only local API smoke and real artifact-backed retrieval. The new smoke path proves that the backend can:

- load artifact-backed retrieval inputs,
- embed the query deterministically for smoke runs,
- retrieve evidence from the FAISS artifact set,
- flow that evidence through prompting / citation validation,
- and return the canonical trust contract over HTTP.

It also keeps smoke runs isolated from a developer’s personal `data/processed/` state by using temporary override paths.

Executed on the working tree:

- `uv sync --locked --extra dev-tools --extra faiss`
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run ruff format --check .`
- `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py`
- `uv run pytest -q` → `152 passed`
- `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...`
- `scripts/smoke-artifact-api.sh`

---

Changes to be committed:
	modified:   README.md
	new file:   scripts/smoke-artifact-api.sh
	new file:   src/supportdoc_rag_chatbot/app/core/artifact_smoke.py
	modified:   src/supportdoc_rag_chatbot/app/core/local_workflow.py
	modified:   src/supportdoc_rag_chatbot/app/core/query_service.py
	modified:   src/supportdoc_rag_chatbot/app/core/retrieval.py
	modified:   src/supportdoc_rag_chatbot/config.py
	new file:   src/supportdoc_rag_chatbot/retrieval/embeddings/fixture.py
	new file:   tests/test_artifact_api_smoke.py