### PR TITLE
On branch doc/91-repo-polish-and-source-of-truth-cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,29 @@ The initial corpus is a pinned snapshot of Kubernetes documentation so the proje
 This README is maintained as a live project document and evolves with each completed task issue.
 
 ### Current Phase
-Trust-layer response contract scaffolded with a canonical schema, checked-in fixtures, and local smoke validation.
+API-first MVP validation with reviewed evidence, documented smoke paths, and source-of-truth cleanup.
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
 - Corpus governance documentation in `docs/data/corpus.md`.
 - Ingestion pipeline artifacts for manifest generation, parsing, section extraction, chunking, and validation.
-- Stable `chunks.jsonl` artifact with chunk-level provenance metadata.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
 - Local FAISS backend that builds, persists, reloads, and searches a dense index over saved embedding artifacts.
 - Developer-facing retrieval smoke CLI for local dense search over a saved FAISS index.
 - Shared retrieval evaluation harness plus dense, BM25, and hybrid baseline runners that execute the committed Dev QA set and write deterministic result artifacts.
-- Retrieval comparison note documenting baseline configs, reference fixture metrics, trade-offs, and the provisional default retrieval mode for later epics.
+- Retrieval comparison note documenting baseline configs, reference fixture metrics, trade-offs, and the provisional hybrid recommendation for later retrieval integration work.
 - Canonical trust-layer `QueryResponse` schema with Pydantic validation, checked-in JSON Schema, example answer/refusal fixtures, and a local trust smoke command.
+- Fixture-mode local API smoke path via `./scripts/run-api-local.sh`.
+- Artifact-mode API smoke suite via `./scripts/smoke-artifact-api.sh`.
+- Container runtime smoke validation via `./scripts/smoke-container-runtime.sh`.
+- Final evidence review package under `docs/validation/` with a committed review set, rubric, results template, raw reviewed outputs, and reviewed summary.
+- AWS baseline deployment notes plus companion cost / ops guidance under `docs/architecture/` and `docs/ops/`.
 
 ### In Progress
-- Prompt rules for citation-backed generation.
-- Citation validation against retrieved evidence spans.
-- Retrieval sufficiency gating before final answer emission.
+- Final MVP readiness closeout / summary documentation.
 
 ### Next Up
-- Wire prompt-generation outputs onto the canonical trust response contract.
-- Connect citation validation and refusal gating to the provisional hybrid retrieval default.
-- Expand deployment and observability documentation as the backend/API layer matures.
+- Publish the final readiness report and closure checklist for Epic 10.
 
 ---
 
@@ -58,7 +58,7 @@ This is the main orchestration layer implemented in this repository. It is respo
 - refusal enforcement.
 
 ### Infrastructure Layer
-The intended deployment target is an AWS-backed web application with a frontend, backend API, vector search layer, and model-serving component. The proposal currently targets a React-based UI, a FastAPI backend, object storage for artifacts, and a vector store such as FAISS, pgvector, or OpenSearch depending on the stage of the project.
+The deploy-now MVP is **API-first**. The repository currently proves the backend shell, trust contract, local artifact-backed retrieval path, and container/runtime smoke workflows. A future React frontend remains explicitly deferred and is documented only as a later deployment option in `docs/architecture/aws_deployment.md`.
 
 ### High-Level System Flow
 
