### PR TITLE
On branch frontend/105-render-citations-refusal-states-and-evidence-d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,13 +568,25 @@ cp .env.example .env.local
 
 - one-page React SPA
 - live `POST /query` submission with the frozen request shape
-- supported-answer rendering from `final_answer`
-- refusal rendering from `final_answer` plus optional `reason_code`
+- supported-answer rendering from `final_answer` with visible citation markers
+- explicit refusal rendering from `refusal.is_refusal` plus visible `reason_code`
+- marker-only evidence behavior aligned to `docs/process/browser_demo_contract.md`
+- small warning not to paste secrets or sensitive data into the demo
 - local empty-input validation and disabled submit while loading
 - tiny `/readyz` status indicator for local operator diagnostics
 - no auth, persistence, client-side routing, or rich evidence cards yet
 
-The FastAPI backend also accepts browser requests from the local Vite dev origins so the SPA can call the API directly during local development.
+The FastAPI backend also accepts browser requests from the local Vite dev origins so the SPA can call the API directly during local development. The current `/query` contract does not expose evidence text, source URL, or attribution to the browser, so the UI stays on citation markers only for now.
+
+### Browser demo smoke
+
+From the repo root:
+
+```bash
+bash scripts/smoke-browser-demo.sh
+```
+
+This installs the committed frontend dependencies, builds the SPA, and briefly serves the generated `frontend/dist/` output to confirm the local browser demo boots cleanly.
 
 See `frontend/README.md` for the focused frontend startup note.
 

--- a/docs/process/browser_demo_contract.md
+++ b/docs/process/browser_demo_contract.md
@@ -71,7 +71,7 @@ The first browser demo uses exactly these user-visible states.
 | --- | --- | --- | --- |
 | `empty_input` | Initial load, or the composer value trims to an empty string | Disable submit. Show no answer panel. Do not call `/query`. | User enters a non-empty question. |
 | `loading` | User submits a non-empty question | Disable submit and replace any prior result panel with a single loading treatment. No partial rendering or streaming. | `POST /query` resolves or fails. |
-| `supported_answer` | `POST /query` returns `200` and `refusal.is_refusal == false` | Render `final_answer` as the primary answer text. Keep the parsed `citations` in state, but do not render evidence cards in the first iteration. | User edits input or submits another question. |
+| `supported_answer` | `POST /query` returns `200` and `refusal.is_refusal == false` | Render `final_answer` as the primary answer text with visible citation markers. Keep the parsed `citations` in state and allow a small marker list, but do not render evidence cards or excerpts in the first iteration. | User edits input or submits another question. |
 | `refusal` | `POST /query` returns `200` and `refusal.is_refusal == true` | Render `final_answer` as the primary refusal text. The UI may optionally show `refusal.reason_code` as a small diagnostic label, but it does not branch to different layouts per reason code. | User edits input or submits another question. |
 | `backend_unavailable` | Network failure, timeout, or any non-`200` response from `/query`; optional `/readyz` failure if the browser probes readiness | Show one generic backend-unavailable treatment with retry affordance. Do not attempt partial answer rendering. The thin client may surface backend `error.message` when present, but it does not create extra error-specific states. | Retry succeeds, or the user returns to editing input. |
 
@@ -87,7 +87,7 @@ The browser must interpret the response fields like this.
 | Field | Browser behavior | Notes |
 | --- | --- | --- |
 | `final_answer` | Always render this as the main visible text for a `200` response. | This applies to both supported answers and refusals. The UI does not concatenate `final_answer` with any other text. |
-| `citations` | Preserve in state with the current result. | For supported answers this list is non-empty by contract. For refusals it is empty by contract. The first browser demo does not use this list to build evidence cards. |
+| `citations` | Preserve in state with the current result. | For supported answers this list is non-empty by contract. For refusals it is empty by contract. The first browser demo uses this list for visible marker rendering only and does not use it to build evidence cards. |
 | `refusal.is_refusal` | Use this as the single branch that selects `supported_answer` vs `refusal`. | Do not infer refusal from citation count or string matching. |
 | `refusal.reason_code` | Optional diagnostic or analytics field only. | The first browser demo does not create separate user-facing flows for `insufficient_evidence`, `no_relevant_docs`, `citation_validation_failed`, or `out_of_scope`. |
 | `refusal.message` | Treat as duplicate refusal metadata rather than a second visible body. | The trust contract requires it for refusals, but the first browser demo renders `final_answer` only. |
