### PR TITLE
On branch frontend/103-wire-the-question-flow-to_query-and-render-sup…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ __marimo__/
 .Trashes
 # Frontend local artifacts
 frontend/node_modules/
+frontend/dist/
 frontend/.env.local
 frontend/.env.*.local
 # Generated retrieval artifacts

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ API-first MVP validation with reviewed evidence, documented smoke paths, and sou
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
-- Thin React + Vite local browser demo scaffold under `frontend/`.
+- Thin React + Vite local browser demo under `frontend/` with live local API wiring.
 - Corpus governance documentation in `docs/data/corpus.md`.
 - Ingestion pipeline artifacts for manifest generation, parsing, section extraction, chunking, and validation.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
@@ -59,7 +59,7 @@ This is the main orchestration layer implemented in this repository. It is respo
 - refusal enforcement.
 
 ### Infrastructure Layer
-The deploy-now MVP remains **API-first** for backend validation. The repository now also includes a thin React browser-demo scaffold under `frontend/`, while frontend hosting, live `/query` wiring, and richer evidence UI remain deferred to later Epic 11 tasks and the deployment baseline in `docs/architecture/aws_deployment.md`.
+The deploy-now MVP remains **API-first** for backend validation. The repository now also includes a thin React browser demo under `frontend/` that can call the local FastAPI `/query` route in development, while frontend hosting and richer evidence UI remain deferred to later Epic 11 tasks and the deployment baseline in `docs/architecture/aws_deployment.md`.
 
 ### High-Level System Flow
 
@@ -530,11 +530,19 @@ If artifact-mode container support is needed later, it should be added as an exp
 
 ---
 
-## 7C. Local browser demo scaffold
+## 7C. Local browser demo
 
-Epic 11 now includes a thin local React SPA scaffold under `frontend/`. This task intentionally keeps the browser shell small: one page, one question box, one submit button, one result panel, and one status area aligned to `docs/process/browser_demo_contract.md`.
+Epic 11 now includes a thin local React SPA under `frontend/`. It stays intentionally small: one page, one question box, one submit button, one result panel, and one status area aligned to `docs/process/browser_demo_contract.md`.
 
 ### Start the frontend locally
+
+Start the local API first:
+
+```bash
+./scripts/run-api-local.sh
+```
+
+Then boot the browser demo:
 
 ```bash
 cd frontend
@@ -543,25 +551,30 @@ npm install
 npm run dev
 ```
 
-Use Node `^20.19.0 || >=22.12.0` for the Vite-based scaffold. The committed `frontend/.npmrc` also keeps the lockfile registry-neutral for local installs on macOS and Linux.
+Use Node `^20.19.0 || >=22.12.0` for the Vite-based app. The committed `frontend/.npmrc` also keeps the lockfile registry-neutral for local installs on macOS and Linux.
 
 The Vite dev server binds to `http://127.0.0.1:5173` by default.
 
 ### API base URL override
 
-The frontend reads `VITE_SUPPORTDOC_API_BASE_URL` and falls back to `http://127.0.0.1:9001`. To point the shell at a different local backend, copy `frontend/.env.example` to `frontend/.env.local` and edit the value.
+The frontend reads `VITE_SUPPORTDOC_API_BASE_URL` and falls back to `http://127.0.0.1:9001`. To point the browser demo at a different local backend, copy `frontend/.env.example` to `frontend/.env.local` and edit the value.
 
 ```bash
 cd frontend
 cp .env.example .env.local
 ```
 
-### Current scope of the scaffold
+### Current scope of the browser demo
 
 - one-page React SPA
-- placeholder layouts for supported answer, refusal, loading, and backend-unavailable states
-- no auth, persistence, or client-side routing
-- no live `/query` request in this task yet
+- live `POST /query` submission with the frozen request shape
+- supported-answer rendering from `final_answer`
+- refusal rendering from `final_answer` plus optional `reason_code`
+- local empty-input validation and disabled submit while loading
+- tiny `/readyz` status indicator for local operator diagnostics
+- no auth, persistence, client-side routing, or rich evidence cards yet
+
+The FastAPI backend also accepts browser requests from the local Vite dev origins so the SPA can call the API directly during local development.
 
 See `frontend/README.md` for the focused frontend startup note.
 