@@ -395,6 +395,8 @@ Prerequisite:
 uv sync --locked --extra dev-tools --extra faiss
 ```
 
+For one place to find the fixture smoke path, artifact smoke path, container runtime smoke, and reviewed evidence artifacts, start at `docs/validation/README.md`.
+
 ### Optional local configuration
 
 Set shell-wrapper options with flags or exported environment variables:
@@ -544,6 +546,8 @@ Evaluation work is planned in two stages:
 
 Retrieval-only artifacts live under `data/evaluation/`. The current artifact-backed MVP trust pass now lives under `docs/validation/final_evidence_review.md`, with the versioned review set in `data/evaluation/final_evidence_review.k8s-9e1e32b.v1.jsonl`.
 
+The canonical validation index for Epic 10 now lives at `docs/validation/README.md`.
+
 ## 9A. Development Retrieval QA Set
 
 A small versioned development QA set now lives under `data/evaluation/` for retrieval-only baseline work. The current committed dataset targets snapshot `k8s-9e1e32b` from `data/manifests/source_manifest.jsonl` and includes answerable plus intentionally unanswerable questions, along with expected section/chunk evidence IDs for retrieval checks.
@@ -575,23 +579,35 @@ See `docs/process/hybrid_retrieval_baseline.md` for the default fusion strategy,
 
 A retrieval-only comparison note now lives at `docs/process/retrieval_comparison_notes.md`. It records the current Epic 4 baseline configs, reference fixture metrics from the shared evaluation harness, qualitative trade-offs, and a **provisional default recommendation of `hybrid-rrf`** for follow-on work.
 
-Because the repository does not commit local processed chunk / embedding / FAISS artifacts, the comparison note distinguishes between reproducible fixture metrics and future corpus-level runs that can be regenerated locally when those artifacts exist.
+Because the repository does not commit local processed chunk / embedding / FAISS artifacts, the comparison note distinguishes between reproducible fixture metrics and future corpus-level runs that can be regenerated locally when those artifacts exist. That recommendation is still an evaluation artifact, not a claim that the current checked-in API path already runs hybrid retrieval end to end.
+
+## 9D. Validation index and reviewed trust artifacts
+
+The final MVP validation materials are grouped under `docs/validation/`:
+
+- `docs/validation/README.md` — entry point for smoke commands and reviewed trust artifacts
+- `docs/validation/final_evidence_review.md` — reviewed evidence correctness summary
+- `docs/validation/final_evidence_review_rubric.md` — reviewer rubric
+- `docs/validation/final_evidence_review_results.template.md` — blank results template
+- `docs/validation/final_evidence_review.first_pass.raw.json` — first reviewed pass raw outputs
+- `docs/validation/final_evidence_review.final_pass.raw.json` — final reviewed pass raw outputs
 
 ---
 
 ## 10. Deployment Overview
 
-The intended deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The local MVP keeps artifacts simple so the deployment architecture can evolve without rewriting the ingestion or embedding steps.
+The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo is API-first**: backend runtime proof, local smoke workflows, reviewed trust artifacts, and an AWS baseline that labels the frontend as deferred.
 
 The canonical AWS deployment baseline for that path now lives in `docs/architecture/aws_deployment.md`, with the rendered diagram in `docs/diagrams/aws_deployment.md` and the versioned Mermaid source in `docs/diagrams/aws_deployment.mmd`.
 
 ---
 
-## 11. Documentation Map / Roadmap
+## 11. Documentation Map / Source of Truth
 
 - `docs/process/git_workflow.md` — branch / PR / lockfile workflow
 - `docs/data/corpus.md` — corpus scope and licensing notes
 - `docs/diagrams/ingestion_pipeline.md` — ingestion pipeline overview
+- `docs/validation/README.md` — validation entry point for fixture smoke, artifact smoke, container runtime smoke, and reviewed trust artifacts
 - `docs/architecture/aws_deployment.md` — canonical AWS deployment baseline, deploy-now scope, and deferred options
 - `docs/diagrams/aws_deployment.md` — AWS deployment diagram
 - `docs/adr/` — architecture decisions and project rationale
@@ -599,4 +615,5 @@ The canonical AWS deployment baseline for that path now lives in `docs/architect
 - `docs/process/retrieval_comparison_notes.md` — Epic 4 baseline comparison and provisional default selection
 - `docs/process/trust_response_contract.md` — canonical response contract, schema artifact, and smoke command
 - `docs/process/refusal_response_builder.md` — canonical refusal messages and builder entry points
-- `PROPOSAL.md` — project proposal and delivery framing
+- `docs/validation/final_evidence_review.md` — reviewed evidence correctness summary for the current MVP trust pass
+- `PROPOSAL.md` — historical proposal / delivery framing only; do not treat it as the operational source of truth

