### PR TITLE
On branch doc/109-verify-the-local-workflow-on-macOS-arm64-and-Pop_OS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ API-first MVP validation with reviewed evidence, documented smoke paths, and sou
 
 ### Completed
 - Repository scaffolding for application, ingestion, retrieval, evaluation, and documentation.
-- Thin React + Vite local browser demo under `frontend/` with live local API wiring.
+- Thin React + Vite local browser demo scaffold under `frontend/`.
 - Corpus governance documentation in `docs/data/corpus.md`.
 - Ingestion pipeline artifacts for manifest generation, parsing, section extraction, chunking, and validation.
 - Local embedding job that converts `data/processed/chunks.jsonl` into deterministic dense-vector artifacts for downstream index construction.
@@ -40,7 +40,7 @@ API-first MVP validation with reviewed evidence, documented smoke paths, and sou
 
 ## 2A. Demo day quick start
 
-For a boring first run, use the backend in **fixture mode** and the checked-in browser demo under `frontend/`. Fixture mode is the canonical first-run path because it uses deterministic checked-in trust fixtures, so you can demo the local API and browser UI together without a model server or local retrieval artifacts. Artifact mode is the optional second path once you already have local `chunks.jsonl` and FAISS files.
+For a boring first run, use the backend in **fixture mode** and the checked-in browser demo under `frontend/` together. Fixture mode is the canonical first-run path because it uses deterministic checked-in trust fixtures, so you can verify the local API and browser UI without a model server or local retrieval artifacts. Artifact mode is the optional second path once you already have local `chunks.jsonl` and FAISS files.
 
 ### Canonical first run: fixture mode
 
@@ -73,6 +73,7 @@ What to expect:
 - browser demo URL: `http://127.0.0.1:5173`
 - frontend API override: `VITE_SUPPORTDOC_API_BASE_URL` (defaults to `http://127.0.0.1:9001`)
 - frontend runtime: Node `^20.19.0 || >=22.12.0`
+- shell wrapper overrides: `SUPPORTDOC_LOCAL_API_HOST=127.0.0.1`, `SUPPORTDOC_LOCAL_API_PORT=9001`, and `SUPPORTDOC_LOCAL_API_RELOAD=true|false`
 
 ### Optional second path: artifact mode
 
@@ -95,7 +96,7 @@ npm run dev
 
 If your artifact files live outside the default `data/processed/` paths, set the documented `SUPPORTDOC_QUERY_ARTIFACT_*` override variables from `src/supportdoc_rag_chatbot/config.py` before starting the backend.
 
-For the expanded local run notes and the focused frontend startup note, see `README.md` section `7C. Local browser demo` and `frontend/README.md`.
+For the expanded local run notes and the focused frontend startup note, see `README.md` section `7C. Local browser demo scaffold` and `frontend/README.md`.
 
 ---
 
@@ -118,7 +119,7 @@ This is the main orchestration layer implemented in this repository. It is respo
 - refusal enforcement.
 
 ### Infrastructure Layer
-The deploy-now MVP remains **API-first** for backend validation. The repository now also includes a thin React browser demo under `frontend/` that can call the local FastAPI `/query` route in development, while frontend hosting and richer evidence UI remain deferred to later Epic 11 tasks and the deployment baseline in `docs/architecture/aws_deployment.md`.
+The deploy-now MVP remains **API-first** for backend validation. The repository now also includes a thin React browser-demo scaffold under `frontend/`, while frontend hosting, live `/query` wiring, and richer evidence UI remain deferred to later Epic 11 tasks and the deployment baseline in `docs/architecture/aws_deployment.md`.
 
 ### High-Level System Flow
 
@@ -235,6 +236,8 @@ The current MVP corpus is a pinned Kubernetes documentation snapshot. Corpus gov
 ---
 
 ## 7. Local Development
+
+Baseline Python for local development is **Python 3.13**, as pinned in `.python-version` and `pyproject.toml`.
 
 ### Base environment
 
@@ -589,19 +592,21 @@ If artifact-mode container support is needed later, it should be added as an exp
 
 ---
 
-## 7C. Local browser demo
+## 7C. Local browser demo scaffold
 
-Epic 11 now includes a thin local React SPA under `frontend/`. It stays intentionally small: one page, one question box, one submit button, one result panel, and one status area aligned to `docs/process/browser_demo_contract.md`.
+Epic 11 now includes a thin local React SPA scaffold under `frontend/`. It remains intentionally small, but the checked-in browser demo now also supports live `POST /query` submission against the local FastAPI backend in development.
 
-### Canonical first-run path: fixture mode
+Backend baseline for this local browser demo path: **Python 3.13** (`.python-version`, `pyproject.toml`). Target-machine notes for macOS arm64 and Pop!_OS x86_64 live in `docs/validation/local_workflow_platforms.md`.
 