@@ -640,7 +653,7 @@ The single closeout status page for Epic 10 now lives at `docs/validation/mvp_re
 
 ## 10. Deployment Overview
 
-The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo remains API-first** for backend proof and reviewed trust artifacts, while the repo now also includes a thin local browser scaffold under `frontend/` for Epic 11 demo work. Frontend hosting and richer browser behavior are still deferred in the AWS baseline.
+The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo remains API-first** for backend proof and reviewed trust artifacts, while the repo now also includes a thin local browser demo under `frontend/` for Epic 11 work, including live local API wiring. Frontend hosting and richer browser behavior are still deferred in the AWS baseline.
 
 The first browser-demo integration contract for that API-first backend now lives in `docs/process/browser_demo_contract.md`. It freezes the UI against the current `/query` and `/readyz` surface and explicitly defers rich evidence cards until the backend exposes a request-scoped evidence payload.
 

--- a/docs/architecture/aws_deployment.md
+++ b/docs/architecture/aws_deployment.md
@@ -39,7 +39,7 @@ What already exists in the ZIP:
 - local retrieval artifacts built around `chunks.jsonl` plus FAISS index files
 - canonical trust-layer response schema and smoke validation
 - structured backend orchestration for retrieval, refusal gating, generation, and citation validation
-- a checked-in React SPA scaffold under `frontend/` for the local browser demo
+- a checked-in React SPA browser demo under `frontend/` that can call the local API in development
 
 What does **not** exist yet in the ZIP:
 
@@ -190,7 +190,7 @@ Optional OpenTelemetry tracing is deferred. CloudWatch-first logging is the defa
 - API-first backend exists
 - local fixture and artifact retrieval flows exist
 - local FAISS artifacts are the current retrieval baseline
-- a thin local frontend scaffold exists under `frontend/`
+- a thin local frontend browser demo exists under `frontend/` and can submit live local `/query` requests
 - no frontend deployment work is committed yet
 - no AWS deployment packaging is committed yet
 

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -15,7 +15,7 @@ The current validated scope is intentionally **backend / API first**:
 - artifact-mode local API smoke is supported,
 - backend container runtime smoke is supported in fixture mode,
 - reviewed evidence correctness artifacts are committed,
-- a thin local browser scaffold now exists under `frontend/`, but frontend query wiring and browser smoke remain outside this validation index,
+- a thin local browser demo now exists under `frontend/` and can call the live local API, but browser smoke remains outside this validation index,
 - artifact-mode inside the container image remains deferred.
 
 ## Canonical commands

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,21 +1,27 @@
-# Frontend browser demo scaffold
+# Frontend browser demo
 
-This directory contains the thin React SPA shell for the local browser demo in Epic 11.
+This directory contains the thin React SPA for the local browser demo in Epic 11.
 
 Current scope:
 
 - one page only
 - one question input and submit button
-- one result panel for answer / refusal / citation placeholders
-- one status area for empty input, loading, and backend-unavailable treatment
-- no auth, persistence, or multi-page routing
-- no live `/query` request yet; that wiring lands in the next scoped task
+- one result panel for supported answers or refusals from the live backend
+- one status area with a tiny `/readyz` indicator for local diagnostics
+- local empty-input validation and submit-disabled loading behavior
+- no auth, persistence, multi-page routing, or rich evidence cards
 
 The UI behavior is pinned to `docs/process/browser_demo_contract.md`.
 
 ## Local startup
 
-Use a Node version supported by Vite before installing dependencies. This scaffold targets Node `^20.19.0 || >=22.12.0`.
+Start the local API first from the repo root:
+
+```bash
+./scripts/run-api-local.sh
+```
+
+Then start the browser demo:
 
 ```bash
 cd frontend
@@ -24,7 +30,7 @@ npm install
 npm run dev
 ```
 
-The Vite dev server binds to `http://127.0.0.1:5173` by default.
+Use Node `^20.19.0 || >=22.12.0` for the Vite-based scaffold. The Vite dev server binds to `http://127.0.0.1:5173` by default.
 
 The checked-in `.npmrc` keeps the lockfile registry-neutral so installs work outside the environment where the lockfile was generated.
 