--- a/docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md
+++ b/docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md
@@ -115,5 +115,5 @@ The baseline should preserve enough standalone meaning for retrieval and generat
 ## Links
 
 - **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §4.4, §5.2, §6.3, §10.1, §11.1
-- **Code:** `<replace-with-repo-path-to-ingestion-code>`
-- **Issue:** `<replace-with-sub-issue-number>`
+- **Code:** `src/supportdoc_rag_chatbot/ingestion/build_manifest.py`, `src/supportdoc_rag_chatbot/ingestion/parse_docs.py`, `src/supportdoc_rag_chatbot/ingestion/chunk_docs.py`, `src/supportdoc_rag_chatbot/ingestion/chunker.py`, `src/supportdoc_rag_chatbot/ingestion/validator.py`
+- **Scope:** `EPIC 2 — Ingestion pipeline (parse → chunk → metadata)`

--- a/docs/adr/0003-embedding-model-and-serving-strategy.md
+++ b/docs/adr/0003-embedding-model-and-serving-strategy.md
@@ -9,15 +9,15 @@
 
 The retrieval stack requires a dense embedding model that is practical for a capstone-scale RAG system, reproducible across runs, and straightforward to serve locally and later in a deployment environment.
 
-The proposal narrows the candidate space to **E5** or **BGE**-class embedding models and allows either local serving or a dedicated embeddings service boundary.
+The original proposal narrowed the candidate space to **E5** or **BGE**-class embedding models. The committed repo, however, now pins a lighter local default in code so the API smoke paths and retrieval baselines can run on an ordinary developer machine without a separate embeddings service.
 
 ## Decision
 
-Use an **E5/BGE-class dense bi-encoder embedding model** as the semantic retrieval baseline.
+Use `sentence-transformers/all-MiniLM-L6-v2` as the **default local dense embedding model** for the current MVP, while keeping the embedding entry points configurable so another checkpoint can be benchmarked and promoted later.
 
 The architectural rules are:
 
-- Pin the exact checkpoint in configuration, for example with `EMBEDDING_MODEL_ID`.
+- Pin the exact checkpoint in code and CLI defaults.
 - Start with **local/in-process serving** for development simplicity.
 - Preserve the option to move embeddings behind a dedicated service boundary, such as **TEI**, when throughput or deployment isolation matters.
 - Record the exact model identifier and revision in evaluation artifacts for reproducibility.
@@ -52,7 +52,7 @@ The project is explicitly oriented around an open-source, reproducible stack.
 **Why not chosen**
 Semantic retrieval is a primary requirement for the support-doc use case.
 
-### 3. Larger embedding models by default
+### 3. Heavier E5 or BGE checkpoints as the immediate default
 
 **Pros**
 - Potential quality gains
@@ -64,26 +64,27 @@ Semantic retrieval is a primary requirement for the support-doc use case.
 - Unnecessary for the initial scoped corpus
 
 **Why not chosen**
-The baseline should optimize for reliability and tractable serving.
+The baseline should optimize for reliability and tractable serving first. Heavier checkpoints can still be benchmarked later without changing the public retrieval interfaces.
 
 ## Consequences
 
 ### Positive
 
 - Keeps the retrieval stack aligned with semantic search requirements
-- Preserves flexibility to benchmark exact E5/BGE checkpoints
+- Preserves flexibility to benchmark stronger E5/BGE checkpoints later
 - Supports local experimentation and later service isolation
 - Improves reproducibility through version pinning
 
 ### Negative / Trade-offs
 
-- Requires benchmarking before finalizing a single checkpoint
+- The lightweight default is a pragmatic runtime choice, not a claim that it is the best final semantic model for every deployment
 - Adds an extra component if TEI is introduced later
 - Index-time and query-time preprocessing must remain consistent
 
 ## Implementation Notes
 
-- Record the final values for `EMBEDDING_MODEL_ID`, revision, vector dimension, and normalization strategy.
+- Keep `src/supportdoc_rag_chatbot/retrieval/embeddings/models.py` as the source of truth for the default local checkpoint.
+- Record the exact model identifier, vector dimension, and normalization strategy in generated embedding metadata.
 - Use the same preprocessing rules for indexing and query embedding.
 - Batch embeddings where practical during ingestion.
 - Cache document embeddings as durable artifacts when possible.