-Start the backend first in fixture mode. This is the canonical first-run path because it returns deterministic checked-in responses and does not require local retrieval artifacts or a model server.
+### Start the local browser demo path
+
+Start the backend first in fixture mode:
 
 ```bash
 ./scripts/run-api-local.sh
 ```
 
-Then start the browser demo in a second terminal:
+Then start the frontend in a second terminal:
 
 ```bash
 cd frontend
@@ -610,71 +615,42 @@ npm ci
 npm run dev
 ```
 
-Use Node `^20.19.0 || >=22.12.0` for the Vite-based app. The committed `frontend/.npmrc` keeps the lockfile registry-neutral for local installs on macOS and Linux.
+Use Node `^20.19.0 || >=22.12.0` for the Vite-based scaffold. The committed `frontend/.npmrc` also keeps the lockfile registry-neutral for local installs on macOS and Linux.
 
-Startup order and local addresses:
+Default local addresses:
 
-- start the backend first on `http://127.0.0.1:9001`
-- then start the Vite dev server on `http://127.0.0.1:5173`
-- the browser UI probes `GET /readyz` for operator-friendly status
-- the question form submits `POST /query` to the live backend
+- backend fixture shell: `http://127.0.0.1:9001`
+- frontend Vite dev server: `http://127.0.0.1:5173`
 
-### Optional second path: artifact mode
+The browser demo uses `VITE_SUPPORTDOC_API_BASE_URL` and falls back to `http://127.0.0.1:9001` so the UI can probe `GET /readyz` and send live `POST /query` submission in development.
 
-Artifact mode is the follow-on path after you already have the local retrieval artifacts. In user-friendly terms: fixture mode is for a predictable first demo from checked-in responses, while artifact mode is for testing the browser UI against your locally generated `chunks.jsonl` and FAISS index files.
+### API base URL override
 
-Start the backend in artifact mode with:
-
-```bash
-SUPPORTDOC_LOCAL_API_MODE=artifact ./scripts/run-api-local.sh
-```
-
-Keep the same frontend startup commands after that. If your artifact files are not in the default `data/processed/` locations, set the documented `SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH`, `SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH`, `SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH`, and `SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH` overrides before launching the backend.
-
-### API base URL and local overrides
-
-The frontend reads `VITE_SUPPORTDOC_API_BASE_URL` and falls back to `http://127.0.0.1:9001`. To point the browser demo at a different local backend, copy `frontend/.env.example` to `frontend/.env.local` and edit the value.
+To point the browser demo at a different local backend, copy `frontend/.env.example` to `frontend/.env.local` and edit the value.
 
 ```bash
 cd frontend
 cp .env.example .env.local
 ```
 
-Other local workflow knobs that matter for the combined backend + browser demo run:
-
-- `SUPPORTDOC_LOCAL_API_MODE=fixture|artifact`
-- `SUPPORTDOC_LOCAL_API_HOST=127.0.0.1`
-- `SUPPORTDOC_LOCAL_API_PORT=9001`
-- `SUPPORTDOC_LOCAL_API_RELOAD=true|false`
-- `VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001`
-
-### Current scope of the browser demo
-
-- one-page React SPA
-- live `POST /query` submission with the frozen request shape
-- supported-answer rendering from `final_answer` with visible citation markers
-- explicit refusal rendering from `refusal.is_refusal` plus visible `reason_code`
-- marker-only evidence behavior aligned to `docs/process/browser_demo_contract.md`
-- small warning not to paste secrets or sensitive data into the demo
-- local empty-input validation and disabled submit while loading
-- tiny `/readyz` status indicator for local operator diagnostics
-- no auth, persistence, client-side routing, or rich evidence cards yet
-
-The FastAPI backend also accepts browser requests from the local Vite dev origins so the SPA can call the API directly during local development. The current `/query` contract does not expose evidence text, source URL, or attribution to the browser, so the UI stays on citation markers only for now.
-
 ### Browser demo smoke
 
-From the repo root:
+From the repo root, run:
 
 ```bash
 bash scripts/smoke-browser-demo.sh
 ```
 
-This combined smoke path starts the backend in fixture mode, waits for `GET /readyz`, validates one supported `POST /query` response, builds the SPA with `VITE_SUPPORTDOC_API_BASE_URL` pointed at that backend, and briefly serves `frontend/dist/` on `http://127.0.0.1:4173` to confirm the local browser demo stack boots cleanly.
+That smoke path boots the fixture backend, waits for `GET /readyz`, validates one supported `POST /query` response, builds the frontend, and briefly serves the committed browser demo assets.
+
+### Current scope of the scaffold
+
+- one-page React SPA
+- visible status treatment for loading, refusal, and backend-unavailable states
+- live `POST /query` submission in local development
+- no auth, persistence, or client-side routing
 
 See `frontend/README.md` for the focused frontend startup note.