@@ -35,6 +41,8 @@ cd frontend
 rm -rf node_modules
 npm install
 ```
+
+The FastAPI backend accepts browser requests from the local Vite dev origins, so the SPA can call the live API directly during local development.
 
 ## API base URL configuration
 
@@ -50,6 +58,15 @@ cp .env.example .env.local
 ```dotenv
 VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001
 ```
+
+## Live browser behavior
+
+- sends `POST /query` with `{ "question": "..." }`
+- renders `final_answer` for both supported answers and refusals
+- shows citation markers only for supported answers
+- disables submit while a request is in flight
+- blocks empty input locally before any network request
+- probes `GET /readyz` for operator-friendly backend status metadata
 
 ## Other useful commands
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { readApiBaseUrl } from "./config";
-
-const STATE_OPTIONS = [
-  {
-    value: "supported_answer",
-    label: "Supported answer",
-  },
-  {
-    value: "refusal",
-    label: "Refusal",
-  },
-  {
-    value: "backend_unavailable",
-    label: "Backend unavailable",
-  },
-];
+import { buildApiUrl, readApiBaseUrl } from "./config";
 
 const UI_STATE_LABELS = {
   empty_input: "Empty input",
@@ -25,66 +10,119 @@ const UI_STATE_LABELS = {
   backend_unavailable: "Backend unavailable",
 };
 
-const SUPPORTED_ANSWER_PREVIEW = {
-  final_answer:
-    "A Pod is the smallest deployable unit in Kubernetes and can run one or more containers that share network and storage resources [1].",
-  citations: [
-    {
-      marker: "[1]",
-      doc_id: "content-en-docs-concepts-workloads-pods-pods",
-      chunk_id: "content-en-docs-concepts-workloads-pods-pods__chunk-0001",
-      start_offset: 0,
-      end_offset: 118,
-    },
-  ],
-  refusal: {
-    is_refusal: false,
-    reason_code: null,
-    message: null,
-  },
+const BACKEND_STATUS_LABELS = {
+  checking: "Checking",
+  ready: "Ready",
+  unavailable: "Unavailable",
+  incompatible: "Incompatible",
 };
 
-const REFUSAL_PREVIEW = {
-  final_answer: "I can’t answer that from the approved support corpus.",
-  citations: [],
-  refusal: {
-    is_refusal: true,
-    reason_code: "no_relevant_docs",
-    message: "I can’t answer that from the approved support corpus.",
-  },
+const REQUEST_TIMEOUT_MS = 10000;
+
+const INITIAL_BACKEND_STATUS = {
+  state: "checking",
+  service: null,
+  environment: null,
+  version: null,
+  queryContract: null,
+  message: "Checking backend readiness via /readyz.",
 };
 
-function buildPreviewState(previewMode) {
-  switch (previewMode) {
-    case "refusal":
-      return {
-        uiState: "refusal",
-        result: REFUSAL_PREVIEW,
-        statusText:
-          "Previewing the refusal layout using final_answer plus refusal metadata from the current QueryResponse contract.",
-      };
-    case "backend_unavailable":
-      return {
-        uiState: "backend_unavailable",
-        result: null,
-        statusText:
-          "Previewing the single backend-unavailable treatment. The thin client does not create extra error-specific states.",
-      };
-    default:
-      return {
-        uiState: "supported_answer",
-        result: SUPPORTED_ANSWER_PREVIEW,
-        statusText:
-          "Previewing a supported answer with visible citation markers and a separate citations list.",
-      };
+function normalizeErrorMessage(error) {
+  if (error instanceof Error) {
+    const normalized = error.message.trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return "The backend request failed.";
+}
+
+async function requestJson(url, init = {}) {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await window.fetch(url, {
+      ...init,
+      headers: {
+        accept: "application/json",
+        ...(init.headers ?? {}),
+      },
+      signal: controller.signal,
+    });
+
+    const responseText = await response.text();
+    const payload = responseText ? JSON.parse(responseText) : null;
+
+    if (!response.ok) {
+      throw new Error(
+        payload?.error?.message ?? `Request failed with status ${response.status}.`
+      );
+    }
+
+    if (payload === null) {
+      throw new Error("The backend returned an empty response.");
+    }
+
+    return payload;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("The backend request timed out.");
+    }
+
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
   }
 }
 
-function ResultPanel({ uiState, result }) {
+async function requestQuery(apiBaseUrl, question) {
+  return requestJson(buildApiUrl(apiBaseUrl, "/query"), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ question }),
+  });
+}
+
+async function requestReadiness(apiBaseUrl) {
+  return requestJson(buildApiUrl(apiBaseUrl, "/readyz"));
+}
+
+function buildBackendStatus(nextStatus) {
+  if (
+    nextStatus.status === "ready" &&
+    nextStatus.query_contract === "QueryResponse"
+  ) {
+    return {
+      state: "ready",
+      service: nextStatus.service,
+      environment: nextStatus.environment,
+      version: nextStatus.version,
+      queryContract: nextStatus.query_contract,
+      message: "Backend readiness probe passed.",
+    };
+  }
+
+  return {
+    state: "incompatible",
+    service: nextStatus.service ?? null,
+    environment: nextStatus.environment ?? null,
+    version: nextStatus.version ?? null,
+    queryContract: nextStatus.query_contract ?? null,
+    message:
+      "The backend responded, but its readiness metadata does not match the current browser contract.",
+  };
+}
+
+function ResultPanel({ uiState, result, backendErrorMessage }) {
   if (uiState === "loading") {
     return (
       <div className="result-state result-state--loading" aria-live="polite">
-        <p>Loading answer preview…</p>
+        <p>Loading answer from the live backend…</p>
         <div className="loading-bar" aria-hidden="true" />
       </div>
     );
@@ -93,7 +131,7 @@ function ResultPanel({ uiState, result }) {
   if (uiState === "empty_input") {
     return (
       <div className="result-state" aria-live="polite">
-        <p>Enter a question to preview the local browser shell.</p>
+        <p>Enter a question to query the local backend.</p>
       </div>
     );
   }
@@ -103,6 +141,9 @@ function ResultPanel({ uiState, result }) {
       <div className="result-state result-state--error" aria-live="polite">
         <p>The backend is unavailable or incompatible right now.</p>
         <p>Retry after the API is healthy again.</p>
+        {backendErrorMessage ? (
+          <p className="result-detail">Last error: {backendErrorMessage}</p>
+        ) : null}
       </div>
     );
   }
@@ -116,16 +157,10 @@ function ResultPanel({ uiState, result }) {
       <div className="result-state result-state--refusal" aria-live="polite">
         <h3>Refusal</h3>
         <p>{result.final_answer}</p>
-        <dl className="result-metadata">
-          <div>
-            <dt>reason_code</dt>
-            <dd>{result.refusal.reason_code}</dd>
-          </div>
-          <div>
-            <dt>message</dt>
-            <dd>{result.refusal.message}</dd>
-          </div>
-        </dl>
+        <div className="result-diagnostic">
+          <span className="status-label">reason_code</span>
+          <code>{result.refusal.reason_code}</code>
+        </div>
       </div>
     );
   }
@@ -134,18 +169,18 @@ function ResultPanel({ uiState, result }) {
     <div className="result-state result-state--answer" aria-live="polite">
       <h3>Supported answer</h3>
       <p>{result.final_answer}</p>
-      <div className="result-subsection">
-        <h4>Citations</h4>
-        <ul className="citation-list">
-          {result.citations.map((citation) => (
-            <li key={citation.marker}>
-              <strong>{citation.marker}</strong>
-              <span>{citation.doc_id}</span>
-              <code>{citation.chunk_id}</code>
-            </li>
-          ))}
-        </ul>
-      </div>
+      {result.citations.length ? (
+        <div className="result-subsection">
+          <h4>Citation markers</h4>
+          <ul className="marker-list">
+            {result.citations.map((citation) => (
+              <li key={`${citation.marker}-${citation.chunk_id}`}>
+                <code>{citation.marker}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -153,21 +188,63 @@ function ResultPanel({ uiState, result }) {
 export default function App() {
   const apiBaseUrl = useMemo(() => readApiBaseUrl(), []);
   const [question, setQuestion] = useState("");
-  const [previewMode, setPreviewMode] = useState("supported_answer");
   const [uiState, setUiState] = useState("empty_input");
   const [result, setResult] = useState(null);
+  const [backendErrorMessage, setBackendErrorMessage] = useState(null);
   const [statusText, setStatusText] = useState(
-    "Enter a question to preview the browser shell. No network request is sent in this scaffold yet."
+    "Enter a question to query the live backend. The status area also probes /readyz for local diagnostics."
   );
   const [lastSubmittedQuestion, setLastSubmittedQuestion] = useState("");
+  const [backendStatus, setBackendStatus] = useState(INITIAL_BACKEND_STATUS);
 
-  function handleSubmit(event) {
+  const isSubmitDisabled = uiState === "loading" || !question.trim();
+
+  const probeBackendStatus = useCallback(async () => {
+    setBackendStatus((currentStatus) => ({
+      ...currentStatus,
+      state: "checking",
+      message: "Checking backend readiness via /readyz.",
+    }));
+
+    try {
+      const nextStatus = await requestReadiness(apiBaseUrl);
+      setBackendStatus(buildBackendStatus(nextStatus));
+    } catch (error) {
+      setBackendStatus({
+        state: "unavailable",
+        service: null,
+        environment: null,
+        version: null,
+        queryContract: null,
+        message: normalizeErrorMessage(error),
+      });
+    }
+  }, [apiBaseUrl]);
+
+  useEffect(() => {
+    void probeBackendStatus();
+  }, [probeBackendStatus]);
+
+  function handleQuestionChange(event) {
+    const nextQuestion = event.target.value;
+    setQuestion(nextQuestion);
+
+    if (!nextQuestion.trim() && uiState !== "loading") {
+      setUiState("empty_input");
+      setResult(null);
+      setBackendErrorMessage(null);
+      setStatusText("Enter a question before submitting.");
+    }
+  }
+
+  async function handleSubmit(event) {
     event.preventDefault();
 
     const trimmedQuestion = question.trim();
     if (!trimmedQuestion) {
       setUiState("empty_input");
       setResult(null);
+      setBackendErrorMessage(null);
       setStatusText("Enter a question before submitting.");
       return;
     }
@@ -175,26 +252,44 @@ export default function App() {
     setLastSubmittedQuestion(trimmedQuestion);
     setUiState("loading");
     setResult(null);
-    setStatusText(
-      "Rendering the loading state. This task keeps the frontend thin and does not call /query yet."
-    );
+    setBackendErrorMessage(null);
+    setStatusText("Submitting a live POST /query request to the backend.");
 
-    window.setTimeout(() => {
-      const preview = buildPreviewState(previewMode);
-      setUiState(preview.uiState);
-      setResult(preview.result);
-      setStatusText(preview.statusText);
-    }, 250);
+    try {
+      const nextResult = await requestQuery(apiBaseUrl, trimmedQuestion);
+      setResult(nextResult);
+      setStatusText(
+        nextResult.refusal.is_refusal
+          ? "Received a refusal from the live backend."
+          : "Received a supported answer from the live backend."
+      );
+      setUiState(nextResult.refusal.is_refusal ? "refusal" : "supported_answer");
+      void probeBackendStatus();
+    } catch (error) {
+      const nextErrorMessage = normalizeErrorMessage(error);
+      setUiState("backend_unavailable");
+      setResult(null);
+      setBackendErrorMessage(nextErrorMessage);
+      setStatusText(`Backend unavailable: ${nextErrorMessage}`);
+      setBackendStatus({
+        state: "unavailable",
+        service: null,
+        environment: null,
+        version: null,
+        queryContract: null,
+        message: nextErrorMessage,
+      });
+    }
   }
 
   return (
     <div className="app-shell">
       <header className="panel page-header">
-        <p className="eyebrow">Local browser demo scaffold</p>
+        <p className="eyebrow">Local browser demo</p>
         <h1>SupportDoc RAG Chatbot</h1>
         <p>
-          Thin React SPA shell for the frozen <code>/query</code> contract. This first
-          frontend task bootstraps the page layout only.
+          Thin React SPA for the frozen <code>/query</code> contract, now wired to the
+          live local backend.
         </p>
       </header>
 
@@ -209,30 +304,15 @@ export default function App() {
               rows="5"
               placeholder="What is a Pod?"
               value={question}
-              onChange={(event) => setQuestion(event.target.value)}
+              onChange={handleQuestionChange}
             />
             <p className="helper-text">
-              The browser trims whitespace before submit and blocks empty input locally.
+              The browser trims whitespace before submit, blocks empty input locally,
+              and disables submit while a request is in flight.
             </p>
 
-            <fieldset className="preview-fieldset">
-              <legend>Placeholder layout preview</legend>
-              {STATE_OPTIONS.map((option) => (
-                <label key={option.value} className="preview-option">
-                  <input
-                    checked={previewMode === option.value}
-                    name="preview-state"
-                    type="radio"
-                    value={option.value}
-                    onChange={(event) => setPreviewMode(event.target.value)}
-                  />
-                  <span>{option.label}</span>
-                </label>
-              ))}
-            </fieldset>
-
             <div className="form-actions">
-              <button type="submit" disabled={uiState === "loading"}>
+              <button type="submit" disabled={isSubmitDisabled}>
                 {uiState === "loading" ? "Loading…" : "Submit"}
               </button>
             </div>
@@ -241,7 +321,11 @@ export default function App() {
 
         <section className="panel">
           <h2>Result panel</h2>
-          <ResultPanel uiState={uiState} result={result} />
+          <ResultPanel
+            uiState={uiState}
+            result={result}
+            backendErrorMessage={backendErrorMessage}
+          />
         </section>
       </main>
 
@@ -257,11 +341,50 @@ export default function App() {
             <code>{apiBaseUrl}</code>
           </div>
           <div>
+            <span className="status-label">Backend status</span>
+            <span className={`status-pill status-pill--${backendStatus.state}`}>
+              {BACKEND_STATUS_LABELS[backendStatus.state]}
+            </span>
+          </div>
+          <div>
+            <span className="status-label">query_contract</span>
+            <code>{backendStatus.queryContract ?? "Unknown"}</code>
+          </div>
+          <div>
+            <span className="status-label">Service</span>
+            <span>{backendStatus.service ?? "Unknown"}</span>
+          </div>
+          <div>
+            <span className="status-label">Environment</span>
+            <span>{backendStatus.environment ?? "Unknown"}</span>
+          </div>
+          <div>
+            <span className="status-label">Version</span>
+            <span>{backendStatus.version ?? "Unknown"}</span>
+          </div>
+          <div>
             <span className="status-label">Last submitted question</span>
             <span>{lastSubmittedQuestion || "None yet"}</span>
           </div>
         </div>
+
+        <div className="form-actions">
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={backendStatus.state === "checking" || uiState === "loading"}
+            onClick={() => {
+              void probeBackendStatus();
+            }}
+          >
+            {backendStatus.state === "checking"
+              ? "Checking backend…"
+              : "Refresh backend status"}
+          </button>
+        </div>
+
         <p className="status-message">{statusText}</p>
+        <p className="helper-text status-meta">{backendStatus.message}</p>
       </aside>
     </div>
   );

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -13,3 +13,8 @@ export function readApiBaseUrl() {
 
   return normalized.replace(/\/+$/, "");
 }
+
+export function buildApiUrl(apiBaseUrl, path) {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${apiBaseUrl}${normalizedPath}`;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -95,24 +95,6 @@ textarea {
   font-size: 0.95rem;
 }
 