@@ -107,9 +107,11 @@ The first browser demo renders **citation markers only**.
 That means:
 
 - the browser renders `final_answer` exactly as returned, including inline markers such as `[1]`
+- the browser may echo the returned markers in a small marker list, but it still treats that as marker-only evidence behavior rather than an evidence-card UI
 - the browser does **not** attempt to dereference `doc_id`, `chunk_id`, or offsets on the client
 - the browser does **not** render expandable evidence cards, modals, or drawers in this first iteration
 - the browser does **not** make the markers clickable in this first iteration
+- the current `/query` contract does **not** expose evidence text, source URL, or attribution to the browser
 
 This is the smallest viable contract because the current `QueryResponse` only exposes citation pointers. It does **not** return the evidence text and source payload needed for a clean rich-card UI.
 

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -15,7 +15,7 @@ The current validated scope is intentionally **backend / API first**:
 - artifact-mode local API smoke is supported,
 - backend container runtime smoke is supported in fixture mode,
 - reviewed evidence correctness artifacts are committed,
-- a thin local browser demo now exists under `frontend/` and can call the live local API, but browser smoke remains outside this validation index,
+- a thin local browser demo now exists under `frontend/` and can call the live local API, with a small local browser smoke path now committed under `scripts/smoke-browser-demo.sh`,
 - artifact-mode inside the container image remains deferred.
 
 ## Canonical commands
@@ -53,6 +53,18 @@ Run the packaged backend runtime smoke path:
 This path builds the checked-in backend image, starts it with `docker run`, waits for health, validates `/healthz`, `/readyz`, and supported + refusal `/query` responses, then cleans up.
 
 Docs: `README.md` section `7B. Containerized Local API Smoke Workflow`
+
+### Browser demo smoke
+
+Build and briefly serve the checked-in browser demo locally:
+
+```bash
+bash scripts/smoke-browser-demo.sh
+```
+
+This path installs the committed frontend dependencies, builds the SPA, and serves `frontend/dist/` long enough to confirm the local UI boots.
+
+Docs: `README.md` section `7C. Local browser demo`
 
 ### Trust-contract schema smoke
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,10 @@ Current scope:
 - one question input and submit button
 - one result panel for supported answers or refusals from the live backend
 - one status area with a tiny `/readyz` indicator for local diagnostics
+- visible citation markers in the supported-answer view
+- explicit refusal rendering from the structured `refusal` contract, not text heuristics
+- marker-only evidence behavior aligned to `docs/process/browser_demo_contract.md`
+- a small warning not to paste secrets or sensitive data into the demo
 - local empty-input validation and submit-disabled loading behavior
 - no auth, persistence, multi-page routing, or rich evidence cards
 
@@ -63,10 +67,26 @@ VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001
 
 - sends `POST /query` with `{ "question": "..." }`
 - renders `final_answer` for both supported answers and refusals
-- shows citation markers only for supported answers
+- shows visible citation markers in the answer body and a marker list below it
+- uses `refusal.is_refusal` to distinguish supported answers from refusals
+- shows `reason_code` as a small refusal diagnostic label
+- keeps evidence display to citation markers only
+- does not render rich evidence cards or excerpts because the current `/query` response does not expose request-scoped evidence text
+- source URL and attribution are not currently available to the browser from the canonical `/query` payload
 - disables submit while a request is in flight
 - blocks empty input locally before any network request
+- warns users: Do not paste secrets or sensitive data into the demo
 - probes `GET /readyz` for operator-friendly backend status metadata