@@ -91,9 +92,9 @@ The baseline should optimize for reliability and tractable serving.
 ## Links
 
 - **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §5.1, §6.3.2, §10.1, §11.2
-- **Code:** `<replace-with-repo-path-to-embedding-config-and-service-code>`
-- **Issue:** `<replace-with-sub-issue-number>`
+- **Code:** `src/supportdoc_rag_chatbot/retrieval/embeddings/models.py`, `src/supportdoc_rag_chatbot/retrieval/embeddings/job.py`, `src/supportdoc_rag_chatbot/retrieval/embeddings/artifacts.py`, `src/supportdoc_rag_chatbot/cli.py`
+- **Scope:** `EPIC 3 — Embeddings + vector index (local MVP first)`
 
 ## Follow-up
 
-Replace this placeholder in the committed version with the exact checkpoint pinned in code, for example one specific E5 or BGE model ID. Only one model ID should remain in the final accepted ADR.
+Future benchmark work can still supersede this ADR with a different default checkpoint, but the current committed source of truth is `sentence-transformers/all-MiniLM-L6-v2`.

--- a/docs/adr/0004-vector-index-and-storage-strategy.md
+++ b/docs/adr/0004-vector-index-and-storage-strategy.md
@@ -94,5 +94,5 @@ FAISS already provides a practical, well-understood baseline.
 ## Links
 
 - **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §5.1, §6.2, §6.6, §9.2.1, §10.1
-- **Code:** `<replace-with-repo-path-to-vector-index-code>`
-- **Issue:** `<replace-with-sub-issue-number>`
+- **Code:** `src/supportdoc_rag_chatbot/retrieval/indexes/faiss_backend.py`, `src/supportdoc_rag_chatbot/retrieval/indexes/base.py`, `src/supportdoc_rag_chatbot/cli.py`, `src/supportdoc_rag_chatbot/evaluation/dense_baseline.py`
+- **Scope:** `EPIC 3 — Embeddings + vector index (local MVP first)`

--- a/docs/adr/0005-retrieval-strategy-and-baseline-selection.md
+++ b/docs/adr/0005-retrieval-strategy-and-baseline-selection.md
@@ -23,8 +23,8 @@ Use **hybrid retrieval as the default target strategy**, while preserving **BM25
 ### Default retrieval shape
 
 - Run a lexical retriever and a dense retriever in parallel.
-- Merge candidate sets using **score normalization and/or Reciprocal Rank Fusion (RRF)**.
-- Start with **top-k = 8** as the default generation context size.
+- Merge candidate sets using **Reciprocal Rank Fusion (RRF)**.
+- Use **top-k = 5** as the default evaluation baseline in the committed retrieval comparison artifacts.
 - Defer reranking until the baseline retrieval comparison is complete.
 
 ### Winner-selection rule
@@ -37,6 +37,8 @@ The default configuration must be justified using at least:
 - **End-to-end latency or TTFT impact**
 
 If later measurements show that a simpler strategy clearly outperforms hybrid retrieval for this corpus and latency budget, this ADR should be superseded with the measured result.
+
+This ADR governs the **retrieval baseline recommendation**. The current checked-in API smoke and evidence-review paths still validate the dense FAISS-backed artifact workflow, not an end-to-end hybrid query path.
 
 ## Alternatives Considered
 
@@ -100,11 +102,11 @@ The baseline hybrid system should be stabilized before adding another ranking st
 - Keep BM25-only and dense-only runnable as first-class baselines.
 - Log component-level retrieval scores where practical.
 - Record `k`, fusion method, and retriever configuration in evaluation artifacts.
-- Link this ADR to the retrieval comparison note or report once that artifact exists.
+- Keep this ADR linked to the committed retrieval comparison note and hybrid-baseline process doc.
 
 ## Links
 
 - **Proposal:** `Capstone_Project_Proposal_SupportDoc_RAG_Chatbot_with_Citations_V13.md` §5.2, §6.2, §7.3.1, §7.4, §7.5, §10.1, §11.3
