### PR TITLE
On branch frontend/101-scaffold-a-thin-local-browser-UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,10 @@ __marimo__/
 ._*
 .Spotlight-V100
 .Trashes
+# Frontend local artifacts
+frontend/node_modules/
+frontend/.env.local
+frontend/.env.*.local
 # Generated retrieval artifacts
 data/processed/embeddings/
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ API-first MVP validation with reviewed evidence, documented smoke paths, and sou
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
+- Thin React + Vite local browser demo scaffold under `frontend/`.
 - Corpus governance documentation in `docs/data/corpus.md`.
 - Ingestion pipeline artifacts for manifest generation, parsing, section extraction, chunking, and validation.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
@@ -58,7 +59,7 @@ This is the main orchestration layer implemented in this repository. It is respo
 - refusal enforcement.
 
 ### Infrastructure Layer
-The deploy-now MVP is **API-first**. The repository currently proves the backend shell, trust contract, local artifact-backed retrieval path, and container/runtime smoke workflows. A future React frontend remains explicitly deferred and is documented only as a later deployment option in `docs/architecture/aws_deployment.md`.
+The deploy-now MVP remains **API-first** for backend validation. The repository now also includes a thin React browser-demo scaffold under `frontend/`, while frontend hosting, live `/query` wiring, and richer evidence UI remain deferred to later Epic 11 tasks and the deployment baseline in `docs/architecture/aws_deployment.md`.
 
 ### High-Level System Flow
 
@@ -162,6 +163,8 @@ docs/
   data/                   # Corpus and licensing docs
   diagrams/               # Architecture / ingestion diagrams
   process/                # Repo workflow and governance docs
+
+frontend/                 # Thin React + Vite local browser demo shell
 ```
 
 ---
@@ -527,6 +530,43 @@ If artifact-mode container support is needed later, it should be added as an exp
 
 ---
 
+## 7C. Local browser demo scaffold
+
+Epic 11 now includes a thin local React SPA scaffold under `frontend/`. This task intentionally keeps the browser shell small: one page, one question box, one submit button, one result panel, and one status area aligned to `docs/process/browser_demo_contract.md`.
+
+### Start the frontend locally
+
+```bash
+cd frontend
+node -v
+npm install
+npm run dev
+```
+
+Use Node `^20.19.0 || >=22.12.0` for the Vite-based scaffold. The committed `frontend/.npmrc` also keeps the lockfile registry-neutral for local installs on macOS and Linux.
+
+The Vite dev server binds to `http://127.0.0.1:5173` by default.
+
+### API base URL override
+
+The frontend reads `VITE_SUPPORTDOC_API_BASE_URL` and falls back to `http://127.0.0.1:9001`. To point the shell at a different local backend, copy `frontend/.env.example` to `frontend/.env.local` and edit the value.
+
+```bash
+cd frontend
+cp .env.example .env.local
+```
+
+### Current scope of the scaffold
+
+- one-page React SPA
+- placeholder layouts for supported answer, refusal, loading, and backend-unavailable states
+- no auth, persistence, or client-side routing
+- no live `/query` request in this task yet
+
+See `frontend/README.md` for the focused frontend startup note.
+
+---
+
 ## 8. Citations and Refusal Behavior
 
 The repository now includes a canonical trust-layer response contract under `src/supportdoc_rag_chatbot/app/schemas/trust.py`. That contract defines structured supported answers, structured refusals, restricted refusal reason codes, and deterministic JSON Schema export under `docs/contracts/`.