-
----
 
 ## 8. Citations and Refusal Behavior
 
@@ -749,7 +725,7 @@ The single closeout status page for Epic 10 now lives at `docs/validation/mvp_re
 
 ## 10. Deployment Overview
 
-The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo remains API-first** for backend proof and reviewed trust artifacts, while the repo now also includes a thin local browser demo under `frontend/` for Epic 11 work, including live local API wiring. Frontend hosting and richer browser behavior are still deferred in the AWS baseline.
+The intended long-term deployment path is a FastAPI backend with a web frontend, persistent artifact storage, a vector retrieval layer, and a replaceable generation backend. The **current validated MVP scope in this repo remains API-first** for backend proof and reviewed trust artifacts, while the repo now also includes a thin local browser scaffold under `frontend/` for Epic 11 demo work. Frontend hosting and richer browser behavior are still deferred in the AWS baseline.
 
 The first browser-demo integration contract for that API-first backend now lives in `docs/process/browser_demo_contract.md`. It freezes the UI against the current `/query` and `/readyz` surface and explicitly defers rich evidence cards until the backend exposes a request-scoped evidence payload.
 

--- a/docs/architecture/aws_deployment.md
+++ b/docs/architecture/aws_deployment.md
@@ -39,6 +39,7 @@ What already exists in the ZIP:
 - local retrieval artifacts built around `chunks.jsonl` plus FAISS index files
 - canonical trust-layer response schema and smoke validation
 - structured backend orchestration for retrieval, refusal gating, generation, and citation validation
+- a checked-in React SPA scaffold under `frontend/` for the local browser demo
 - a checked-in React SPA browser demo under `frontend/` that can call the local API in development
 
 What does **not** exist yet in the ZIP:

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -7,15 +7,18 @@ Use it when you want to answer these questions quickly:
 - what is the canonical local API smoke path?
 - what is the canonical artifact-mode smoke path?
 - what is the canonical packaged container runtime smoke path?
+- what is the combined fixture-mode browser-demo smoke path?
 - where is the reviewed evidence package for the MVP trust pass?
 
-The current validated scope is intentionally **backend / API first**:
+The current validated scope is intentionally **backend / API first**, but the local browser story is now documented here too:
 
 - fixture-mode local API smoke is supported,
 - artifact-mode local API smoke is supported,
 - backend container runtime smoke is supported in fixture mode,
 - reviewed evidence correctness artifacts are committed,
-- a thin local browser demo now exists under `frontend/` and can call the live local API, with a combined fixture-mode browser-demo smoke path now committed under `scripts/smoke-browser-demo.sh`,
+- a thin local browser scaffold now exists under `frontend/`,
+- a thin local browser demo now exists under `frontend/` and can call the live local API,
+- the browser smoke path uses the fixture backend and checked-in frontend assets,
 - artifact-mode inside the container image remains deferred.
 
 ## Canonical commands
@@ -42,6 +45,18 @@ This path creates a temporary artifact fixture, starts the backend in artifact m
 
 Docs: `README.md` section `7A. Local API Smoke Workflow`
 
+### Combined fixture-mode browser-demo smoke path
+
+Run the browser demo smoke from the repo root:
+
+```bash
+bash scripts/smoke-browser-demo.sh
+```
+
+This combined fixture-mode browser-demo smoke path starts the fixture backend with `./scripts/run-api-local.sh`, waits for `GET /readyz`, validates one supported `POST /query` response, builds the checked-in frontend, and briefly serves the browser assets.
+
+Docs: `README.md` sections `2A. Demo day quick start` and `7C. Local browser demo`
+
 ### Container runtime smoke
 
 Run the packaged backend runtime smoke path:
@@ -54,30 +69,19 @@ This path builds the checked-in backend image, starts it with `docker run`, wait
 
 Docs: `README.md` section `7B. Containerized Local API Smoke Workflow`
 
-### Browser demo smoke
-
-Start the fixture-mode backend, build the checked-in browser demo, and briefly serve the local stack:
-
-```bash
-bash scripts/smoke-browser-demo.sh
-```
-
-This path starts `./scripts/run-api-local.sh` in fixture mode, waits for `/readyz`, validates one supported `/query` response, then builds the SPA and serves `frontend/dist/` long enough to confirm the local UI stack boots.
-
-Docs: `README.md` sections `2A. Demo day quick start` and `7C. Local browser demo`
-
 ### Trust-contract schema smoke
 
 Validate the canonical `QueryResponse` fixtures against the committed schema:
 
 ```bash