-- **Code:** `<replace-with-repo-path-to-retriever-and-rank-fusion-code>`
-- **Issue:** `<replace-with-sub-issue-number>`
-- **Evaluation artifact:** `<replace-with-retrieval-comparison-note-or-report>`
+- **Code:** `src/supportdoc_rag_chatbot/evaluation/retrievers.py`, `src/supportdoc_rag_chatbot/evaluation/dense_baseline.py`, `src/supportdoc_rag_chatbot/evaluation/bm25_baseline.py`, `src/supportdoc_rag_chatbot/evaluation/hybrid_baseline.py`
+- **Scope:** `EPIC 4 — Retrieval baselines (dense / BM25 / hybrid)`
+- **Evaluation artifact:** `docs/process/retrieval_comparison_notes.md`, `docs/process/hybrid_retrieval_baseline.md`

--- a/docs/architecture/aws_deployment.md
+++ b/docs/architecture/aws_deployment.md
@@ -11,6 +11,8 @@ The baseline is intentionally opinionated so later infra work can build against 
 
 Companion cost and operations notes for the same baseline live in `docs/ops/cost_and_ops.md`.
 
+The runtime / trust validation entry point for this same API-first MVP lives in `docs/validation/README.md`.
+
 ## Baseline decision summary
 
 The capstone MVP will use this default AWS path:
@@ -66,6 +68,8 @@ For immediate deployment readiness, the backend can start in **fixture mode** an
 - deterministic `/healthz` and `/readyz` responses
 - a stable `/query` contract
 - log capture and operational visibility
+
+Those proofs are exercised locally with `./scripts/smoke-container-runtime.sh` and the reviewed trust artifacts grouped under `docs/validation/`.
 
 This is the shortest path from the current repo to an AWS-hosted backend shell.
 

--- a/docs/data/corpus.md
+++ b/docs/data/corpus.md
@@ -32,13 +32,14 @@ The corpus is built from a **pinned snapshot** of the Kubernetes documentation r
 
 ### Snapshot Metadata
 
-> Replace the placeholder values below before the first production ingestion run.
+The committed repo artifacts are currently tied to one pinned snapshot label:
 
 - **Source repository:** https://github.com/kubernetes/website
-- **Snapshot ID:** `<snapshot_commit_hash>`
-- **Snapshot date:** `<YYYY-MM-DD>`
-- **Suggested snapshot label:** `k8s-<short_commit_hash>`
+- **Snapshot ID / label:** `k8s-9e1e32b`
+- **Snapshot date:** not persisted in the committed repo artifacts; for the current MVP, `k8s-9e1e32b` is the reproducibility handle used by the manifest and evaluation datasets
 - **Source base URL:** https://kubernetes.io
+
+If a broader corpus refresh is generated later, keep recording the human-readable snapshot date in the ingest report or release notes, but do not replace the snapshot label as the primary operational identifier.
 
 ### Reproducibility Rule
 
@@ -169,14 +170,18 @@ After ingestion, the project should be able to generate or update the following 
 
 ---
 
-## Corpus Size (Filled After Ingestion)
+## Corpus Size and committed repo signals
 
-These values should be updated after the corpus is ingested from the pinned snapshot.
+The Git-tracked repo intentionally commits the snapshot manifest and evaluation artifacts, but it does **not** commit a full `data/parsed/sections.jsonl` or `data/processed/chunks.jsonl` corpus build. That keeps developer-local processed state out of version control while preserving one stable snapshot label.
 
-- **Documents:** TBD
-- **Sections:** TBD
-- **Chunks:** TBD
-- **Estimated tokens:** TBD
+Current committed signals:
+
+- **Documents in `data/manifests/source_manifest.jsonl`:** `2`
+- **Sections:** not committed in Git; generated locally at `data/parsed/sections.jsonl` during ingestion runs
+- **Chunks:** not committed in Git; generated locally at `data/processed/chunks.jsonl` during ingestion runs
+- **Estimated tokens:** not committed in Git; record this in `data/processed/ingest_report.json` for any full local corpus rebuild
+
+Smoke fixtures and reviewed evidence artifacts intentionally use small deterministic subsets derived from the same snapshot label rather than claiming corpus-wide section/chunk statistics in the repo root docs.
 
 ---
 