@@ -600,7 +640,7 @@ The single closeout status page for Epic 10 now lives at `docs/validation/mvp_re
 
 ## 10. Deployment Overview
 
-The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo is API-first**: backend runtime proof, local smoke workflows, reviewed trust artifacts, and an AWS baseline that labels the frontend as deferred.
+The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo remains API-first** for backend proof and reviewed trust artifacts, while the repo now also includes a thin local browser scaffold under `frontend/` for Epic 11 demo work. Frontend hosting and richer browser behavior are still deferred in the AWS baseline.
 
 The first browser-demo integration contract for that API-first backend now lives in `docs/process/browser_demo_contract.md`. It freezes the UI against the current `/query` and `/readyz` surface and explicitly defers rich evidence cards until the backend exposes a request-scoped evidence payload.
 
@@ -621,6 +661,7 @@ The canonical AWS deployment baseline for that path now lives in `docs/architect
 - `docs/process/retrieval_comparison_notes.md` — Epic 4 baseline comparison and provisional default selection
 - `docs/process/trust_response_contract.md` — canonical response contract, schema artifact, and smoke command
 - `docs/process/browser_demo_contract.md` — frozen browser-demo state model and current API/UI contract
+- `frontend/README.md` — local startup and API base URL override for the browser demo shell
 - `docs/process/refusal_response_builder.md` — canonical refusal messages and builder entry points
 - `docs/validation/final_evidence_review.md` — reviewed evidence correctness summary for the current MVP trust pass
 - `PROPOSAL.md` — historical proposal / delivery framing only; do not treat it as the operational source of truth

--- a/docs/architecture/aws_deployment.md
+++ b/docs/architecture/aws_deployment.md
@@ -39,12 +39,12 @@ What already exists in the ZIP:
 - local retrieval artifacts built around `chunks.jsonl` plus FAISS index files
 - canonical trust-layer response schema and smoke validation
 - structured backend orchestration for retrieval, refusal gating, generation, and citation validation
+- a checked-in React SPA scaffold under `frontend/` for the local browser demo
 
 What does **not** exist yet in the ZIP:
 
 - a production AWS deployment definition
-- a checked-in frontend application
-- container packaging for deployment
+- frontend deployment packaging or hosting configuration
 - a cloud retrieval adapter for `pgvector`
 - a dedicated AWS inference deployment
 
@@ -60,7 +60,7 @@ It is a subset of the baseline path:
 - keep the public entry point at an ALB
 - wire CloudWatch logging and basic ECS / ALB health monitoring
 - store deployment-time artifacts and future ingestion outputs in S3
-- keep the frontend out of scope for now
+- keep frontend hosting out of scope for now
 
 For immediate deployment readiness, the backend can start in **fixture mode** and prove:
 
@@ -190,6 +190,7 @@ Optional OpenTelemetry tracing is deferred. CloudWatch-first logging is the defa
 - API-first backend exists
 - local fixture and artifact retrieval flows exist
 - local FAISS artifacts are the current retrieval baseline
+- a thin local frontend scaffold exists under `frontend/`
 - no frontend deployment work is committed yet
 - no AWS deployment packaging is committed yet
 
@@ -219,7 +220,7 @@ The following points still need explicit implementation decisions in later infra
 1. **Inference server choice:** vLLM vs TGI for the first EC2 GPU deployment
 2. **Retrieval promotion job:** whether `pgvector` loading happens from a one-off script, ECS task, or CI/CD step
 3. **Artifact promotion path:** which exact S3 prefixes become the stable handoff points for deployment-ready data
-4. **Frontend cutover timing:** whether the capstone demo initially ships API-only or with the React frontend enabled
+4. **Frontend cutover timing:** whether the capstone demo initially ships API-only or with the React frontend query flow enabled
 5. **Dependency-aware readiness:** whether `/readyz` should grow deep checks for RDS and inference before final deployment
 
 ## Diagram source

--- a/docs/ops/cost_and_ops.md
+++ b/docs/ops/cost_and_ops.md
@@ -63,7 +63,7 @@ This posture is useful for short periods, but it should not be the default outsi
 | Artifact storage | S3 | Versioned corpus snapshots, processed artifacts, and evaluation outputs |
 | Observability | CloudWatch Logs / Metrics / Alarms | Small baseline telemetry footprint |
 | Secrets and config | Secrets Manager + SSM Parameter Store | Secrets stay out of the container image |