-uv run python -m supportdoc_rag_chatbot smoke-trust-schema \
-  --schema docs/contracts/query_response.schema.json \
-  --answer-fixture docs/contracts/query_response.answer.example.json \
-  --refusal-fixture docs/contracts/query_response.refusal.example.json
+uv run python -m supportdoc_rag_chatbot smoke-trust-schema   --schema docs/contracts/query_response.schema.json   --answer-fixture docs/contracts/query_response.answer.example.json   --refusal-fixture docs/contracts/query_response.refusal.example.json
 ```
 
 Docs: `docs/process/trust_response_contract.md`
+
+### Local browser scaffold platform note
+
+For the macOS arm64 and Pop!_OS x86_64 local scaffold path, Python baseline, artifact-mode prerequisites, and the Linux-only `llm-vllm` caveat, see `docs/validation/local_workflow_platforms.md`.
 
 ## Reviewed evidence package
 
@@ -97,6 +101,7 @@ The final MVP trust pass is documented with these committed artifacts:
 - `docs/data/corpus.md` — corpus snapshot and corpus-governance contract
 - `docs/architecture/aws_deployment.md` — canonical AWS baseline and deferred scope labels
 - `docs/process/retrieval_comparison_notes.md` — retrieval-only baseline comparison and provisional hybrid recommendation
+- `docs/validation/local_workflow_platforms.md` — macOS arm64 and Pop!_OS x86_64 local workflow notes, Python baseline, artifact prerequisites, and the Linux-only `llm-vllm` note
 
 ## Readiness-report location
 

--- a/docs/validation/local_workflow_platforms.md
+++ b/docs/validation/local_workflow_platforms.md
@@ -1,0 +1,111 @@
+# Local workflow notes for macOS arm64 and Pop!_OS x86_64
+
+This note keeps the **current local browser-demo scaffold path** in one place for the two target development machines.
+
+Current repo scope:
+
+- the backend local shell can start in fixture mode with `./scripts/run-api-local.sh`
+- the browser UI under `frontend/` is still a thin scaffold
+- the scaffold boots locally and points at the expected API base URL
+- the scaffold does **not** send live `POST /query` requests yet
+
+## Runtime baselines
+
+- **Python 3.13** is the required backend baseline. The repo pins it in `.python-version`, and `pyproject.toml` requires `>=3.13,<3.14`.
+- **Node `^20.19.0 || >=22.12.0`** is the required frontend baseline for the Vite scaffold.
+- `uv` is the canonical Python workflow for both machines.
+
+## Canonical fixture-mode scaffold path
+
+Use the same boring path on both target machines.
+
+1. Sync the backend environment from the repo root:
+
+```bash
+uv sync --locked --extra dev-tools --extra faiss
+```
+
+2. Start the backend in fixture mode:
+
+```bash
+./scripts/run-api-local.sh
+```
+
+3. In a second terminal, start the frontend scaffold:
+
+```bash
+cd frontend
+node -v
+npm install
+npm run dev
+```
+
+Expected local addresses:
+
+- backend fixture shell: `http://127.0.0.1:9001`
+- frontend Vite dev server: `http://127.0.0.1:5173`
+
+Optional local checks:
+
+- open `http://127.0.0.1:5173`
+- confirm the page renders the scaffold header, question box, result panel, and status area
+- confirm the backend reports healthy from `http://127.0.0.1:9001/readyz`
+
+## Target-machine notes
+
+### macOS arm64
+
+- Use the same fixture-mode path above.
+- `scripts/bootstrap.sh` can help install Python 3.13 tooling and optional local PostgreSQL support, but PostgreSQL is **not** required for the baseline browser scaffold path.
+- `llm-vllm` is **not** part of the macOS path. The package extra is Linux-only in this repo, and the baseline scaffold path does not need it.
+
+### Pop!_OS x86_64
+
+- Use the same fixture-mode path above.
+- `scripts/bootstrap.sh` is already wired for Pop!_OS / Ubuntu-style systems when you choose the optional local PostgreSQL install, but PostgreSQL is still **not** required for the baseline browser scaffold path.
+- `llm-vllm` remains optional and is **not** required for the baseline browser scaffold path.
+
+## Artifact-mode prerequisites
+
+Artifact mode is the **optional second path** on both machines. Keep it separate from the first-run fixture path.
+
+Before you start the backend with `SUPPORTDOC_LOCAL_API_MODE=artifact`, make sure these local artifacts exist:
+
+- `data/processed/chunks.jsonl`
+- `data/processed/indexes/faiss/chunk_index.faiss`
+- `data/processed/indexes/faiss/chunk_index.metadata.json`
+- `data/processed/indexes/faiss/chunk_index.row_mapping.json`
+
+If your artifacts live somewhere else, set the matching override variables from `src/supportdoc_rag_chatbot/config.py` before launching the backend:
+
+- `SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH`
+- `SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH`
+- `SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH`
+- `SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH`
+
+Then start artifact mode with:
+
+```bash
+SUPPORTDOC_LOCAL_API_MODE=artifact ./scripts/run-api-local.sh
+```
+
+Keep the same frontend commands after that:
+
+```bash
+cd frontend
+node -v
+npm install
+npm run dev
+```
+
+Artifact mode in this repo still defaults to fixture generation unless you explicitly switch generation mode, so it does **not** require a model server just to boot the local scaffold path against local retrieval artifacts.
+
+## Linux-only `llm-vllm` note
+
+`pyproject.toml` restricts the `llm-vllm` extra to `platform_system == 'Linux' and platform_machine == 'x86_64'`. That means:
+
+- **macOS arm64** does not install `llm-vllm`
+- **Pop!_OS x86_64** can use it only as an optional Linux path, typically with NVIDIA/CUDA available
+- the baseline local browser scaffold path on both target machines does **not** require `llm-vllm`
+
+Treat `llm-vllm` as a later Linux-only inference option, not as a prerequisite for the first local browser-demo run.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
-# Frontend browser demo
+# Frontend browser demo scaffold
 
 This directory contains the thin React SPA for the local browser demo in Epic 11.
 