@@ -185,11 +190,11 @@ These values should be updated after the corpus is ingested from the pinned snap
 A typical rebuild flow should look like this:
 
 ```bash
-python -m supportdoc_rag_chatbot.ingestion.fetch_snapshot
-python -m supportdoc_rag_chatbot.ingestion.build_manifest
-python -m supportdoc_rag_chatbot.ingestion.parse_docs
-python -m supportdoc_rag_chatbot.ingestion.chunk_docs
-python -m supportdoc_rag_chatbot.ingestion.validate_corpus
+uv run python -m supportdoc_rag_chatbot.ingestion.fetch_snapshot
+uv run python -m supportdoc_rag_chatbot.ingestion.build_manifest
+uv run python -m supportdoc_rag_chatbot.ingestion.parse_docs
+uv run python -m supportdoc_rag_chatbot.ingestion.chunk_docs
+uv run python -m supportdoc_rag_chatbot.ingestion.validate_corpus
 ```
 
 If some commands do not exist yet, this section should still be kept as the target ingestion contract.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,0 +1,91 @@
+# Validation Index
+
+This directory is the source-of-truth landing page for **API-first MVP validation**.
+
+Use it when you want to answer these questions quickly:
+
+- what is the canonical local API smoke path?
+- what is the canonical artifact-mode smoke path?
+- what is the canonical packaged container runtime smoke path?
+- where is the reviewed evidence package for the MVP trust pass?
+
+The current validated scope is intentionally **backend / API first**:
+
+- fixture-mode local API smoke is supported,
+- artifact-mode local API smoke is supported,
+- backend container runtime smoke is supported in fixture mode,
+- reviewed evidence correctness artifacts are committed,
+- frontend delivery remains deferred,
+- artifact-mode inside the container image remains deferred.
+
+## Canonical commands
+
+### Fixture-mode local API smoke
+
+Boot the local API with deterministic fixture responses:
+
+```bash
+./scripts/run-api-local.sh
+```
+
+Docs: `README.md` section `7A. Local API Smoke Workflow`
+
+### Artifact-mode API smoke
+
+Run the deterministic artifact-backed API smoke suite:
+
+```bash
+./scripts/smoke-artifact-api.sh
+```
+
+This path creates a temporary artifact fixture, starts the backend in artifact mode, validates `/healthz`, `/readyz`, and supported + refusal `/query` responses, then cleans up.
+
+Docs: `README.md` section `7A. Local API Smoke Workflow`
+
+### Container runtime smoke
+
+Run the packaged backend runtime smoke path:
+
+```bash
+./scripts/smoke-container-runtime.sh
+```
+
+This path builds the checked-in backend image, starts it with `docker run`, waits for health, validates `/healthz`, `/readyz`, and supported + refusal `/query` responses, then cleans up.
+
+Docs: `README.md` section `7B. Containerized Local API Smoke Workflow`
+
+### Trust-contract schema smoke
+
+Validate the canonical `QueryResponse` fixtures against the committed schema:
+
+```bash
+uv run python -m supportdoc_rag_chatbot smoke-trust-schema \
+  --schema docs/contracts/query_response.schema.json \
+  --answer-fixture docs/contracts/query_response.answer.example.json \
+  --refusal-fixture docs/contracts/query_response.refusal.example.json
+```
+
+Docs: `docs/process/trust_response_contract.md`
+
+## Reviewed evidence package
+
+The final MVP trust pass is documented with these committed artifacts:
+
+- `data/evaluation/final_evidence_review.k8s-9e1e32b.v1.jsonl` — versioned review set
+- `data/evaluation/final_evidence_review.k8s-9e1e32b.v1.metadata.json` — review-set metadata
+- `docs/validation/final_evidence_review_rubric.md` — reviewer rubric
+- `docs/validation/final_evidence_review_results.template.md` — blank review template
+- `docs/validation/final_evidence_review.first_pass.raw.json` — first reviewed pass raw outputs
+- `docs/validation/final_evidence_review.final_pass.raw.json` — final reviewed pass raw outputs
+- `docs/validation/final_evidence_review.md` — reviewed evidence summary and known limitations
+
+## Related source-of-truth docs
+
+- `README.md` — repo overview, local workflows, validation entry points, and deployment framing
+- `docs/data/corpus.md` — corpus snapshot and corpus-governance contract
+- `docs/architecture/aws_deployment.md` — canonical AWS baseline and deferred scope labels
+- `docs/process/retrieval_comparison_notes.md` — retrieval-only baseline comparison and provisional hybrid recommendation
+
+## Readiness-report location
+
+This directory is also the canonical home for the final Epic 10 closeout artifact. When the MVP readiness report is published, it should live alongside the files above so reviewers can find smoke proofs and reviewed trust evidence from one place.