+
+## Local browser smoke
+
+From the repo root:
+
+```bash
+bash scripts/smoke-browser-demo.sh
+```
+
+This smoke path installs from the committed lockfile, builds the SPA, and briefly serves `frontend/dist/` so you can confirm the local browser demo boots.
 
 ## Other useful commands
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
 import { buildApiUrl, readApiBaseUrl } from "./config";
 
@@ -18,6 +18,7 @@ const BACKEND_STATUS_LABELS = {
 };
 
 const REQUEST_TIMEOUT_MS = 10000;
+const CITATION_MARKER_PATTERN = /(\[\d+\])/g;
 
 const INITIAL_BACKEND_STATUS = {
   state: "checking",
@@ -27,6 +28,47 @@ const INITIAL_BACKEND_STATUS = {
   queryContract: null,
   message: "Checking backend readiness via /readyz.",
 };
+
+function isCitationMarkerSegment(segment) {
+  return /^\[\d+\]$/.test(segment);
+}
+
+function renderAnswerWithMarkers(finalAnswer) {
+  return finalAnswer.split(CITATION_MARKER_PATTERN).map((segment, index) => {
+    if (!segment) {
+      return null;
+    }
+
+    if (isCitationMarkerSegment(segment)) {
+      return (
+        <sup
+          key={`${segment}-${index}`}
+          className="citation-marker-inline"
+          aria-label={`Citation marker ${segment}`}
+        >
+          {segment}
+        </sup>
+      );
+    }
+
+    return <Fragment key={`${segment}-${index}`}>{segment}</Fragment>;
+  });
+}
+
+function normalizeOptionalText(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function citationHasSourceMetadata(citation) {
+  return Boolean(
+    normalizeOptionalText(citation.source_url) || normalizeOptionalText(citation.attribution)
+  );
+}
 
 function normalizeErrorMessage(error) {
   if (error instanceof Error) {
@@ -118,6 +160,46 @@ function buildBackendStatus(nextStatus) {
   };
 }
 
+function CitationMarkers({ citations }) {
+  const hasSourceMetadata = citations.some(citationHasSourceMetadata);
+
+  return (
+    <div className="result-subsection">
+      <h4>Citation markers</h4>
+      <p className="helper-text result-note">
+        This local demo follows the frozen browser contract: citation markers only.
+        Rich evidence cards are deferred because the current <code>/query</code>
+        response does not include request-scoped evidence text.
+        {hasSourceMetadata
+          ? " Any source URL or attribution already exposed to the UI is shown directly under the matching marker."
+          : " Source URL and attribution are not exposed to the browser in the current response shape."}
+      </p>
+      <ul className="marker-list">
+        {citations.map((citation) => {
+          const sourceUrl = normalizeOptionalText(citation.source_url);
+          const attribution = normalizeOptionalText(citation.attribution);
+
+          return (
+            <li key={`${citation.marker}-${citation.chunk_id}`} className="marker-list-item">
+              <code>{citation.marker}</code>
+              {sourceUrl || attribution ? (
+                <div className="citation-source-meta">
+                  {sourceUrl ? (
+                    <a href={sourceUrl} target="_blank" rel="noreferrer">
+                      {sourceUrl}
+                    </a>
+                  ) : null}
+                  {attribution ? <span>{attribution}</span> : null}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 function ResultPanel({ uiState, result, backendErrorMessage }) {
   if (uiState === "loading") {
     return (
@@ -155,32 +237,31 @@ function ResultPanel({ uiState, result, backendErrorMessage }) {
   if (result.refusal.is_refusal) {
     return (
       <div className="result-state result-state--refusal" aria-live="polite">
+        <p className="result-kicker">Trust outcome</p>
         <h3>Refusal</h3>
         <p>{result.final_answer}</p>
-        <div className="result-diagnostic">
-          <span className="status-label">reason_code</span>
-          <code>{result.refusal.reason_code}</code>
-        </div>
+        <dl className="result-metadata">
+          <div>
+            <dt>Reason code</dt>
+            <dd>
+              <code>{result.refusal.reason_code}</code>
+            </dd>
+          </div>
+          <div>
+            <dt>Evidence behavior</dt>
+            <dd>Refusals do not carry citations in the current QueryResponse contract.</dd>
+          </div>
+        </dl>
       </div>
     );
   }
 
   return (
     <div className="result-state result-state--answer" aria-live="polite">
+      <p className="result-kicker">Trust outcome</p>
       <h3>Supported answer</h3>
-      <p>{result.final_answer}</p>
-      {result.citations.length ? (
-        <div className="result-subsection">
-          <h4>Citation markers</h4>
-          <ul className="marker-list">
-            {result.citations.map((citation) => (
-              <li key={`${citation.marker}-${citation.chunk_id}`}>
-                <code>{citation.marker}</code>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
+      <p className="answer-text">{renderAnswerWithMarkers(result.final_answer)}</p>
+      {result.citations.length ? <CitationMarkers citations={result.citations} /> : null}
     </div>
   );
 }
@@ -260,8 +341,8 @@ export default function App() {
       setResult(nextResult);
       setStatusText(
         nextResult.refusal.is_refusal
-          ? "Received a refusal from the live backend."
-          : "Received a supported answer from the live backend."
+          ? "Received an explicit refusal from the live backend."
+          : "Received a supported answer from the live backend with visible citation markers."
       );
       setUiState(nextResult.refusal.is_refusal ? "refusal" : "supported_answer");
       void probeBackendStatus();
@@ -310,6 +391,10 @@ export default function App() {
               The browser trims whitespace before submit, blocks empty input locally,
               and disables submit while a request is in flight.
             </p>
+            <p className="privacy-warning" role="note">
+              Do not paste secrets, credentials, access tokens, or other sensitive data
+              into this local demo.
+            </p>
 
             <div className="form-actions">
               <button type="submit" disabled={isSubmitDisabled}>
@@ -345,6 +430,10 @@ export default function App() {
             <span className={`status-pill status-pill--${backendStatus.state}`}>
               {BACKEND_STATUS_LABELS[backendStatus.state]}
             </span>
+          </div>
+          <div>
+            <span className="status-label">Evidence display</span>
+            <span>Citation markers only</span>
           </div>
           <div>
             <span className="status-label">query_contract</span>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -93,6 +93,15 @@ textarea {
 .helper-text {
   margin: 0;
   font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.privacy-warning {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid #fdba74;
+  border-radius: 12px;
+  background: #fff7ed;
 }
 
 .form-actions {
@@ -134,16 +143,48 @@ button:disabled {
   background: #f9fafb;
 }
 
-.result-state--loading,
-.result-state--error,
-.result-state--refusal,
-.result-state--answer {
+.result-state--loading {
   background: #f9fafb;
 }
 
+.result-state--error {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+.result-state--refusal {
+  background: #fff7ed;
+  border-color: #fdba74;
+}
+
+.result-state--answer {
+  background: #f0fdf4;
+  border-color: #86efac;
+}
+
 .result-detail,
-.result-diagnostic {
+.result-diagnostic,
+.result-metadata,
+.result-subsection {
   margin-top: 1rem;
+}
+
+.result-kicker {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.answer-text {
+  margin-bottom: 0;
+}
+
+.citation-marker-inline {
+  margin-left: 0.1rem;
+  font-size: 0.82em;
+  font-weight: 700;
 }
 
 .loading-bar {
@@ -153,16 +194,51 @@ button:disabled {
   background: linear-gradient(90deg, #d7dce5 0%, #e8ecf3 50%, #d7dce5 100%);
 }
 
-.result-subsection {
-  margin-top: 1rem;
+.result-note {
+  margin-bottom: 0.75rem;
 }
 
 .marker-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  display: grid;
+  gap: 0.75rem;
   margin: 0;
   padding-left: 1.25rem;
+}
+
+.marker-list-item {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.citation-source-meta {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.citation-source-meta a {
+  color: inherit;
+}
+
+.result-metadata {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.result-metadata div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.result-metadata dt,
+.status-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.result-metadata dd {
+  margin: 0;
 }
 
 .status-panel {
@@ -181,9 +257,10 @@ button:disabled {
   gap: 0.25rem;
 }
 
-.status-label {
-  font-size: 0.9rem;
-  font-weight: 700;
+.status-grid code,
+.status-grid span,
+.status-grid strong {
+  overflow-wrap: anywhere;
 }
 
 .status-pill {

--- a/scripts/smoke-browser-demo.sh
+++ b/scripts/smoke-browser-demo.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+frontend_dir="$repo_root/frontend"
+dist_dir="$frontend_dir/dist"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to smoke the browser demo." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to serve the built browser demo." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to fetch the served browser demo." >&2
+  exit 1
+fi
+
+cd "$frontend_dir"
+npm ci
+npm run build
+
+server_log="$(mktemp)"
+python3 -m http.server 4173 --bind 127.0.0.1 --directory "$dist_dir" >"$server_log" 2>&1 &
+server_pid=$!
+
+cleanup() {
+  if kill -0 "$server_pid" >/dev/null 2>&1; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -f "$server_log"
+}
+trap cleanup EXIT
+
+attempt=0
+until curl -fsS http://127.0.0.1:4173/ >/dev/null; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 20 ]; then
+    echo "Timed out waiting for the browser demo smoke server." >&2
+    cat "$server_log" >&2 || true
+    exit 1
+  fi
+  sleep 0.25
+done
+
+echo "Browser demo smoke passed."

--- a/tests/test_browser_demo_contract.py
+++ b/tests/test_browser_demo_contract.py
@@ -46,6 +46,7 @@ def test_browser_demo_contract_freezes_required_ui_states_and_evidence_decision(
 
     assert "citation markers only" in normalized
     assert "does **not** make the markers clickable" in normalized
+    assert "does **not** expose evidence text, source url, or attribution" in normalized
     assert "query_response.retrieved_context.example.json" in content
     assert "follow-up" in normalized
     assert "request-scoped evidence payload" in normalized

--- a/tests/test_frontend_live_query.py
+++ b/tests/test_frontend_live_query.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 FRONTEND_APP = Path("frontend/src/App.jsx")
 FRONTEND_README = Path("frontend/README.md")
+SMOKE_SCRIPT = Path("scripts/smoke-browser-demo.sh")
 
 
 def test_frontend_live_query_wiring_uses_query_and_readyz_routes() -> None:
@@ -28,6 +29,21 @@ def test_frontend_live_query_guard_keeps_submit_disabled_for_empty_input_and_loa
     assert "Enter a question before submitting." in content
 
 
+def test_frontend_trust_rendering_distinguishes_supported_answers_from_refusals() -> None:
+    content = FRONTEND_APP.read_text(encoding="utf-8")
+    normalized = content.casefold()
+
+    assert "renderanswerwithmarkers" in normalized
+    assert "citation markers only" in normalized
+    assert "reason code" in normalized
+    assert "refusals do not carry citations" in normalized
+    assert "do not paste secrets" in normalized
+    assert "result-state--answer" in content
+    assert "result-state--refusal" in content
+    assert "citation.source_url" in content
+    assert "citation.attribution" in content
+
+
 def test_frontend_readme_documents_live_backend_wiring_and_readyz_status_probe() -> None:
     content = FRONTEND_README.read_text(encoding="utf-8")
 
@@ -37,3 +53,13 @@ def test_frontend_readme_documents_live_backend_wiring_and_readyz_status_probe()
     assert "final_answer" in content
     assert "citation markers only" in content
     assert "local Vite dev origins" in content
+    assert "Do not paste secrets" in content
+
+
+def test_browser_demo_smoke_script_builds_and_serves_the_frontend() -> None:
+    content = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "npm ci" in content
+    assert "npm run build" in content
+    assert "python3 -m http.server" in content
+    assert "curl -fsS http://127.0.0.1:4173/" in content

--- a/tests/test_frontend_scaffold.py
+++ b/tests/test_frontend_scaffold.py
@@ -51,6 +51,8 @@ def test_frontend_shell_contains_required_browser_demo_regions() -> None:
         "loading",
         "Refresh backend status",
         "Citation markers",
+        "Citation markers only",
+        "Do not paste secrets",
     ):
         assert required_text in content
 
@@ -67,6 +69,9 @@ def test_frontend_readme_and_env_example_document_local_startup_and_api_base_url
     assert "http://127.0.0.1:9001" in readme
     assert "POST /query" in readme
     assert "GET /readyz" in readme
+    assert "citation markers only" in readme
+    assert "Do not paste secrets" in readme
+    assert "bash scripts/smoke-browser-demo.sh" in readme
     assert "VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001" in env_example
 
 
@@ -80,8 +85,10 @@ def test_repo_docs_link_to_frontend_scaffold_and_local_startup() -> None:
     assert "VITE_SUPPORTDOC_API_BASE_URL" in readme_content
     assert "^20.19.0 || >=22.12.0" in readme_content
     assert "live `POST /query` submission" in readme_content
+    assert "bash scripts/smoke-browser-demo.sh" in readme_content
     assert "checked-in React SPA browser demo under `frontend/`" in aws_note
     assert (
         "thin local browser demo now exists under `frontend/` and can call the live local API"
         in validation_index
     )
+    assert "scripts/smoke-browser-demo.sh" in validation_index


### PR DESCRIPTION
…isplay

Closes #105
---

This change finishes the trust-facing UI pass for the local browser demo. The frontend now renders supported answers with visible citation markers, renders refusals from the structured `QueryResponse.refusal` contract, keeps evidence display on the Task 1 marker-only decision, adds a small warning not to paste secrets, and adds a tiny browser smoke script for local validation. The verification commands below are written in the repo’s `uv` workflow so they can be copied directly into a normal local checkout.

- updated `frontend/src/App.jsx` to:
  - render visible inline citation markers from `final_answer`
  - keep a small marker list below supported answers
  - distinguish supported answers from refusals strictly through `refusal.is_refusal`
  - show refusal `reason_code` as a small diagnostic label
  - keep evidence behavior explicitly marker-only
  - show source URL / attribution cleanly if those fields are ever exposed to the browser payload later
  - add a visible “do not paste secrets” warning
  - surface evidence-display mode in the status area
- updated `frontend/src/styles.css` for the supported-answer, refusal, warning, and marker-display states
- updated `docs/process/browser_demo_contract.md` so the frozen contract matches the implemented marker-only evidence behavior
- updated `README.md`, `frontend/README.md`, and `docs/validation/README.md` to document:
  - visible citation markers
  - explicit refusal handling
  - current evidence limitations of `/query`
  - the new local browser smoke command
- added `scripts/smoke-browser-demo.sh` to build and briefly serve the committed browser demo
- expanded frontend/browser tests in:
  - `tests/test_frontend_scaffold.py`
  - `tests/test_frontend_live_query.py`
  - `tests/test_browser_demo_contract.py`

This is the first browser-demo slice that actually matches the project’s trust claims instead of only showing a generic result shell. The local UI now makes the answer/refusal distinction explicit, keeps citations visible, preserves the scoped backend contract from Task 1, and avoids inventing a richer evidence model than the current API actually returns.

Scoped tests:

- `uv run pytest -q tests/test_frontend_scaffold.py tests/test_frontend_live_query.py tests/test_browser_demo_contract.py`
- `13 passed`

Shared-surface / dependent tests:

- `uv run pytest -q tests/test_api_app.py tests/test_local_api_workflow.py tests/test_trust_schema.py tests/test_frontend_scaffold.py tests/test_frontend_live_query.py tests/test_browser_demo_contract.py`
- `37 passed`

Full suite:

- `uv run pytest -q`
- `169 passed`

Additional smoke:

- `bash scripts/smoke-browser-demo.sh`
- passed

---

Changes to be committed:
	modified:   README.md
	modified:   docs/process/browser_demo_contract.md
	modified:   docs/validation/README.md
	modified:   frontend/README.md
	modified:   frontend/src/App.jsx
	modified:   frontend/src/styles.css
	new file:   scripts/smoke-browser-demo.sh
	modified:   tests/test_browser_demo_contract.py
	modified:   tests/test_frontend_live_query.py
	modified:   tests/test_frontend_scaffold.py