-.preview-fieldset {
-  margin: 0;
-  padding: 0.85rem 1rem;
-  border: 1px solid #d7dce5;
-  border-radius: 12px;
-}
-
-.preview-option {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.preview-option:first-of-type {
-  margin-top: 0;
-}
-
 .form-actions {
   display: flex;
   align-items: center;
@@ -134,19 +116,34 @@ button:disabled {
   cursor: wait;
 }
 
+.secondary-button {
+  background: #e5e7eb;
+  color: #111827;
+}
+
 .result-state > :last-child,
-.status-message {
+.status-message,
+.status-meta {
   margin-bottom: 0;
+}
+
+.result-state {
+  border: 1px solid #d7dce5;
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f9fafb;
 }
 
 .result-state--loading,
 .result-state--error,
 .result-state--refusal,
 .result-state--answer {
-  border: 1px solid #d7dce5;
-  border-radius: 12px;
-  padding: 1rem;
   background: #f9fafb;
+}
+
+.result-detail,
+.result-diagnostic {
+  margin-top: 1rem;
 }
 
 .loading-bar {
@@ -160,31 +157,12 @@ button:disabled {
   margin-top: 1rem;
 }
 
-.citation-list {
-  display: grid;
-  gap: 0.75rem;
+.marker-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
   padding-left: 1.25rem;
-}
-
-.citation-list li {
-  display: grid;
-  gap: 0.2rem;
-}
-
-.result-metadata {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.result-metadata div {
-  display: grid;
-  gap: 0.15rem;
-}
-
-.result-metadata dt,
-.status-label {
-  font-size: 0.9rem;
-  font-weight: 700;
 }
 
 .status-panel {
@@ -201,6 +179,36 @@ button:disabled {
 .status-grid div {
   display: grid;
   gap: 0.25rem;
+}
+
+.status-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-width: 6.25rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #d7dce5;
+  font-weight: 700;
+}
+
+.status-pill--checking {
+  background: #f3f4f6;
+}
+
+.status-pill--ready {
+  background: #ecfdf5;
+}
+
+.status-pill--unavailable,
+.status-pill--incompatible {
+  background: #fef2f2;
 }
 
 @media (max-width: 640px) {

--- a/src/supportdoc_rag_chatbot/app/api/middleware.py
+++ b/src/supportdoc_rag_chatbot/app/api/middleware.py
@@ -4,6 +4,7 @@ import logging
 from time import perf_counter
 
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 
 from supportdoc_rag_chatbot.logging_conf import (
     REQUEST_ID_HEADER,
@@ -14,9 +15,19 @@ from supportdoc_rag_chatbot.logging_conf import (
 
 logger = logging.getLogger(__name__)
 
+LOCAL_BROWSER_ORIGIN_REGEX = r"https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$"
+
 
 def register_api_middleware(app: FastAPI) -> None:
-    """Register request correlation and lifecycle logging middleware."""
+    """Register API middleware for local browser access and request lifecycle logging."""
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origin_regex=LOCAL_BROWSER_ORIGIN_REGEX,
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+    )
 
     @app.middleware("http")
     async def _request_logging_middleware(request: Request, call_next):
@@ -63,4 +74,4 @@ def _resolve_route_path(request: Request) -> str:
     return request.url.path
 
 
-__all__ = ["register_api_middleware"]
+__all__ = ["LOCAL_BROWSER_ORIGIN_REGEX", "register_api_middleware"]

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -88,6 +88,30 @@ def test_readyz_returns_deterministic_json_without_external_dependencies() -> No
     }
 
 
+def test_readyz_allows_local_browser_get_requests_via_cors() -> None:
+    with build_test_client() as client:
+        response = client.get("/readyz", headers={"Origin": "http://localhost:5173"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+
+
+def test_query_preflight_allows_local_browser_post_requests_via_cors() -> None:
+    with build_test_client() as client:
+        response = client.options(
+            "/query",
+            headers={
+                "Origin": "http://127.0.0.1:5173",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:5173"
+    assert "POST" in response.headers["access-control-allow-methods"]
+
+
 def test_query_returns_supported_answer_from_backend_orchestration() -> None:
     with build_test_client() as client:
         response = client.post("/query", json={"question": "What is a Pod?"})

--- a/tests/test_frontend_live_query.py
+++ b/tests/test_frontend_live_query.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+FRONTEND_APP = Path("frontend/src/App.jsx")
+FRONTEND_README = Path("frontend/README.md")
+
+
+def test_frontend_live_query_wiring_uses_query_and_readyz_routes() -> None:
+    content = FRONTEND_APP.read_text(encoding="utf-8")
+
+    assert '"/query"' in content
+    assert '"/readyz"' in content
+    assert 'method: "POST"' in content
+    assert "JSON.stringify({ question })" in content
+    assert "result.final_answer" in content
+    assert "result.refusal.is_refusal" in content
+    assert "Citation markers" in content
+
+
+def test_frontend_live_query_guard_keeps_submit_disabled_for_empty_input_and_loading() -> None:
+    content = FRONTEND_APP.read_text(encoding="utf-8")
+    normalized = "".join(content.split())
+
+    assert 'constisSubmitDisabled=uiState==="loading"||!question.trim();' in normalized
+    assert "disabled={isSubmitDisabled}" in content
+    assert 'setUiState("empty_input")' in content
+    assert "Enter a question before submitting." in content
+
+
+def test_frontend_readme_documents_live_backend_wiring_and_readyz_status_probe() -> None:
+    content = FRONTEND_README.read_text(encoding="utf-8")
+
+    assert "./scripts/run-api-local.sh" in content
+    assert "POST /query" in content
+    assert "GET /readyz" in content
+    assert "final_answer" in content
+    assert "citation markers only" in content
+    assert "local Vite dev origins" in content

--- a/tests/test_frontend_scaffold.py
+++ b/tests/test_frontend_scaffold.py
@@ -49,6 +49,8 @@ def test_frontend_shell_contains_required_browser_demo_regions() -> None:
         "Refusal",
         "Backend unavailable",
         "loading",
+        "Refresh backend status",
+        "Citation markers",
     ):
         assert required_text in content
 
@@ -57,11 +59,14 @@ def test_frontend_readme_and_env_example_document_local_startup_and_api_base_url
     readme = (FRONTEND_DIR / "README.md").read_text(encoding="utf-8")
     env_example = (FRONTEND_DIR / ".env.example").read_text(encoding="utf-8")
 
+    assert "./scripts/run-api-local.sh" in readme
     assert "npm install" in readme
     assert "npm run dev" in readme
     assert "^20.19.0 || >=22.12.0" in readme
     assert "VITE_SUPPORTDOC_API_BASE_URL" in readme
     assert "http://127.0.0.1:9001" in readme
+    assert "POST /query" in readme
+    assert "GET /readyz" in readme
     assert "VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001" in env_example
 
 
@@ -70,9 +75,13 @@ def test_repo_docs_link_to_frontend_scaffold_and_local_startup() -> None:
     aws_note = Path("docs/architecture/aws_deployment.md").read_text(encoding="utf-8")
     validation_index = Path("docs/validation/README.md").read_text(encoding="utf-8")
 
-    assert "## 7C. Local browser demo scaffold" in readme_content
+    assert "## 7C. Local browser demo" in readme_content
     assert "frontend/README.md" in readme_content
     assert "VITE_SUPPORTDOC_API_BASE_URL" in readme_content
     assert "^20.19.0 || >=22.12.0" in readme_content
-    assert "checked-in React SPA scaffold under `frontend/`" in aws_note
-    assert "thin local browser scaffold now exists under `frontend/`" in validation_index
+    assert "live `POST /query` submission" in readme_content
+    assert "checked-in React SPA browser demo under `frontend/`" in aws_note
+    assert (
+        "thin local browser demo now exists under `frontend/` and can call the live local API"
+        in validation_index
+    )


### PR DESCRIPTION
…ported

Closes #103
--

Connect the checked-in React browser demo to the existing FastAPI backend so the local UI submits real `POST /query` requests instead of rendering mock preview states. Keep the client thin: single-page request/response flow, local empty-input validation, loading/submit guard, supported-answer and refusal rendering from `final_answer`, and a tiny `/readyz` status indicator for local diagnostics.

- wired the frontend shell under `frontend/` to the live backend
  - sends `POST /query` with `{ "question": "..." }`
  - renders `final_answer` for supported answers and refusals
  - keeps citation rendering to marker-only output per the frozen browser contract
  - disables submit while a request is in flight
  - blocks empty input locally before any network request
- added a small backend-status probe in the status area
  - calls `GET /readyz`
  - surfaces readiness, `query_contract`, service, environment, and version metadata
  - provides a manual refresh action for local operator testing
- added minimal backend CORS support for local browser development origins
  - allows `localhost`, `127.0.0.1`, and `[::1]` origins across local dev ports
  - keeps the backend/API surface unchanged; no new routes were introduced
- updated docs so the checked-in browser demo is described as a live local API client instead of a placeholder-only scaffold
  - `README.md`
  - `frontend/README.md`
  - `docs/architecture/aws_deployment.md`
  - `docs/validation/README.md`
- updated `.gitignore` to ignore `frontend/dist/`
- added/updated tests for:
  - live frontend `/query` + `/readyz` wiring
  - local empty-input and loading-submit guard behavior
  - local-browser CORS coverage on `/readyz` and `/query`
  - refreshed repo/frontend docs assertions

- turns the Epic 11 browser demo into a real local end-to-end path against the existing FastAPI backend
- preserves the thin-client contract from Task 1 instead of widening backend scope
- makes local operator testing easier by surfacing readiness metadata directly in the browser UI
- keeps earlier public Python surfaces intact: no `__init__.py` exports, CLI commands, schemas, fixtures, or snapshots were removed or renamed

- scoped pytest
  - `tests/test_frontend_scaffold.py`
  - `tests/test_frontend_live_query.py`
  - `tests/test_api_app.py`
  - result: `19 passed`
- dependent/shared-surface pytest
  - `tests/test_browser_demo_contract.py`
  - `tests/test_local_api_workflow.py`
  - `tests/test_api_logging.py`
  - result: `12 passed`
- required baseline commands
  - `uv run pytest -q tests/test_dense_retrieval_baseline.py tests/test_bm25_baseline.py tests/test_hybrid_baseline.py` → `5 passed`
  - `uv run pytest -q` → `167 passed`
  - `uv run python -m supportdoc_rag_chatbot smoke-trust-schema ...` → `status: ok`
- frontend smoke
  - `cd frontend && npm ci` → passed
  - `cd frontend && npm run build` → passed
  - Vite dev-server boot smoke on `127.0.0.1:4174` + `curl -I` → passed
- local API smoke
  - `./scripts/run-api-local.sh`
  - `curl http://127.0.0.1:9001/readyz`
  - `curl -X POST http://127.0.0.1:9001/query ...`
  - result: passed
- overlay validation
  - reapplied `epic11_task103_changed_files.zip` onto a fresh unzip of the same provided HEAD ZIP
  - reran `pytest -q` → `167 passed`
  - reran trust-schema smoke + CLI help
  - reran frontend `npm ci` + `npm run build`
  - reran local API smoke via `./scripts/run-api-local.sh` + `curl`

- rich evidence cards remain deferred; the browser still renders citation markers only, per `docs/process/browser_demo_contract.md`
- local-browser CORS support is intentionally narrow to localhost-style development origins and does not add any new backend routes or auth behavior

--
Changes to be committed:
	modified:   .gitignore
	modified:   README.md
	modified:   docs/architecture/aws_deployment.md
	modified:   docs/validation/README.md
	modified:   frontend/README.md
	modified:   frontend/src/App.jsx
	modified:   frontend/src/config.js
	modified:   frontend/src/styles.css
	modified:   src/supportdoc_rag_chatbot/app/api/middleware.py
	modified:   tests/test_api_app.py
	new file:   tests/test_frontend_live_query.py
	modified:   tests/test_frontend_scaffold.py