### PR DESCRIPTION
Closes #91
---

Tighten the repo’s source-of-truth documentation so the current MVP reads as one coherent **API-first** story instead of a mix of current behavior, placeholders, and earlier planning intent.

- Updated `README.md` to reflect the current validated MVP state:
  - current phase now reflects API-first MVP validation,
  - completed work now includes fixture API smoke, artifact-mode smoke, container runtime smoke, reviewed evidence artifacts, and AWS baseline docs,
  - validation entry points now point to one canonical landing page,
  - deployment framing now labels the frontend as deferred instead of implied.
- Added `docs/validation/README.md` as the validation index for:
  - fixture-mode local API smoke,
  - artifact-mode API smoke,
  - container runtime smoke,
  - trust-schema smoke,
  - reviewed evidence artifacts,
  - the canonical home for the final Epic 10 closeout report.
- Updated `docs/data/corpus.md` to remove misleading placeholder metadata:
  - replaced snapshot placeholders with the committed snapshot label `k8s-9e1e32b`,
  - replaced fake TBD corpus statistics with explicit committed-repo signals and justified notes about intentionally untracked local artifacts,
  - normalized rebuild commands to `uv run python -m ...`.
- Updated ADR implementation references so they point at real code and scope references instead of placeholders:
  - `docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md`
  - `docs/adr/0003-embedding-model-and-serving-strategy.md`
  - `docs/adr/0004-vector-index-and-storage-strategy.md`
  - `docs/adr/0005-retrieval-strategy-and-baseline-selection.md`
- Aligned `docs/adr/0003-*` with the actual committed local embedding default (`sentence-transformers/all-MiniLM-L6-v2`) instead of leaving the ADR at proposal-era candidate language.
- Aligned `docs/adr/0005-*` with the current retrieval-baseline story:
  - hybrid remains the evaluation recommendation,
  - the checked-in API smoke/evidence path is still the dense artifact-backed backend,
  - no misleading implication that hybrid already powers the reviewed API path.
- Updated `docs/architecture/aws_deployment.md` to point readers at the validation index and to keep the deploy-now scope tied to the current API-first proof points.

This closes the last documentation-drift gap before the final readiness closeout.

A reviewer landing on the repo now gets:

- one obvious validation entry point,
- explicit smoke commands,
- reviewed trust artifacts in a predictable location,
- resolved corpus metadata notes,
- ADRs that reference real code instead of placeholders,
- and a clear distinction between what is implemented now versus what is still deferred.

---
Changes to be committed:
	modified:   README.md
	modified:   docs/adr/0002-ingestion-pipeline-and-chunking-strategy.md
	modified:   docs/adr/0003-embedding-model-and-serving-strategy.md
	modified:   docs/adr/0004-vector-index-and-storage-strategy.md
	modified:   docs/adr/0005-retrieval-strategy-and-baseline-selection.md
	modified:   docs/architecture/aws_deployment.md
	modified:   docs/data/corpus.md
	new file:   docs/validation/README.md