-| Frontend | Amplify Hosting | Deferred until the frontend exists in the repo |
+| Frontend | Amplify Hosting | Deferred until frontend hosting joins the deployable AWS baseline |
 
 ## Baseline cost table
 

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -15,7 +15,7 @@ The current validated scope is intentionally **backend / API first**:
 - artifact-mode local API smoke is supported,
 - backend container runtime smoke is supported in fixture mode,
 - reviewed evidence correctness artifacts are committed,
-- frontend delivery remains deferred,
+- a thin local browser scaffold now exists under `frontend/`, but frontend query wiring and browser smoke remain outside this validation index,
 - artifact-mode inside the container image remains deferred.
 
 ## Canonical commands

--- a/docs/validation/mvp_readiness.md
+++ b/docs/validation/mvp_readiness.md
@@ -95,7 +95,7 @@ The repo already has container packaging documentation and tests that assert the
 These points are still open or explicitly deferred in the current ZIP and should stay visible in readiness review:
 
 - artifact-mode container support is explicitly deferred in `README.md`
-- no frontend application is committed in this ZIP; the repo remains API-first
+- the validated scope remains API-first; the thin local frontend scaffold under `frontend/` is outside the Epic 10 readiness package
 - AWS deployment architecture is documented, but AWS baseline cost/ops notes are not yet committed
 - container packaging exists, but runtime-smoke and build-smoke evidence are not yet committed as final-readiness artifacts
 - end-to-end evidence review materials and reviewed evidence-correctness outputs are not yet committed in this snapshot

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env.local when you want to override the backend target.
+VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,60 @@
+# Frontend browser demo scaffold
+
+This directory contains the thin React SPA shell for the local browser demo in Epic 11.
+
+Current scope:
+
+- one page only
+- one question input and submit button
+- one result panel for answer / refusal / citation placeholders
+- one status area for empty input, loading, and backend-unavailable treatment
+- no auth, persistence, or multi-page routing
+- no live `/query` request yet; that wiring lands in the next scoped task
+
+The UI behavior is pinned to `docs/process/browser_demo_contract.md`.
+
+## Local startup
+
+Use a Node version supported by Vite before installing dependencies. This scaffold targets Node `^20.19.0 || >=22.12.0`.
+
+```bash
+cd frontend
+node -v
+npm install
+npm run dev
+```
+
+The Vite dev server binds to `http://127.0.0.1:5173` by default.
+
+The checked-in `.npmrc` keeps the lockfile registry-neutral so installs work outside the environment where the lockfile was generated.
+
+If you already hit a failed install once, remove the partial local install and retry:
+
+```bash
+cd frontend
+rm -rf node_modules
+npm install
+```
+
+## API base URL configuration
+
+The app reads `VITE_SUPPORTDOC_API_BASE_URL` and falls back to `http://127.0.0.1:9001`.
+
+Override it for local work by copying `.env.example` to `.env.local` and editing the value:
+
+```bash
+cd frontend
+cp .env.example .env.local
+```
+
+```dotenv
+VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001
+```
+
+## Other useful commands
+
+```bash
+cd frontend
+npm run build
+npm run preview
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SupportDoc Browser Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,920 @@
+{
+  "name": "supportdoc-browser-demo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "supportdoc-browser-demo",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "19.2.4",
+        "react-dom": "19.2.4"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "6.0.1",
+        "vite": "8.0.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "supportdoc-browser-demo",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "6.0.1",
+    "vite": "8.0.3"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,268 @@
+import { useMemo, useState } from "react";
+
+import { readApiBaseUrl } from "./config";
+
+const STATE_OPTIONS = [
+  {
+    value: "supported_answer",
+    label: "Supported answer",
+  },
+  {
+    value: "refusal",
+    label: "Refusal",
+  },
+  {
+    value: "backend_unavailable",
+    label: "Backend unavailable",
+  },
+];
+
+const UI_STATE_LABELS = {
+  empty_input: "Empty input",
+  loading: "Loading",
+  supported_answer: "Supported answer",
+  refusal: "Refusal",
+  backend_unavailable: "Backend unavailable",
+};
+
+const SUPPORTED_ANSWER_PREVIEW = {
+  final_answer:
+    "A Pod is the smallest deployable unit in Kubernetes and can run one or more containers that share network and storage resources [1].",
+  citations: [
+    {
+      marker: "[1]",
+      doc_id: "content-en-docs-concepts-workloads-pods-pods",
+      chunk_id: "content-en-docs-concepts-workloads-pods-pods__chunk-0001",
+      start_offset: 0,
+      end_offset: 118,
+    },
+  ],
+  refusal: {
+    is_refusal: false,
+    reason_code: null,
+    message: null,
+  },
+};
+
+const REFUSAL_PREVIEW = {
+  final_answer: "I can’t answer that from the approved support corpus.",
+  citations: [],
+  refusal: {
+    is_refusal: true,
+    reason_code: "no_relevant_docs",
+    message: "I can’t answer that from the approved support corpus.",
+  },
+};
+
+function buildPreviewState(previewMode) {
+  switch (previewMode) {
+    case "refusal":
+      return {
+        uiState: "refusal",
+        result: REFUSAL_PREVIEW,
+        statusText:
+          "Previewing the refusal layout using final_answer plus refusal metadata from the current QueryResponse contract.",
+      };
+    case "backend_unavailable":
+      return {
+        uiState: "backend_unavailable",
+        result: null,
+        statusText:
+          "Previewing the single backend-unavailable treatment. The thin client does not create extra error-specific states.",
+      };
+    default:
+      return {
+        uiState: "supported_answer",
+        result: SUPPORTED_ANSWER_PREVIEW,
+        statusText:
+          "Previewing a supported answer with visible citation markers and a separate citations list.",
+      };
+  }
+}
+
+function ResultPanel({ uiState, result }) {
+  if (uiState === "loading") {
+    return (
+      <div className="result-state result-state--loading" aria-live="polite">
+        <p>Loading answer preview…</p>
+        <div className="loading-bar" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (uiState === "empty_input") {
+    return (
+      <div className="result-state" aria-live="polite">
+        <p>Enter a question to preview the local browser shell.</p>
+      </div>
+    );
+  }
+
+  if (uiState === "backend_unavailable") {
+    return (
+      <div className="result-state result-state--error" aria-live="polite">
+        <p>The backend is unavailable or incompatible right now.</p>
+        <p>Retry after the API is healthy again.</p>
+      </div>
+    );
+  }
+
+  if (!result) {
+    return null;
+  }
+
+  if (result.refusal.is_refusal) {
+    return (
+      <div className="result-state result-state--refusal" aria-live="polite">
+        <h3>Refusal</h3>
+        <p>{result.final_answer}</p>
+        <dl className="result-metadata">
+          <div>
+            <dt>reason_code</dt>
+            <dd>{result.refusal.reason_code}</dd>
+          </div>
+          <div>
+            <dt>message</dt>
+            <dd>{result.refusal.message}</dd>
+          </div>
+        </dl>
+      </div>
+    );
+  }
+
+  return (
+    <div className="result-state result-state--answer" aria-live="polite">
+      <h3>Supported answer</h3>
+      <p>{result.final_answer}</p>
+      <div className="result-subsection">
+        <h4>Citations</h4>
+        <ul className="citation-list">
+          {result.citations.map((citation) => (
+            <li key={citation.marker}>
+              <strong>{citation.marker}</strong>
+              <span>{citation.doc_id}</span>
+              <code>{citation.chunk_id}</code>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  const apiBaseUrl = useMemo(() => readApiBaseUrl(), []);
+  const [question, setQuestion] = useState("");
+  const [previewMode, setPreviewMode] = useState("supported_answer");
+  const [uiState, setUiState] = useState("empty_input");
+  const [result, setResult] = useState(null);
+  const [statusText, setStatusText] = useState(
+    "Enter a question to preview the browser shell. No network request is sent in this scaffold yet."
+  );
+  const [lastSubmittedQuestion, setLastSubmittedQuestion] = useState("");
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const trimmedQuestion = question.trim();
+    if (!trimmedQuestion) {
+      setUiState("empty_input");
+      setResult(null);
+      setStatusText("Enter a question before submitting.");
+      return;
+    }
+
+    setLastSubmittedQuestion(trimmedQuestion);
+    setUiState("loading");
+    setResult(null);
+    setStatusText(
+      "Rendering the loading state. This task keeps the frontend thin and does not call /query yet."
+    );
+
+    window.setTimeout(() => {
+      const preview = buildPreviewState(previewMode);
+      setUiState(preview.uiState);
+      setResult(preview.result);
+      setStatusText(preview.statusText);
+    }, 250);
+  }
+
+  return (
+    <div className="app-shell">
+      <header className="panel page-header">
+        <p className="eyebrow">Local browser demo scaffold</p>
+        <h1>SupportDoc RAG Chatbot</h1>
+        <p>
+          Thin React SPA shell for the frozen <code>/query</code> contract. This first
+          frontend task bootstraps the page layout only.
+        </p>
+      </header>
+
+      <main className="page-grid">
+        <section className="panel">
+          <h2>Question box</h2>
+          <form className="question-form" onSubmit={handleSubmit}>
+            <label htmlFor="question-input">Question</label>
+            <textarea
+              id="question-input"
+              name="question"
+              rows="5"
+              placeholder="What is a Pod?"
+              value={question}
+              onChange={(event) => setQuestion(event.target.value)}
+            />
+            <p className="helper-text">
+              The browser trims whitespace before submit and blocks empty input locally.
+            </p>
+
+            <fieldset className="preview-fieldset">
+              <legend>Placeholder layout preview</legend>
+              {STATE_OPTIONS.map((option) => (
+                <label key={option.value} className="preview-option">
+                  <input
+                    checked={previewMode === option.value}
+                    name="preview-state"
+                    type="radio"
+                    value={option.value}
+                    onChange={(event) => setPreviewMode(event.target.value)}
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))}
+            </fieldset>
+
+            <div className="form-actions">
+              <button type="submit" disabled={uiState === "loading"}>
+                {uiState === "loading" ? "Loading…" : "Submit"}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="panel">
+          <h2>Result panel</h2>
+          <ResultPanel uiState={uiState} result={result} />
+        </section>
+      </main>
+
+      <aside className="panel status-panel">
+        <h2>Status area</h2>
+        <div className="status-grid">
+          <div>
+            <span className="status-label">UI state</span>
+            <strong>{UI_STATE_LABELS[uiState]}</strong>
+          </div>
+          <div>
+            <span className="status-label">Configured API base URL</span>
+            <code>{apiBaseUrl}</code>
+          </div>
+          <div>
+            <span className="status-label">Last submitted question</span>
+            <span>{lastSubmittedQuestion || "None yet"}</span>
+          </div>
+        </div>
+        <p className="status-message">{statusText}</p>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,15 @@
+export const DEFAULT_API_BASE_URL = "http://127.0.0.1:9001";
+
+export function readApiBaseUrl() {
+  const configured = import.meta.env.VITE_SUPPORTDOC_API_BASE_URL;
+  if (typeof configured !== "string") {
+    return DEFAULT_API_BASE_URL;
+  }
+
+  const normalized = configured.trim();
+  if (!normalized) {
+    return DEFAULT_API_BASE_URL;
+  }
+
+  return normalized.replace(/\/+$/, "");
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import App from "./App.jsx";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,215 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background: #f5f6f8;
+  color: #111827;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+.page-header,
+.panel {
+  background: #ffffff;
+  border: 1px solid #d7dce5;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgb(15 23 42 / 0.06);
+}
+
+.panel {
+  padding: 1.25rem;
+}
+
+.page-header {
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.page-header h1,
+.panel h2,
+.panel h3,
+.panel h4 {
+  margin-top: 0;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.page-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.question-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #c7cdd8;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  min-height: 8rem;
+  background: #ffffff;
+}
+
+.helper-text {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.preview-fieldset {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid #d7dce5;
+  border-radius: 12px;
+}
+
+.preview-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.preview-option:first-of-type {
+  margin-top: 0;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1.2rem;
+  font-weight: 700;
+  background: #111827;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.65;
+  cursor: wait;
+}
+
+.result-state > :last-child,
+.status-message {
+  margin-bottom: 0;
+}
+
+.result-state--loading,
+.result-state--error,
+.result-state--refusal,
+.result-state--answer {
+  border: 1px solid #d7dce5;
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f9fafb;
+}
+
+.loading-bar {
+  width: 100%;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #d7dce5 0%, #e8ecf3 50%, #d7dce5 100%);
+}
+
+.result-subsection {
+  margin-top: 1rem;
+}
+
+.citation-list {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.citation-list li {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.result-metadata {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.result-metadata div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.result-metadata dt,
+.status-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.status-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.status-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.status-grid div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 1rem 0.75rem 2rem;
+  }
+
+  .panel,
+  .page-header {
+    padding: 1rem;
+  }
+}

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+  },
+  preview: {
+    host: "127.0.0.1",
+    port: 4173,
+  },
+});

--- a/tests/test_frontend_scaffold.py
+++ b/tests/test_frontend_scaffold.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FRONTEND_DIR = Path("frontend")
+
+
+def test_frontend_scaffold_uses_react_and_vite() -> None:
+    package_json = FRONTEND_DIR / "package.json"
+    assert package_json.is_file()
+
+    package = json.loads(package_json.read_text(encoding="utf-8"))
+
+    assert package["name"] == "supportdoc-browser-demo"
+    assert package["private"] is True
+    assert package["scripts"]["dev"] == "vite"
+    assert package["scripts"]["build"] == "vite build"
+    assert package["scripts"]["preview"] == "vite preview"
+    assert "react" in package["dependencies"]
+    assert "react-dom" in package["dependencies"]
+    assert "vite" in package["devDependencies"]
+    assert "@vitejs/plugin-react" in package["devDependencies"]
+    assert package["engines"]["node"] == "^20.19.0 || >=22.12.0"
+
+
+def test_frontend_npmrc_and_lockfile_avoid_environment_specific_registry_pinning() -> None:
+    npmrc = (FRONTEND_DIR / ".npmrc").read_text(encoding="utf-8")
+    lockfile = (FRONTEND_DIR / "package-lock.json").read_text(encoding="utf-8")
+
+    assert "omit-lockfile-registry-resolved=true" in npmrc
+    assert '"resolved"' not in lockfile
+    assert "packages.applied-caas-gateway1.internal.api.openai.org" not in lockfile
+
+
+def test_frontend_shell_contains_required_browser_demo_regions() -> None:
+    app_file = FRONTEND_DIR / "src" / "App.jsx"
+    assert app_file.is_file()
+
+    content = app_file.read_text(encoding="utf-8")
+
+    for required_text in (
+        "SupportDoc RAG Chatbot",
+        "Question box",
+        "Submit",
+        "Result panel",
+        "Status area",
+        "Supported answer",
+        "Refusal",
+        "Backend unavailable",
+        "loading",
+    ):
+        assert required_text in content
+
+
+def test_frontend_readme_and_env_example_document_local_startup_and_api_base_url() -> None:
+    readme = (FRONTEND_DIR / "README.md").read_text(encoding="utf-8")
+    env_example = (FRONTEND_DIR / ".env.example").read_text(encoding="utf-8")
+
+    assert "npm install" in readme
+    assert "npm run dev" in readme
+    assert "^20.19.0 || >=22.12.0" in readme
+    assert "VITE_SUPPORTDOC_API_BASE_URL" in readme
+    assert "http://127.0.0.1:9001" in readme
+    assert "VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001" in env_example
+
+
+def test_repo_docs_link_to_frontend_scaffold_and_local_startup() -> None:
+    readme_content = Path("README.md").read_text(encoding="utf-8")
+    aws_note = Path("docs/architecture/aws_deployment.md").read_text(encoding="utf-8")
+    validation_index = Path("docs/validation/README.md").read_text(encoding="utf-8")
+
+    assert "## 7C. Local browser demo scaffold" in readme_content
+    assert "frontend/README.md" in readme_content
+    assert "VITE_SUPPORTDOC_API_BASE_URL" in readme_content
+    assert "^20.19.0 || >=22.12.0" in readme_content
+    assert "checked-in React SPA scaffold under `frontend/`" in aws_note
+    assert "thin local browser scaffold now exists under `frontend/`" in validation_index


### PR DESCRIPTION
Closes  #101
---

Add a checked-in React + Vite frontend scaffold under `frontend/` for the local browser demo. The shell stays intentionally small and aligned with the frozen backend contract from Task 1: one page, one question box, one submit button, one result panel, and one status area with placeholder treatments for supported answer, refusal, loading, empty input, and backend-unavailable states.

- added a single canonical frontend app under `frontend/`
  - `package.json` + `package-lock.json`
  - Vite config
  - single-page React shell
  - minimal CSS
- added local API base URL configuration via `VITE_SUPPORTDOC_API_BASE_URL`
  - default fallback: `http://127.0.0.1:9001`
  - `frontend/.env.example`
  - focused startup note in `frontend/README.md`