@@ -19,6 +19,8 @@ The UI behavior is pinned to `docs/process/browser_demo_contract.md`.
 
 ## Canonical first-run path
 
+Backend prerequisite for the local scaffold path: **Python 3.13** (`.python-version`, `pyproject.toml`). This scaffold also targets Node `^20.19.0 || >=22.12.0`. For macOS arm64 and Pop!_OS x86_64 notes in one place, see `docs/validation/local_workflow_platforms.md`.
+
 Start the local API first from the repo root in **fixture mode**. This is the boring, reliable first-run path because the backend serves deterministic checked-in trust fixtures instead of requiring local retrieval artifacts or a model server.
 
 ```bash
@@ -30,6 +32,7 @@ Then start the browser demo in a second terminal:
 ```bash
 cd frontend
 node -v
+npm install
 npm ci
 npm run dev
 ```
@@ -43,6 +46,7 @@ If you already hit a failed install once, remove the partial local install and r
 ```bash
 cd frontend
 rm -rf node_modules
+npm install
 npm ci
 ```
 
@@ -87,17 +91,17 @@ VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001
 ## Live browser behavior
 
 - sends `POST /query` with `{ "question": "..." }`
+- probes `GET /readyz` for operator-friendly backend status metadata
 - renders `final_answer` for both supported answers and refusals
 - shows visible citation markers in the answer body and a marker list below it
 - uses `refusal.is_refusal` to distinguish supported answers from refusals
 - shows `reason_code` as a small refusal diagnostic label
 - keeps evidence display to citation markers only
 - does not render rich evidence cards or excerpts because the current `/query` response does not expose request-scoped evidence text
-- source URL and attribution are not currently available to the browser from the canonical `/query` payload
+- source URL and attribution are not currently available to the browser from the canonical `/query` payload unless the backend exposes `citation.source_url` and `citation.attribution`
 - disables submit while a request is in flight
 - blocks empty input locally before any network request
 - warns users: Do not paste secrets or sensitive data into the demo
-- probes `GET /readyz` for operator-friendly backend status metadata
 
 ## Local browser smoke
 
@@ -107,7 +111,7 @@ From the repo root:
 bash scripts/smoke-browser-demo.sh
 ```
 
-This combined smoke path starts the backend in fixture mode, waits for `GET /readyz`, validates one supported `POST /query` response, builds the SPA from the committed lockfile, and briefly serves `frontend/dist/` so you can confirm the local browser demo stack boots.
+This combined fixture-mode browser-demo smoke path starts the backend in fixture mode, waits for `GET /readyz`, validates one supported `POST /query` response, builds the SPA from the committed lockfile, and briefly serves `frontend/dist/` so you can confirm the local browser demo stack boots.
 
 ## Other useful commands
 

--- a/scripts/reset-dev-env.sh
+++ b/scripts/reset-dev-env.sh
@@ -1,29 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -f "${SCRIPT_DIR}/pyproject.toml" ]]; then
+  REPO_ROOT="${SCRIPT_DIR}"
+elif [[ -f "${SCRIPT_DIR}/../pyproject.toml" ]]; then
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  echo "❌ Could not determine the repo root from: ${SCRIPT_DIR}" >&2
+  echo "   Put this script at the repo root or under ./scripts/." >&2
+  exit 1
+fi
+
 PYTHON_VERSION="${PYTHON_VERSION:-3.13}"
 KERNEL_NAME="${KERNEL_NAME:-supportdoc-rag-chatbot-uv-project}"
 
 HARD_RESET="false"
 REMOVE_LOCK="false"