- added placeholder UI treatments for:
  - supported answer
  - refusal
  - loading
  - empty input
  - backend unavailable
- updated repo docs to point to the new frontend scaffold while keeping the backend/API-first framing intact
- updated `.gitignore` for frontend local artifacts
- added `tests/test_frontend_scaffold.py`

- gives Epic 11 a real browser-app location without introducing a framework pivot
- keeps the frontend thin and explicitly scoped before `/query` wiring lands
- makes local startup and backend target override easy for demo work
- preserves all existing Python exports, CLI commands, trust schemas, and fixtures

- frontend smoke in the working tree
  - `npm install`
  - `npm run build`
  - `npm run dev -- --host 127.0.0.1 --port 4174`
- scoped pytest
  - `tests/test_frontend_scaffold.py` → `4 passed`
- dependent/shared-surface pytest
  - `tests/test_browser_demo_contract.py`
  - `tests/test_mvp_readiness_docs.py`
  - `tests/test_artifact_api_smoke.py`
  - `tests/test_container_packaging.py`
  - `tests/test_container_runtime_smoke.py`
  - result: `18 passed`
- full suite
  - `pytest -q` → `161 passed`
- required baseline commands
  - `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py` → `5 passed`
  - `uv run pytest -q` → `161 passed`
  - `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...` → `status: ok`
- overlay validation
  - reapplied `epic11_task101_changed_files.zip` on top of a fresh copy from the same inspected base ZIP snapshot
  - reran `pytest -q` → `161 passed`
  - reran CLI help + trust smoke
  - reran frontend `npm install`, `npm run build`, and dev-server boot smoke

---

Changes to be committed:
	modified:   ../.gitignore
	modified:   ../README.md
	modified:   ../docs/architecture/aws_deployment.md
	modified:   ../docs/ops/cost_and_ops.md
	modified:   ../docs/validation/README.md
	modified:   ../docs/validation/mvp_readiness.md
	new file:   .env.example
	new file:   .npmrc
	new file:   README.md
	new file:   index.html
	new file:   package-lock.json
	new file:   package.json
	new file:   src/App.jsx
	new file:   src/config.js
	new file:   src/main.jsx
	new file:   src/styles.css
	new file:   vite.config.mjs
	new file:   ../tests/test_frontend_scaffold.py