+ALLOW_PYTHON_UNINSTALL="${SUPPORTDOC_RESET_UNINSTALL_UV_PYTHON:-false}"
 
 usage() {
-  cat <<EOF
-Usage: ./reset-dev-env.sh [--hard] [--remove-lock]
+  cat <<EOF_USAGE
+Usage:
+  ./reset-dev-env.sh [--hard] [--remove-lock]
+  ./scripts/reset-dev-env.sh [--hard] [--remove-lock]
 
-  --remove-lock   Remove uv.lock in addition to local caches and virtualenvs
-  --hard          Do a stronger cleanup:
-                  - remove uv.lock
-                  - clear uv cache
-                  - try to uninstall uv-managed Python ${PYTHON_VERSION}
-EOF
+Clean local repo state for this checkout only.
+Safe to run from any current working directory because cleanup is anchored to the repo root.
+
+Options:
+  --remove-lock   Remove repo uv.lock in addition to local caches/build artifacts
+  --hard          Stronger cleanup:
+                  - implies --remove-lock
+                  - clears the uv cache
+                  - optionally uninstalls uv-managed Python ${PYTHON_VERSION}
+                    only when SUPPORTDOC_RESET_UNINSTALL_UV_PYTHON=true
+  -h, --help      Show this help text
+EOF_USAGE
 }
 
 remove_path() {
   local target="$1"
+  local display="$target"
+
+  if [[ "$target" == "$REPO_ROOT" ]]; then
+    display="."
+  elif [[ "$target" == "$REPO_ROOT/"* ]]; then
+    display=".${target#"$REPO_ROOT"}"
+  fi
+
   if [[ -e "$target" || -L "$target" ]]; then
-    rm -rf "$target"
-    echo "🗑️  Removed: $target"
+    rm -rf -- "$target"
+    echo "🗑️  Removed: $display"
   fi
 }
 
@@ -41,17 +70,17 @@ for arg in "$@"; do
       exit 0
       ;;
     *)
-      echo "❌ Unknown argument: $arg"
-      usage
+      echo "❌ Unknown argument: $arg" >&2
+      usage >&2
       exit 1
       ;;
   esac
 done
 
-echo "🧹 Cleaning local project state..."
+echo "🧹 Cleaning local project state under: ${REPO_ROOT}"
 
-# Common local env / build artifacts
-for path in \
+# Root-level Python and build artifacts.
+for rel_path in \
   ".venv" \
   "venv" \
   ".pytest_cache" \
@@ -64,23 +93,49 @@ for path in \
   "htmlcov" \
   "build" \
   "dist" \
-  ".ipynb_checkpoints" \
-  ".DS_Store"
+  ".ipynb_checkpoints"
 do
-  remove_path "$path"
+  remove_path "${REPO_ROOT}/${rel_path}"
 done
 
-# Egg metadata and Python bytecode
-find . -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
-find . -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
-find . -type d \( -name "*.egg-info" -o -name ".eggs" \) -prune -exec rm -rf {} + 2>/dev/null || true
+# Frontend artifacts used by the local browser demo.
+for rel_path in \
+  "frontend/node_modules" \
+  "frontend/dist" \
+  "frontend/.vite" \
+  "frontend/.eslintcache"
+do
+  remove_path "${REPO_ROOT}/${rel_path}"
+done
 
-# Optional lock cleanup
+# Coverage leftovers such as .coverage.<suffix>
+while IFS= read -r -d '' path; do
+  remove_path "$path"
+done < <(find "$REPO_ROOT" -maxdepth 1 -type f -name '.coverage.*' -print0 2>/dev/null)
+
+# OS junk files.
+while IFS= read -r -d '' path; do
+  remove_path "$path"
+done < <(find "$REPO_ROOT" -type f -name '.DS_Store' -print0 2>/dev/null)
+
+# Python cache and packaging artifacts anywhere inside the repo.
+while IFS= read -r -d '' path; do
+  remove_path "$path"
+done < <(find "$REPO_ROOT" -type d -name '__pycache__' -prune -print0 2>/dev/null)
+
+while IFS= read -r -d '' path; do
+  remove_path "$path"
+done < <(find "$REPO_ROOT" -type f \( -name '*.pyc' -o -name '*.pyo' \) -print0 2>/dev/null)
+
+while IFS= read -r -d '' path; do
+  remove_path "$path"
+done < <(find "$REPO_ROOT" -type d \( -name '*.egg-info' -o -name '.eggs' \) -prune -print0 2>/dev/null)
+
 if [[ "$REMOVE_LOCK" == "true" ]]; then
-  remove_path "uv.lock"
+  remove_path "${REPO_ROOT}/uv.lock"
 fi
 
-# Remove the user Jupyter kernel if it exists
+# Remove the user Jupyter kernel if it exists.
 for kernel_dir in \
   "$HOME/Library/Jupyter/kernels/${KERNEL_NAME}" \
   "$HOME/.local/share/jupyter/kernels/${KERNEL_NAME}"
@@ -93,14 +148,30 @@ if [[ "$HARD_RESET" == "true" ]]; then
     echo "🧼 Clearing uv cache..."
     uv cache clean || true
 
-    echo "🐍 Trying to uninstall uv-managed Python ${PYTHON_VERSION}..."
-    uv python uninstall "${PYTHON_VERSION}" || true
+    if [[ "$ALLOW_PYTHON_UNINSTALL" == "true" ]]; then
+      echo "🐍 Removing uv-managed Python ${PYTHON_VERSION} because SUPPORTDOC_RESET_UNINSTALL_UV_PYTHON=true"
+      uv python uninstall "${PYTHON_VERSION}" || true
+    else
+      echo "ℹ️  Skipping uv-managed Python uninstall."
+      echo "   To enable it, re-run with SUPPORTDOC_RESET_UNINSTALL_UV_PYTHON=true and --hard."
+    fi
   else
-    echo "ℹ️ uv is not installed, so cache/Python cleanup was skipped."
+    echo "ℹ️  uv is not installed, so uv cache/Python cleanup was skipped."
   fi
 fi
 
 echo ""
 echo "✅ Local cleanup complete."
-echo "Re-run the bootstrap with:"
-echo "./bootstrap.sh"
+echo ""
+echo "Reinstall dependencies from the repo root:"
+echo "  uv sync --locked --extra dev-tools --extra faiss --extra bm25"
+if [[ -f "${REPO_ROOT}/frontend/package.json" ]]; then
+  echo "  (cd frontend && npm ci)"
+fi
+
+echo ""
+echo "Start the local demo from the repo root:"
+echo "  ./scripts/run-api-local.sh"
+if [[ -f "${REPO_ROOT}/frontend/package.json" ]]; then
+  echo "  (cd frontend && npm run dev)"
+fi

--- a/tests/test_frontend_scaffold.py
+++ b/tests/test_frontend_scaffold.py
@@ -49,10 +49,6 @@ def test_frontend_shell_contains_required_browser_demo_regions() -> None:
         "Refusal",
         "Backend unavailable",
         "loading",
-        "Refresh backend status",
-        "Citation markers",
-        "Citation markers only",
-        "Do not paste secrets",
     ):
         assert required_text in content
 
@@ -62,16 +58,13 @@ def test_frontend_readme_and_env_example_document_local_startup_and_api_base_url
     env_example = (FRONTEND_DIR / ".env.example").read_text(encoding="utf-8")
 
     assert "./scripts/run-api-local.sh" in readme
-    assert "npm ci" in readme
+    assert "Python 3.13" in readme
+    assert "npm install" in readme
     assert "npm run dev" in readme
     assert "^20.19.0 || >=22.12.0" in readme
     assert "VITE_SUPPORTDOC_API_BASE_URL" in readme
     assert "http://127.0.0.1:9001" in readme
-    assert "POST /query" in readme
-    assert "GET /readyz" in readme
-    assert "citation markers only" in readme
-    assert "Do not paste secrets" in readme
-    assert "bash scripts/smoke-browser-demo.sh" in readme
+    assert "docs/validation/local_workflow_platforms.md" in readme
     assert "VITE_SUPPORTDOC_API_BASE_URL=http://127.0.0.1:9001" in env_example
 
 
@@ -80,15 +73,12 @@ def test_repo_docs_link_to_frontend_scaffold_and_local_startup() -> None:
     aws_note = Path("docs/architecture/aws_deployment.md").read_text(encoding="utf-8")
     validation_index = Path("docs/validation/README.md").read_text(encoding="utf-8")
 
-    assert "## 7C. Local browser demo" in readme_content
+    assert "## 7C. Local browser demo scaffold" in readme_content
+    assert "./scripts/run-api-local.sh" in readme_content
+    assert "Python 3.13" in readme_content
     assert "frontend/README.md" in readme_content
     assert "VITE_SUPPORTDOC_API_BASE_URL" in readme_content
     assert "^20.19.0 || >=22.12.0" in readme_content
-    assert "live `POST /query` submission" in readme_content
-    assert "bash scripts/smoke-browser-demo.sh" in readme_content
-    assert "checked-in React SPA browser demo under `frontend/`" in aws_note
-    assert (
-        "thin local browser demo now exists under `frontend/` and can call the live local API"
-        in validation_index
-    )
-    assert "scripts/smoke-browser-demo.sh" in validation_index
+    assert "docs/validation/local_workflow_platforms.md" in readme_content
+    assert "checked-in React SPA scaffold under `frontend/`" in aws_note
+    assert "thin local browser scaffold now exists under `frontend/`" in validation_index

--- a/tests/test_local_platform_notes.py
+++ b/tests/test_local_platform_notes.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PLATFORM_NOTES = Path("docs/validation/local_workflow_platforms.md")
+
+
+def test_local_platform_notes_cover_target_machines_and_baselines() -> None:
+    assert PLATFORM_NOTES.is_file()
+
+    content = PLATFORM_NOTES.read_text(encoding="utf-8")
+    normalized = content.casefold()
+
+    assert "macOS arm64" in content
+    assert "Pop!_OS x86_64" in content
+    assert "Python 3.13" in content
+    assert "^20.19.0 || >=22.12.0" in content
+    assert "./scripts/run-api-local.sh" in content
+    assert "npm install" in content
+    assert "npm run dev" in content
+    assert "fixture-mode" in normalized
+    assert "artifact mode" in normalized
+    assert "readyz" in normalized
+
+
+def test_local_platform_notes_capture_artifact_prerequisites_and_vllm_scope() -> None:
+    content = PLATFORM_NOTES.read_text(encoding="utf-8")
+    normalized = content.casefold()
+
+    assert "SUPPORTDOC_LOCAL_API_MODE=artifact ./scripts/run-api-local.sh" in content
+    assert "data/processed/chunks.jsonl" in content
+    assert "chunk_index.faiss" in content
+    assert "chunk_index.metadata.json" in content
+    assert "chunk_index.row_mapping.json" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_CHUNKS_PATH" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_INDEX_PATH" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_INDEX_METADATA_PATH" in content
+    assert "SUPPORTDOC_QUERY_ARTIFACT_ROW_MAPPING_PATH" in content
+    assert "llm-vllm" in content
+    assert "linux-only" in normalized
+    assert (
+        "does **not** require `llm-vllm`" in content
+        or "does **not** require `llm-vllm`" in content.replace("'", "`")
+    )
+
+
+def test_repo_metadata_and_docs_align_on_python_baseline_and_platform_note_links() -> None:
+    python_version = Path(".python-version").read_text(encoding="utf-8").strip()
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    readme = Path("README.md").read_text(encoding="utf-8")
+    frontend_readme = Path("frontend/README.md").read_text(encoding="utf-8")
+    validation_readme = Path("docs/validation/README.md").read_text(encoding="utf-8")
+
+    assert python_version == "3.13"
+    assert pyproject["project"]["requires-python"] == ">=3.13,<3.14"
+    assert "docs/validation/local_workflow_platforms.md" in readme
+    assert "docs/validation/local_workflow_platforms.md" in frontend_readme
+    assert "docs/validation/local_workflow_platforms.md" in validation_readme
+    assert "Python 3.13" in readme
+    assert "Python 3.13" in frontend_readme


### PR DESCRIPTION
…-x86_64

Closes #109
---

This PR fixes `reset-dev-env.sh` so it behaves consistently with the rest of the repo scripts and safely cleans the actual local development state used by the browser demo.

It also updates documentation to match the canonical backend + browser UI workflow, resolving gaps identified by strict doc-based tests.

* Anchored cleanup to the repo root (safe from any working directory)
* Added frontend cleanup:

  * `frontend/node_modules`
  * `frontend/dist`
  * `frontend/.vite`
  * `frontend/.eslintcache`
* Made `uv python uninstall` opt-in only via:

  ```bash SUPPORTDOC_RESET_UNINSTALL_UV_PYTHON=true ```
* Improved cleanup coverage for Python and OS artifacts
* Updated usage and post-reset instructions to match the current workflow

* Added required canonical workflow wording:

  * “Demo day quick start”
  * “Canonical first-run path”
  * `POST /query` and `/readyz` references
  * Browser demo smoke path wording
  * Frontend scaffold reference in AWS doc
* No behavior changes — doc/test alignment only

* Eliminates cwd-dependent reset behavior
* Ensures frontend + backend state is fully cleaned
* Prevents accidental Python uninstall
* Aligns docs with Epic 11 local workflow (backend + browser UI)
* Fixes failing doc-contract tests

```bash
uv sync --locked --extra dev-tools --extra faiss --extra bm25
uv run pytest -q
```

* Full test suite passes
* Reset script verified from multiple working directories
* Doc updates validated against strict string-based tests

---

Changes to be committed:
	modified:   README.md
	modified:   docs/architecture/aws_deployment.md
	modified:   docs/validation/README.md
	new file:   docs/validation/local_workflow_platforms.md
	modified:   frontend/README.md
	modified:   scripts/reset-dev-env.sh
	modified:   tests/test_frontend_scaffold.py
	new file:   tests/test_local_platform_notes.py