### PR TITLE
On branch infra/122-provisionthe-AWS-foundation-for-the-MVP-environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,8 @@ The deploy-now AWS slice is still the backend shell on ECS/ALB in fixture mode. 
 
 The canonical AWS deployment baseline for that path now lives in `docs/architecture/aws_deployment.md`, with the rendered diagram in `docs/diagrams/aws_deployment.md` and the versioned Mermaid source in `docs/diagrams/aws_deployment.mmd`.
 
+The concrete EPIC 12 / Task 1 implementation now lives under `infra/aws/task1-foundation/`, with the repo-aligned operator contract in `docs/ops/aws_task1_foundation.md` and the verification helper in `scripts/verify-aws-task1.sh`.
+
 For copy-ready report wording on the baseline no-fine-tuning answer, the snapshot -> parse -> chunk -> embed -> index preparation flow, and the UI/AWS handoff boundary, use `docs/validation/report_and_aws_handoff_notes.md`.
 
 ---
@@ -694,6 +696,8 @@ For copy-ready report wording on the baseline no-fine-tuning answer, the snapsho
 - `docs/diagrams/ingestion_pipeline.md` — ingestion pipeline overview
 - `docs/validation/README.md` — validation entry point for fixture smoke, artifact smoke, container runtime smoke, cloud runtime smoke, and reviewed trust artifacts
 - `docs/architecture/aws_deployment.md` — canonical AWS deployment baseline, deploy-now scope, and deferred options
+- `infra/aws/task1-foundation/` — Terraform stack for the EPIC 12 / Task 1 AWS foundation and HTTPS entry point
+- `docs/ops/aws_task1_foundation.md` — repo-aligned Task 1 env/secret contract and naming decisions
 - `docs/diagrams/aws_deployment.md` — AWS deployment diagram
 - `docs/adr/` — architecture decisions and project rationale
 - `docs/process/hybrid_retrieval_baseline.md` — default hybrid baseline config and run command

--- a/docs/architecture/aws_deployment.md
+++ b/docs/architecture/aws_deployment.md
@@ -11,6 +11,8 @@ The baseline is intentionally opinionated so later infra work can build against 
 
 Companion cost and operations notes for the same baseline live in `docs/ops/cost_and_ops.md`.
 
+The concrete EPIC 12 / Task 1 implementation now lives under `infra/aws/task1-foundation/`, with the repo-aligned operator contract documented in `docs/ops/aws_task1_foundation.md`.
+
 The runtime / trust validation entry point for this same API-first MVP lives in `docs/validation/README.md`.
 
 Report-facing UI wording and the later browser-to-AWS handoff notes live in `docs/validation/report_and_aws_handoff_notes.md`.

--- a/docs/ops/aws_task1_foundation.md
+++ b/docs/ops/aws_task1_foundation.md
@@ -1,0 +1,114 @@
+# AWS Task 1 foundation decisions and runtime contract
+
+This note is the operator-facing companion to `infra/aws/task1-foundation/`.
+
+It translates the repo's actual backend/frontend config surface into the exact AWS foundation choices needed for **EPIC 12 / Task 1**.
+
+## Selected MVP defaults
+
+The Task 1 implementation locks these defaults unless a later task proves they must change:
+
+- **AWS region:** `us-east-1`
+- **environment name:** `mvp`
+- **resource naming prefix:** `supportdoc-rag-chatbot-mvp`
+- **backend API domain pattern:** `api.supportdoc-mvp.<root_domain_name>`
+- **ECR repository:** `supportdoc-rag-chatbot/mvp/backend`
+- **S3 bucket pattern:** `supportdoc-rag-chatbot-mvp-<account-id>-us-east-1-artifacts`
+- **SSM path prefix:** `/supportdoc-rag-chatbot/mvp`
+- **Secrets Manager name prefix:** `supportdoc-rag-chatbot/mvp`
+- **backend log group:** `/aws/supportdoc-rag-chatbot/mvp/backend`
+- **inference log group:** `/aws/supportdoc-rag-chatbot/mvp/inference`
+
+## Network layout
+
+The Terraform stack creates one shared VPC with three subnet tiers across two Availability Zones:
+
+- **public subnets** — ALB only
+- **private app subnets** — ECS tasks and the private inference host
+- **private data subnets** — RDS PostgreSQL
+
+### Route intent
+
+- public subnets route `0.0.0.0/0` to the internet gateway
+- private app subnets route `0.0.0.0/0` to a single NAT gateway for the MVP
+- private data subnets stay private and do not get a direct internet route
+
+That layout keeps the public HTTPS edge on the ALB, gives ECS and inference an outbound path for image/model downloads, and avoids public database exposure.
+
+## Security groups
+
+Task 1 pins the inbound traffic chain to:
+
+- **ALB SG** — public ingress on `80` and `443`
+- **ECS SG** — backend port `9001` from the ALB SG only
+- **RDS SG** — PostgreSQL `5432` from the ECS SG only
+- **inference SG** — inference port `8000` from the ECS SG only
+
+## Repo-aligned runtime contract
+
+The current repo already defines the backend AWS-mode contract and the thin frontend seam.
+
+### Non-secret backend values
+
+Store these in **ECS environment variables** or **SSM Parameter Store** under `/supportdoc-rag-chatbot/mvp/backend/`:
+
+| Env var | Recommended value for the AWS MVP | Notes |
+| --- | --- | --- |
+| `SUPPORTDOC_DEPLOYMENT_TARGET` | `aws` | Required by the backend when the service runs in AWS mode. |
+| `SUPPORTDOC_ENV` | `mvp` | Returned through `/readyz` and used in ops labeling. |
+| `SUPPORTDOC_API_CORS_ALLOWED_ORIGINS` | set during Task 4/5 | Must include the real Amplify frontend origin before browser cutover. |
+| `SUPPORTDOC_API_CORS_ALLOWED_ORIGIN_REGEX` | optional alternative | Use only if the frontend origin cannot be pinned to an exact allowlist. |
+| `SUPPORTDOC_QUERY_RETRIEVAL_MODE` | `pgvector` | Final deployed retrieval path required by the EPIC. |
+| `SUPPORTDOC_QUERY_PGVECTOR_SCHEMA_NAME` | `supportdoc_rag` | Matches the repo default. |
+| `SUPPORTDOC_QUERY_PGVECTOR_RUNTIME_ID` | `default` | Matches the repo default. |
+| `SUPPORTDOC_QUERY_PGVECTOR_EMBEDDER_MODE` | `local` | Keeps query-time embeddings in-container on ECS. |
+| `SUPPORTDOC_QUERY_PGVECTOR_EMBEDDER_FIXTURE_PATH` | set only for deterministic smoke tests | Do not use in the normal MVP runtime. |
+| `SUPPORTDOC_QUERY_GENERATION_MODE` | `openai_compatible` | Final deployed generation path required by the EPIC. |
+| `SUPPORTDOC_QUERY_GENERATION_BASE_URL` | private inference base URL | Non-secret internal service location; set in Task 3/4. Do not include `/v1/chat/completions` in the base URL. |
+| `SUPPORTDOC_QUERY_GENERATION_MODEL` | `mistralai/Mistral-7B-Instruct-v0.3` by default | Change only if Task 0 chooses a different inference model identifier. |
+| `SUPPORTDOC_QUERY_GENERATION_TIMEOUT_SECONDS` | tune later | Not required for Task 1, but remains a non-secret runtime control. |
+| `SUPPORTDOC_QUERY_TOP_K` | tune later | Non-secret retrieval tuning; leave default unless evaluation changes it. |
+
+### Secret backend values
+
+Store these in **AWS Secrets Manager**:
+
+| Env var / secret purpose | Secret name |
+| --- | --- |
+| RDS master credentials | `supportdoc-rag-chatbot/mvp/database/master-credentials` |
+| `SUPPORTDOC_QUERY_PGVECTOR_DSN` | `supportdoc-rag-chatbot/mvp/backend/query-pgvector-dsn` |
+| `SUPPORTDOC_QUERY_GENERATION_API_KEY` | `supportdoc-rag-chatbot/mvp/backend/query-generation-api-key` |
+
+The Terraform stack creates those **secret resources as named placeholders** so later tasks can populate values without renaming anything.
+
+### Browser-visible value
+
+Only one public browser config seam should reach Amplify:
+
+| Variable | Where it lives | Purpose |
+| --- | --- | --- |
+| `VITE_SUPPORTDOC_API_BASE_URL` | Amplify environment variables | Points the React SPA at the public HTTPS backend origin. |
+
+Do not put database credentials, inference keys, retrieval paths, or other backend-only runtime values into the browser environment.
+
+## Task 1 outputs that matter later
+
+Carry these outputs into the later deployment tasks:
+
+- `backend_base_url`
+- `backend_target_group_arn`
+- `security_group_ids`
+- `artifact_bucket_name`
+- `ecr_repository_url`
+- `ssm_parameter_prefix`
+- `secret_names`
+
+## What changed versus the earlier placeholder notes
+
+The repo previously carried AWS guidance as documentation only. Task 1 now adds:
+
+- a real Terraform foundation stack under `infra/aws/task1-foundation/`
+- a concrete region default of `us-east-1`
+- real reserved names for SSM parameters and Secrets Manager secrets
+- a concrete HTTPS ALB + ACM + Route 53 entry point
+- a verification script that checks the accepted public/private and exposure boundaries

--- a/docs/ops/cost_and_ops.md
+++ b/docs/ops/cost_and_ops.md
@@ -12,6 +12,8 @@ These notes are intentionally directional rather than price-quote accurate. They
 
 This note matches the current baseline defined in `docs/architecture/aws_deployment.md`:
 
+The concrete Task 1 implementation and its exact env/secret naming contract live in `infra/aws/task1-foundation/` and `docs/ops/aws_task1_foundation.md`.
+
 - **API hosting:** ECS Fargate behind an ALB
 - **Inference hosting:** one private EC2 GPU instance
 - **Vector store / retrieval backend:** RDS PostgreSQL with `pgvector`
@@ -20,7 +22,7 @@ This note matches the current baseline defined in `docs/architecture/aws_deploym
 - **Secrets / config:** Secrets Manager plus SSM Parameter Store
 - **Browser hosting:** Amplify Hosting for the checked-in SPA when the separate browser-hosting slice is enabled
 
-The working assumption for planning is one U.S. commercial AWS region, using **`us-west-2` as the default placeholder region** until the final deployment region is explicitly chosen.
+The working assumption for planning is one U.S. commercial AWS region, now pinned to **`us-east-1` for the MVP foundation** so the networking, HTTPS edge, and runtime config naming stay consistent across later tasks.
 
 ## Operating modes
 

--- a/infra/aws/task1-foundation/README.md
+++ b/infra/aws/task1-foundation/README.md
@@ -1,0 +1,116 @@
+# EPIC 12 / Task 1 — AWS foundation + HTTPS entry points
+
+This Terraform stack implements the **Task 1** baseline for the SupportDoc RAG Chatbot MVP using the actual runtime contract present in the repo.
+
+## What it creates
+
+- one target region: `us-east-1` by default
+- one environment name: `mvp` by default
+- one shared naming convention based on `supportdoc-rag-chatbot-mvp`
+- one VPC with:
+  - **public subnets** for the internet-facing ALB
+  - **private app subnets** for ECS tasks and the private inference host
+  - **private data subnets** for RDS
+- security groups that enforce:
+  - public ALB ingress
+  - ECS ingress from the ALB only
+  - RDS ingress from ECS only
+  - inference ingress from ECS only
+- one private ECR repository for the backend image
+- one versioned S3 artifacts bucket with seeded prefixes:
+  - `corpus/`
+  - `processed/`
+  - `evaluation/outputs/`
+  - `deployment/`
+- two CloudWatch log groups:
+  - backend
+  - inference
+- one SSM Parameter Store prefix with repo-aligned non-secret runtime defaults
+- one Secrets Manager naming scheme with placeholder secret resources for:
+  - database master credentials
+  - `SUPPORTDOC_QUERY_PGVECTOR_DSN`
+  - `SUPPORTDOC_QUERY_GENERATION_API_KEY`
+- one public ALB with:
+  - HTTP -> HTTPS redirect
+  - ACM certificate
+  - HTTPS listener
+  - Route 53 alias record
+  - backend target group pinned to `/healthz`
+
+## Locked defaults
+
+These defaults are baked into this stack to keep the MVP path opinionated and fast:
+
+- **region:** `us-east-1`
+- **environment:** `mvp`
+- **backend API subdomain pattern:** `api.supportdoc-mvp.<root_domain_name>`
+- **pgvector schema name:** `supportdoc_rag`
+- **pgvector runtime id:** `default`
+- **generation mode target:** OpenAI-compatible
+- **default model identifier:** `mistralai/Mistral-7B-Instruct-v0.3`
+
+## Prerequisites
+
+- Terraform `>= 1.6`
+- AWS credentials with permission to create the listed resources
+- an existing **public Route 53 hosted zone**
+- a real root domain name you control, for example `example.com`
+
+## Deploy
+
+```bash
+cd infra/aws/task1-foundation
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars so root_domain_name points to a real Route 53 zone you own
+terraform init
+terraform plan
+terraform apply
+```
+
+## What this stack intentionally does *not* create yet
+
+Task 1 stops at the shared foundation and HTTPS entry points. The following remain for later tasks:
+
+- ECS cluster, service, task definition, and IAM roles
+- RDS instance and database creation
+- inference EC2 host
+- population of actual secret values
+- promotion of the runtime dataset into PostgreSQL
+- Amplify Hosting
+
+## Outputs you will use later
+
+After `terraform apply`, capture these outputs because later tasks depend on them:
+
+- `backend_base_url`
+- `backend_target_group_arn`
+- `ecr_repository_url`
+- `artifact_bucket_name`
+- `security_group_ids`
+- `public_subnet_ids`
+- `app_private_subnet_ids`
+- `data_private_subnet_ids`
+- `ssm_parameter_prefix`
+- `secret_names`
+
+## Runtime contract
+
+The exact repo-aligned env var and secret split is documented in:
+
+- `docs/ops/aws_task1_foundation.md`
+
+## Verification
+
+Run the companion validation script after apply:
+
+```bash
+bash scripts/verify-aws-task1.sh --terraform-dir infra/aws/task1-foundation
+```
+
+The script checks:
+
+- ECR repository presence
+- S3 write access
+- subnet and route-table public/private split
+- security-group exposure rules
+- HTTPS resolution for the backend API domain

--- a/infra/aws/task1-foundation/main.tf
+++ b/infra/aws/task1-foundation/main.tf
@@ -1,0 +1,568 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  root_domain_name         = trimsuffix(var.root_domain_name, ".")
+  backend_api_domain       = "${var.backend_api_subdomain}.${local.root_domain_name}"
+  name_prefix              = "${var.project}-${var.environment}"
+  ecr_repository_name      = "${var.project}/${var.environment}/backend"
+  s3_bucket_name           = lower("${var.project}-${var.environment}-${data.aws_caller_identity.current.account_id}-${var.aws_region}-artifacts")
+  ssm_parameter_prefix     = "/${var.project}/${var.environment}"
+  secrets_prefix           = "${var.project}/${var.environment}"
+  backend_log_group_name   = "/aws/${var.project}/${var.environment}/backend"
+  inference_log_group_name = "/aws/${var.project}/${var.environment}/inference"
+
+  public_subnet_map = {
+    for index, cidr in var.public_subnet_cidrs :
+    "public-${index + 1}" => {
+      cidr = cidr
+      az   = data.aws_availability_zones.available.names[index]
+    }
+  }
+
+  app_private_subnet_map = {
+    for index, cidr in var.app_private_subnet_cidrs :
+    "app-private-${index + 1}" => {
+      cidr = cidr
+      az   = data.aws_availability_zones.available.names[index]
+    }
+  }
+
+  data_private_subnet_map = {
+    for index, cidr in var.data_private_subnet_cidrs :
+    "data-private-${index + 1}" => {
+      cidr = cidr
+      az   = data.aws_availability_zones.available.names[index]
+    }
+  }
+
+  parameter_seed_values = {
+    SUPPORTDOC_DEPLOYMENT_TARGET            = "aws"
+    SUPPORTDOC_ENV                          = var.environment
+    SUPPORTDOC_QUERY_RETRIEVAL_MODE         = "pgvector"
+    SUPPORTDOC_QUERY_PGVECTOR_SCHEMA_NAME   = var.pgvector_schema_name
+    SUPPORTDOC_QUERY_PGVECTOR_RUNTIME_ID    = var.pgvector_runtime_id
+    SUPPORTDOC_QUERY_PGVECTOR_EMBEDDER_MODE = var.pgvector_embedder_mode
+    SUPPORTDOC_QUERY_GENERATION_MODE        = "openai_compatible"
+    SUPPORTDOC_QUERY_GENERATION_MODEL       = var.inference_model_id
+  }
+
+  common_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Epic        = "EPIC-12"
+      Task        = "task1-foundation"
+    },
+    var.tags,
+  )
+}
+
+data "aws_route53_zone" "public" {
+  name         = "${local.root_domain_name}."
+  private_zone = false
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = local.public_subnet_map
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name        = "${local.name_prefix}-${each.key}"
+    NetworkTier = "public"
+  })
+}
+
+resource "aws_subnet" "app_private" {
+  for_each = local.app_private_subnet_map
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = false
+
+  tags = merge(local.common_tags, {
+    Name        = "${local.name_prefix}-${each.key}"
+    NetworkTier = "private-app"
+  })
+}
+
+resource "aws_subnet" "data_private" {
+  for_each = local.data_private_subnet_map
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = false
+
+  tags = merge(local.common_tags, {
+    Name        = "${local.name_prefix}-${each.key}"
+    NetworkTier = "private-data"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-nat-eip"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = values(aws_subnet.public)[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "app_private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-app-private-rt"
+  })
+}
+
+resource "aws_route" "app_private_default" {
+  route_table_id         = aws_route_table.app_private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this.id
+}
+
+resource "aws_route_table_association" "app_private" {
+  for_each = aws_subnet.app_private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.app_private.id
+}
+
+resource "aws_route_table" "data_private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-data-private-rt"
+  })
+}
+
+resource "aws_route_table_association" "data_private" {
+  for_each = aws_subnet.data_private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.data_private.id
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb-sg"
+  description = "Public ingress for the SupportDoc MVP Application Load Balancer."
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description      = "Public HTTP redirect entrypoint"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Public HTTPS entrypoint"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    description      = "Outbound to backend targets and health checks"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-alb-sg"
+  })
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${local.name_prefix}-ecs-sg"
+  description = "Backend ECS tasks only accept traffic from the ALB."
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "Backend traffic from the public ALB"
+    from_port       = var.backend_container_port
+    to_port         = var.backend_container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description      = "Allow outbound calls to RDS, inference, ECR, S3, and model downloads"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-ecs-sg"
+  })
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${local.name_prefix}-rds-sg"
+  description = "Private PostgreSQL ingress only from ECS."
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "PostgreSQL from ECS tasks only"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    description      = "Default egress for managed database operations"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-rds-sg"
+  })
+}
+
+resource "aws_security_group" "inference" {
+  name        = "${local.name_prefix}-inference-sg"
+  description = "Private OpenAI-compatible inference ingress only from ECS."
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "Inference traffic from ECS tasks only"
+    from_port       = var.inference_port
+    to_port         = var.inference_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    description      = "Outbound for package, model, and patch downloads"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-inference-sg"
+  })
+}
+
+resource "aws_ecr_repository" "backend" {
+  name                 = local.ecr_repository_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-ecr"
+  })
+}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket        = local.s3_bucket_name
+  force_destroy = var.s3_force_destroy
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-artifacts"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_object" "artifact_prefixes" {
+  for_each = toset([
+    "corpus/",
+    "processed/",
+    "evaluation/outputs/",
+    "deployment/",
+  ])
+
+  bucket  = aws_s3_bucket.artifacts.id
+  key     = each.value
+  content = ""
+}
+
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = local.backend_log_group_name
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-log-group"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "inference" {
+  name              = local.inference_log_group_name
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-inference-log-group"
+  })
+}
+
+resource "aws_ssm_parameter" "backend_non_secret" {
+  for_each = local.parameter_seed_values
+
+  name  = "${local.ssm_parameter_prefix}/backend/${each.key}"
+  type  = "String"
+  value = each.value
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-${lower(replace(each.key, "_", "-"))}-parameter"
+  })
+}
+
+resource "aws_secretsmanager_secret" "rds_master_credentials" {
+  name        = "${local.secrets_prefix}/database/master-credentials"
+  description = "Placeholder secret for the RDS PostgreSQL master credentials created in Task 2."
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-database-master-secret"
+  })
+}
+
+resource "aws_secretsmanager_secret" "backend_query_pgvector_dsn" {
+  name        = "${local.secrets_prefix}/backend/query-pgvector-dsn"
+  description = "Placeholder secret for SUPPORTDOC_QUERY_PGVECTOR_DSN."
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-pgvector-dsn-secret"
+  })
+}
+
+resource "aws_secretsmanager_secret" "backend_query_generation_api_key" {
+  name        = "${local.secrets_prefix}/backend/query-generation-api-key"
+  description = "Placeholder secret for SUPPORTDOC_QUERY_GENERATION_API_KEY when the inference endpoint requires authentication."
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-generation-api-key-secret"
+  })
+}
+
+resource "aws_lb" "public" {
+  name               = substr(replace("${local.name_prefix}-alb", "-", ""), 0, 32)
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = values(aws_subnet.public)[*].id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = substr(replace("${local.name_prefix}-api", "-", ""), 0, 32)
+  port        = var.backend_container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.this.id
+
+  health_check {
+    enabled             = true
+    path                = "/healthz"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+    timeout             = 5
+    matcher             = "200-399"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-tg"
+  })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.public.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_acm_certificate" "backend" {
+  domain_name       = local.backend_api_domain
+  validation_method = "DNS"
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-acm"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "backend_validation" {
+  for_each = {
+    for option in aws_acm_certificate.backend.domain_validation_options :
+    option.domain_name => {
+      name   = option.resource_record_name
+      type   = option.resource_record_type
+      record = option.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.public.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  ttl             = 60
+  records         = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "backend" {
+  certificate_arn         = aws_acm_certificate.backend.arn
+  validation_record_fqdns = values(aws_route53_record.backend_validation)[*].fqdn
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.public.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.backend.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+resource "aws_route53_record" "backend_alias_a" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = local.backend_api_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.public.dns_name
+    zone_id                = aws_lb.public.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "backend_alias_aaaa" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = local.backend_api_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_lb.public.dns_name
+    zone_id                = aws_lb.public.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/aws/task1-foundation/outputs.tf
+++ b/infra/aws/task1-foundation/outputs.tf
@@ -1,0 +1,130 @@
+output "aws_region" {
+  description = "Selected AWS region for the MVP foundation."
+  value       = var.aws_region
+}
+
+output "environment" {
+  description = "Single deployed environment name."
+  value       = var.environment
+}
+
+output "name_prefix" {
+  description = "Shared resource naming prefix."
+  value       = local.name_prefix
+}
+
+output "backend_api_domain" {
+  description = "Public HTTPS backend domain fronting the ALB."
+  value       = local.backend_api_domain
+}
+
+output "backend_base_url" {
+  description = "Public HTTPS backend base URL."
+  value       = "https://${local.backend_api_domain}"
+}
+
+output "vpc_id" {
+  description = "Shared MVP VPC identifier."
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs for the ALB."
+  value       = values(aws_subnet.public)[*].id
+}
+
+output "app_private_subnet_ids" {
+  description = "Private app subnet IDs for ECS tasks and the inference host."
+  value       = values(aws_subnet.app_private)[*].id
+}
+
+output "data_private_subnet_ids" {
+  description = "Private data subnet IDs for RDS."
+  value       = values(aws_subnet.data_private)[*].id
+}
+
+output "route_table_ids" {
+  description = "Route tables used by the public, app-private, and data-private subnet tiers."
+  value = {
+    public       = aws_route_table.public.id
+    app_private  = aws_route_table.app_private.id
+    data_private = aws_route_table.data_private.id
+  }
+}
+
+output "security_group_ids" {
+  description = "Security groups that enforce ALB -> ECS -> RDS/inference traffic."
+  value = {
+    alb       = aws_security_group.alb.id
+    ecs       = aws_security_group.ecs.id
+    rds       = aws_security_group.rds.id
+    inference = aws_security_group.inference.id
+  }
+}
+
+output "ecr_repository_name" {
+  description = "Private ECR repository name for the backend image."
+  value       = aws_ecr_repository.backend.name
+}
+
+output "ecr_repository_url" {
+  description = "Private ECR repository URL for pushes."
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "artifact_bucket_name" {
+  description = "Artifacts bucket name."
+  value       = aws_s3_bucket.artifacts.bucket
+}
+
+output "artifact_prefixes" {
+  description = "Seeded S3 prefixes for corpus, processed data, deployment files, and evaluation outputs."
+  value       = sort([for object in aws_s3_object.artifact_prefixes : object.key])
+}
+
+output "cloudwatch_log_group_names" {
+  description = "CloudWatch log groups reserved for the backend and inference runtimes."
+  value = {
+    backend   = aws_cloudwatch_log_group.backend.name
+    inference = aws_cloudwatch_log_group.inference.name
+  }
+}
+
+output "ssm_parameter_prefix" {
+  description = "SSM Parameter Store path prefix for non-secret backend runtime configuration."
+  value       = local.ssm_parameter_prefix
+}
+
+output "ssm_parameter_names" {
+  description = "Seeded backend non-secret parameters aligned to the repo runtime contract."
+  value       = { for key, parameter in aws_ssm_parameter.backend_non_secret : key => parameter.name }
+}
+
+output "secret_names" {
+  description = "Secrets Manager names reserved for backend and database secrets."
+  value = {
+    database_master_credentials      = aws_secretsmanager_secret.rds_master_credentials.name
+    backend_query_pgvector_dsn       = aws_secretsmanager_secret.backend_query_pgvector_dsn.name
+    backend_query_generation_api_key = aws_secretsmanager_secret.backend_query_generation_api_key.name
+  }
+}
+
+output "alb_arn" {
+  description = "Application Load Balancer ARN."
+  value       = aws_lb.public.arn
+}
+
+output "alb_dns_name" {
+  description = "Public ALB DNS name."
+  value       = aws_lb.public.dns_name
+}
+
+output "https_listener_arn" {
+  description = "HTTPS listener ARN that fronts the backend target group."
+  value       = aws_lb_listener.https.arn
+}
+
+output "backend_target_group_arn" {
+  description = "Backend target group ARN reserved for the ECS service in Task 4."
+  value       = aws_lb_target_group.backend.arn
+}

--- a/infra/aws/task1-foundation/terraform.tfvars.example
+++ b/infra/aws/task1-foundation/terraform.tfvars.example
@@ -1,0 +1,19 @@
+aws_region            = "us-east-1"
+project               = "supportdoc-rag-chatbot"
+environment           = "mvp"
+root_domain_name      = "example.com"
+backend_api_subdomain = "api.supportdoc-mvp"
+
+# Keep the repo-aligned runtime defaults unless later tasks intentionally change them.
+inference_model_id     = "mistralai/Mistral-7B-Instruct-v0.3"
+pgvector_schema_name   = "supportdoc_rag"
+pgvector_runtime_id    = "default"
+pgvector_embedder_mode = "local"
+
+public_subnet_cidrs       = ["10.42.0.0/24", "10.42.1.0/24"]
+app_private_subnet_cidrs  = ["10.42.10.0/24", "10.42.11.0/24"]
+data_private_subnet_cidrs = ["10.42.20.0/24", "10.42.21.0/24"]
+
+tags = {
+  Owner = "supportdoc"
+}

--- a/infra/aws/task1-foundation/variables.tf
+++ b/infra/aws/task1-foundation/variables.tf
@@ -1,0 +1,126 @@
+variable "aws_region" {
+  description = "Target AWS region for the single MVP environment."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project" {
+  description = "Project slug used in names, tags, and parameter paths."
+  type        = string
+  default     = "supportdoc-rag-chatbot"
+}
+
+variable "environment" {
+  description = "Single deployed environment name for the MVP."
+  type        = string
+  default     = "mvp"
+}
+
+variable "root_domain_name" {
+  description = "Existing public Route 53 hosted-zone root used for the backend API record."
+  type        = string
+}
+
+variable "backend_api_subdomain" {
+  description = "Subdomain label prefix used to derive the public backend API FQDN."
+  type        = string
+  default     = "api.supportdoc-mvp"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the shared MVP VPC."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "Two public subnets for the internet-facing ALB."
+  type        = list(string)
+  default     = ["10.42.0.0/24", "10.42.1.0/24"]
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == 2
+    error_message = "Exactly two public subnet CIDRs are required."
+  }
+}
+
+variable "app_private_subnet_cidrs" {
+  description = "Two private app subnets for ECS tasks and the private inference host."
+  type        = list(string)
+  default     = ["10.42.10.0/24", "10.42.11.0/24"]
+
+  validation {
+    condition     = length(var.app_private_subnet_cidrs) == 2
+    error_message = "Exactly two app private subnet CIDRs are required."
+  }
+}
+
+variable "data_private_subnet_cidrs" {
+  description = "Two private data subnets for RDS."
+  type        = list(string)
+  default     = ["10.42.20.0/24", "10.42.21.0/24"]
+
+  validation {
+    condition     = length(var.data_private_subnet_cidrs) == 2
+    error_message = "Exactly two data private subnet CIDRs are required."
+  }
+}
+
+variable "backend_container_port" {
+  description = "Backend container port exposed to the ALB target group."
+  type        = number
+  default     = 9001
+}
+
+variable "inference_port" {
+  description = "Private OpenAI-compatible inference port that ECS will call."
+  type        = number
+  default     = 8000
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention used for backend and inference groups."
+  type        = number
+  default     = 14
+}
+
+variable "inference_model_id" {
+  description = "Default non-secret model identifier recorded in Parameter Store for the backend runtime."
+  type        = string
+  default     = "mistralai/Mistral-7B-Instruct-v0.3"
+}
+
+variable "pgvector_schema_name" {
+  description = "Canonical pgvector schema name aligned to the repo defaults."
+  type        = string
+  default     = "supportdoc_rag"
+}
+
+variable "pgvector_runtime_id" {
+  description = "Canonical pgvector runtime identifier aligned to the repo defaults."
+  type        = string
+  default     = "default"
+}
+
+variable "pgvector_embedder_mode" {
+  description = "Query embedder mode used by the AWS pgvector runtime."
+  type        = string
+  default     = "local"
+
+  validation {
+    condition     = contains(["local", "fixture"], var.pgvector_embedder_mode)
+    error_message = "pgvector_embedder_mode must be either local or fixture."
+  }
+}
+
+variable "s3_force_destroy" {
+  description = "Allow Terraform to delete the artifacts bucket even if it contains objects."
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags merged into all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/aws/task1-foundation/versions.tf
+++ b/infra/aws/task1-foundation/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/scripts/verify-aws-task1.sh
+++ b/scripts/verify-aws-task1.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TERRAFORM_DIR="infra/aws/task1-foundation"
+
+usage() {
+  cat <<'EOF_USAGE'
+Usage: bash scripts/verify-aws-task1.sh [--terraform-dir DIR]
+
+Verification order:
+1. resolve identifiers from environment variables or Terraform outputs
+2. verify the ECR repository exists
+3. verify the S3 bucket exists and is writable
+4. verify subnet tiers and route tables match the intended public/private split
+5. verify ECS / RDS / inference security groups are not publicly exposed
+6. verify the backend API domain resolves over HTTPS
+
+You can either:
+- run from the repo root after `terraform apply`, or
+- export the needed values manually if Terraform state is elsewhere
+
+Optional flags:
+  --terraform-dir DIR   Terraform module directory (default: infra/aws/task1-foundation)
+  -h, --help            Show this help text
+
+Environment overrides:
+  SUPPORTDOC_TASK1_AWS_REGION
+  SUPPORTDOC_TASK1_BACKEND_API_DOMAIN
+  SUPPORTDOC_TASK1_ECR_REPOSITORY_NAME
+  SUPPORTDOC_TASK1_S3_BUCKET_NAME
+  SUPPORTDOC_TASK1_ALB_SECURITY_GROUP_ID
+  SUPPORTDOC_TASK1_ECS_SECURITY_GROUP_ID
+  SUPPORTDOC_TASK1_RDS_SECURITY_GROUP_ID
+  SUPPORTDOC_TASK1_INFERENCE_SECURITY_GROUP_ID
+  SUPPORTDOC_TASK1_PUBLIC_ROUTE_TABLE_ID
+  SUPPORTDOC_TASK1_APP_PRIVATE_ROUTE_TABLE_ID
+  SUPPORTDOC_TASK1_DATA_PRIVATE_ROUTE_TABLE_ID
+  SUPPORTDOC_TASK1_PUBLIC_SUBNET_IDS        comma-separated
+  SUPPORTDOC_TASK1_APP_PRIVATE_SUBNET_IDS   comma-separated
+  SUPPORTDOC_TASK1_DATA_PRIVATE_SUBNET_IDS  comma-separated
+EOF_USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --terraform-dir)
+      TERRAFORM_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "Required command not found: $name" >&2
+    exit 1
+  fi
+}
+
+require_non_blank() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "${value// }" ]]; then
+    echo "Missing required value: ${name}" >&2
+    exit 1
+  fi
+}
+
+tf_raw() {
+  local output_name="$1"
+  if ! command -v terraform >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ ! -d "${TERRAFORM_DIR}" ]]; then
+    return 0
+  fi
+  terraform -chdir="${TERRAFORM_DIR}" output -raw "${output_name}" 2>/dev/null || true
+}
+
+csv_or_tf_list() {
+  local env_value="$1"
+  local tf_output_name="$2"
+  if [[ -n "${env_value// }" ]]; then
+    printf '%s' "${env_value}"
+    return 0
+  fi
+  if ! command -v terraform >/dev/null 2>&1 || [[ ! -d "${TERRAFORM_DIR}" ]]; then
+    return 0
+  fi
+  local json_payload
+  json_payload="$(terraform -chdir="${TERRAFORM_DIR}" output -json "${tf_output_name}" 2>/dev/null || true)"
+  if [[ -z "${json_payload// }" ]]; then
+    return 0
+  fi
+  JSON_PAYLOAD="${json_payload}" python - <<'PY'
+from __future__ import annotations
+import json
+import os
+payload = json.loads(os.environ["JSON_PAYLOAD"])
+if isinstance(payload, list):
+    print(",".join(str(item) for item in payload))
+PY
+}
+
+map_or_tf_field() {
+  local env_value="$1"
+  local tf_output_name="$2"
+  local field_name="$3"
+  if [[ -n "${env_value// }" ]]; then
+    printf '%s' "${env_value}"
+    return 0
+  fi
+  if ! command -v terraform >/dev/null 2>&1 || [[ ! -d "${TERRAFORM_DIR}" ]]; then
+    return 0
+  fi
+  local json_payload
+  json_payload="$(terraform -chdir="${TERRAFORM_DIR}" output -json "${tf_output_name}" 2>/dev/null || true)"
+  if [[ -z "${json_payload// }" ]]; then
+    return 0
+  fi
+  JSON_PAYLOAD="${json_payload}" FIELD_NAME="${field_name}" python - <<'PY'
+from __future__ import annotations
+import json
+import os
+payload = json.loads(os.environ["JSON_PAYLOAD"])
+field_name = os.environ["FIELD_NAME"]
+value = payload.get(field_name, "")
+if value is None:
+    value = ""
+print(value)
+PY
+}
+
+AWS_REGION="${SUPPORTDOC_TASK1_AWS_REGION:-$(tf_raw aws_region)}"
+BACKEND_API_DOMAIN="${SUPPORTDOC_TASK1_BACKEND_API_DOMAIN:-$(tf_raw backend_api_domain)}"
+ECR_REPOSITORY_NAME="${SUPPORTDOC_TASK1_ECR_REPOSITORY_NAME:-$(tf_raw ecr_repository_name)}"
+S3_BUCKET_NAME="${SUPPORTDOC_TASK1_S3_BUCKET_NAME:-$(tf_raw artifact_bucket_name)}"
+
+ALB_SECURITY_GROUP_ID="${SUPPORTDOC_TASK1_ALB_SECURITY_GROUP_ID:-$(map_or_tf_field "" security_group_ids alb)}"
+ECS_SECURITY_GROUP_ID="${SUPPORTDOC_TASK1_ECS_SECURITY_GROUP_ID:-$(map_or_tf_field "" security_group_ids ecs)}"
+RDS_SECURITY_GROUP_ID="${SUPPORTDOC_TASK1_RDS_SECURITY_GROUP_ID:-$(map_or_tf_field "" security_group_ids rds)}"
+INFERENCE_SECURITY_GROUP_ID="${SUPPORTDOC_TASK1_INFERENCE_SECURITY_GROUP_ID:-$(map_or_tf_field "" security_group_ids inference)}"
+
+PUBLIC_ROUTE_TABLE_ID="${SUPPORTDOC_TASK1_PUBLIC_ROUTE_TABLE_ID:-$(map_or_tf_field "" route_table_ids public)}"
+APP_PRIVATE_ROUTE_TABLE_ID="${SUPPORTDOC_TASK1_APP_PRIVATE_ROUTE_TABLE_ID:-$(map_or_tf_field "" route_table_ids app_private)}"
+DATA_PRIVATE_ROUTE_TABLE_ID="${SUPPORTDOC_TASK1_DATA_PRIVATE_ROUTE_TABLE_ID:-$(map_or_tf_field "" route_table_ids data_private)}"
+
+PUBLIC_SUBNET_IDS="$(csv_or_tf_list "${SUPPORTDOC_TASK1_PUBLIC_SUBNET_IDS:-}" public_subnet_ids)"
+APP_PRIVATE_SUBNET_IDS="$(csv_or_tf_list "${SUPPORTDOC_TASK1_APP_PRIVATE_SUBNET_IDS:-}" app_private_subnet_ids)"
+DATA_PRIVATE_SUBNET_IDS="$(csv_or_tf_list "${SUPPORTDOC_TASK1_DATA_PRIVATE_SUBNET_IDS:-}" data_private_subnet_ids)"
+
+require_command aws
+require_command curl
+require_command python
+
+require_non_blank "AWS region" "${AWS_REGION}"
+require_non_blank "backend API domain" "${BACKEND_API_DOMAIN}"
+require_non_blank "ECR repository name" "${ECR_REPOSITORY_NAME}"
+require_non_blank "S3 bucket name" "${S3_BUCKET_NAME}"
+require_non_blank "ALB security group id" "${ALB_SECURITY_GROUP_ID}"
+require_non_blank "ECS security group id" "${ECS_SECURITY_GROUP_ID}"
+require_non_blank "RDS security group id" "${RDS_SECURITY_GROUP_ID}"
+require_non_blank "inference security group id" "${INFERENCE_SECURITY_GROUP_ID}"
+require_non_blank "public route table id" "${PUBLIC_ROUTE_TABLE_ID}"
+require_non_blank "app private route table id" "${APP_PRIVATE_ROUTE_TABLE_ID}"
+require_non_blank "data private route table id" "${DATA_PRIVATE_ROUTE_TABLE_ID}"
+require_non_blank "public subnet ids" "${PUBLIC_SUBNET_IDS}"
+require_non_blank "app private subnet ids" "${APP_PRIVATE_SUBNET_IDS}"
+require_non_blank "data private subnet ids" "${DATA_PRIVATE_SUBNET_IDS}"
+
+echo "1/6 Verify the ECR repository exists"
+aws ecr describe-repositories \
+  --region "${AWS_REGION}" \
+  --repository-names "${ECR_REPOSITORY_NAME}" \
+  >/dev/null
+echo "   OK: ${ECR_REPOSITORY_NAME}"
+
+echo "2/6 Verify the S3 bucket exists and is writable"
+tmpfile="$(mktemp)"
+trap 'rm -f "${tmpfile}"' EXIT
+printf 'supportdoc-task1-smoke\n' > "${tmpfile}"
+smoke_key="deployment/task1-smoke-$(date +%s).txt"
+aws s3api put-object \
+  --region "${AWS_REGION}" \
+  --bucket "${S3_BUCKET_NAME}" \
+  --key "${smoke_key}" \
+  --body "${tmpfile}" \
+  >/dev/null
+aws s3api head-object \
+  --region "${AWS_REGION}" \
+  --bucket "${S3_BUCKET_NAME}" \
+  --key "${smoke_key}" \
+  >/dev/null
+aws s3api delete-object \
+  --region "${AWS_REGION}" \
+  --bucket "${S3_BUCKET_NAME}" \
+  --key "${smoke_key}" \
+  >/dev/null
+echo "   OK: s3://${S3_BUCKET_NAME}/${smoke_key}"
+
+echo "3/6 Verify subnet tiers and route tables"
+python - "${AWS_REGION}" "${PUBLIC_SUBNET_IDS}" "${APP_PRIVATE_SUBNET_IDS}" "${DATA_PRIVATE_SUBNET_IDS}" "${PUBLIC_ROUTE_TABLE_ID}" "${APP_PRIVATE_ROUTE_TABLE_ID}" "${DATA_PRIVATE_ROUTE_TABLE_ID}" <<'PY'
+from __future__ import annotations
+import json
+import subprocess
+import sys
+
+region, public_csv, app_csv, data_csv, public_rt, app_rt, data_rt = sys.argv[1:]
+public_subnets = [item for item in public_csv.split(",") if item]
+app_subnets = [item for item in app_csv.split(",") if item]
+data_subnets = [item for item in data_csv.split(",") if item]
+
+subnet_ids = public_subnets + app_subnets + data_subnets
+subnets_payload = subprocess.check_output(
+    ["aws", "ec2", "describe-subnets", "--region", region, "--subnet-ids", *subnet_ids],
+    text=True,
+)
+subnets = {item["SubnetId"]: item for item in json.loads(subnets_payload)["Subnets"]}
+
+for subnet_id in public_subnets:
+    if not subnets[subnet_id]["MapPublicIpOnLaunch"]:
+        raise SystemExit(f"Public subnet {subnet_id} does not map public IPs on launch.")
+for subnet_id in app_subnets + data_subnets:
+    if subnets[subnet_id]["MapPublicIpOnLaunch"]:
+        raise SystemExit(f"Private subnet {subnet_id} unexpectedly maps public IPs on launch.")
+
+route_tables_payload = subprocess.check_output(
+    ["aws", "ec2", "describe-route-tables", "--region", region, "--route-table-ids", public_rt, app_rt, data_rt],
+    text=True,
+)
+route_tables = {item["RouteTableId"]: item for item in json.loads(route_tables_payload)["RouteTables"]}
+
+def default_targets(route_table: dict) -> list[str]:
+    targets: list[str] = []
+    for route in route_table.get("Routes", []):
+        if route.get("DestinationCidrBlock") != "0.0.0.0/0":
+            continue
+        if route.get("GatewayId"):
+            targets.append(route["GatewayId"])
+        if route.get("NatGatewayId"):
+            targets.append(route["NatGatewayId"])
+    return targets
+
+public_targets = default_targets(route_tables[public_rt])
+if not any(target.startswith("igw-") for target in public_targets):
+    raise SystemExit("Public route table is missing a default route to an internet gateway.")
+
+app_targets = default_targets(route_tables[app_rt])
+if not any(target.startswith("nat-") for target in app_targets):
+    raise SystemExit("App private route table is missing a default route to a NAT gateway.")
+
+data_targets = default_targets(route_tables[data_rt])
+if any(target.startswith("igw-") for target in data_targets):
+    raise SystemExit("Data private route table must not have a default route to an internet gateway.")
+
+print("   OK: subnet map_public_ip flags and route-table targets match the intended split")
+PY
+
+echo "4/6 Verify security groups are not publicly exposed and follow ALB -> ECS -> RDS/inference"
+python - "${AWS_REGION}" "${ALB_SECURITY_GROUP_ID}" "${ECS_SECURITY_GROUP_ID}" "${RDS_SECURITY_GROUP_ID}" "${INFERENCE_SECURITY_GROUP_ID}" <<'PY'
+from __future__ import annotations
+import json
+import subprocess
+import sys
+
+region, alb_sg, ecs_sg, rds_sg, inference_sg = sys.argv[1:]
+payload = subprocess.check_output(
+    ["aws", "ec2", "describe-security-groups", "--region", region, "--group-ids", alb_sg, ecs_sg, rds_sg, inference_sg],
+    text=True,
+)
+groups = {item["GroupId"]: item for item in json.loads(payload)["SecurityGroups"]}
+
+def any_public_ingress(group: dict) -> bool:
+    for permission in group.get("IpPermissions", []):
+        for entry in permission.get("IpRanges", []):
+            if entry.get("CidrIp") == "0.0.0.0/0":
+                return True
+        for entry in permission.get("Ipv6Ranges", []):
+            if entry.get("CidrIpv6") == "::/0":
+                return True
+    return False
+
+if not any_public_ingress(groups[alb_sg]):
+    raise SystemExit("ALB security group is expected to be publicly reachable on the listener ports.")
+if any_public_ingress(groups[ecs_sg]):
+    raise SystemExit("ECS security group must not allow public ingress.")
+if any_public_ingress(groups[rds_sg]):
+    raise SystemExit("RDS security group must not allow public ingress.")
+if any_public_ingress(groups[inference_sg]):
+    raise SystemExit("Inference security group must not allow public ingress.")
+
+def allows_from(group: dict, expected_source_sg: str, expected_port: int) -> bool:
+    for permission in group.get("IpPermissions", []):
+        if permission.get("IpProtocol") != "tcp":
+            continue
+        if permission.get("FromPort") != expected_port or permission.get("ToPort") != expected_port:
+            continue
+        for pair in permission.get("UserIdGroupPairs", []):
+            if pair.get("GroupId") == expected_source_sg:
+                return True
+    return False
+
+if not allows_from(groups[ecs_sg], alb_sg, 9001):
+    raise SystemExit("ECS security group must allow port 9001 from the ALB security group.")
+if not allows_from(groups[rds_sg], ecs_sg, 5432):
+    raise SystemExit("RDS security group must allow port 5432 from the ECS security group.")
+if not allows_from(groups[inference_sg], ecs_sg, 8000):
+    raise SystemExit("Inference security group must allow port 8000 from the ECS security group.")
+
+print("   OK: exposure and source-security-group rules match the intended flow")
+PY
+
+echo "5/6 Verify the backend API domain resolves"
+python - "${BACKEND_API_DOMAIN}" <<'PY'
+from __future__ import annotations
+import socket
+import sys
+domain = sys.argv[1]
+answers = sorted({item[4][0] for item in socket.getaddrinfo(domain, 443, proto=socket.IPPROTO_TCP)})
+if not answers:
+    raise SystemExit(f"No DNS answers returned for {domain}")
+print("   OK: DNS answers -> " + ", ".join(answers))
+PY
+
+echo "6/6 Verify HTTPS responds at the backend API domain"
+http_code="$(curl -sS -o /dev/null -w '%{http_code}' "https://${BACKEND_API_DOMAIN}/" --max-time 20)"
+case "${http_code}" in
+  200|301|302|401|403|404|503)
+    echo "   OK: HTTPS responded with status ${http_code}"
+    ;;
+  *)
+    echo "Unexpected HTTPS status code from https://${BACKEND_API_DOMAIN}/: ${http_code}" >&2
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "Task 1 verification passed."

--- a/tests/test_aws_task1_foundation_assets.py
+++ b/tests/test_aws_task1_foundation_assets.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT_README = Path("README.md")
+TASK1_DOC = Path("docs/ops/aws_task1_foundation.md")
+TASK1_README = Path("infra/aws/task1-foundation/README.md")
+TASK1_MAIN_TF = Path("infra/aws/task1-foundation/main.tf")
+TASK1_VARIABLES_TF = Path("infra/aws/task1-foundation/variables.tf")
+TASK1_OUTPUTS_TF = Path("infra/aws/task1-foundation/outputs.tf")
+TASK1_TFVARS = Path("infra/aws/task1-foundation/terraform.tfvars.example")
+TASK1_VERIFY = Path("scripts/verify-aws-task1.sh")
+
+
+def test_task1_foundation_assets_exist() -> None:
+    for path in [
+        TASK1_DOC,
+        TASK1_README,
+        TASK1_MAIN_TF,
+        TASK1_VARIABLES_TF,
+        TASK1_OUTPUTS_TF,
+        TASK1_TFVARS,
+        TASK1_VERIFY,
+    ]:
+        assert path.exists(), f"Missing Task 1 foundation asset: {path}"
+
+
+def test_task1_docs_pin_repo_runtime_contract() -> None:
+    content = TASK1_DOC.read_text(encoding="utf-8")
+
+    assert "SUPPORTDOC_DEPLOYMENT_TARGET" in content
+    assert "SUPPORTDOC_QUERY_RETRIEVAL_MODE" in content
+    assert "SUPPORTDOC_QUERY_GENERATION_MODE" in content
+    assert "SUPPORTDOC_QUERY_PGVECTOR_DSN" in content
+    assert "SUPPORTDOC_QUERY_GENERATION_API_KEY" in content
+    assert "VITE_SUPPORTDOC_API_BASE_URL" in content
+    assert "supportdoc-rag-chatbot/mvp/backend" in content
+    assert "/supportdoc-rag-chatbot/mvp" in content
+
+
+def test_task1_terraform_covers_https_foundation_requirements() -> None:
+    content = TASK1_MAIN_TF.read_text(encoding="utf-8")
+
+    assert 'resource "aws_lb" "public"' in content
+    assert 'resource "aws_acm_certificate" "backend"' in content
+    assert 'resource "aws_route53_record" "backend_alias_a"' in content
+    assert 'resource "aws_ecr_repository" "backend"' in content
+    assert 'resource "aws_s3_bucket" "artifacts"' in content
+    assert 'resource "aws_cloudwatch_log_group" "backend"' in content
+    assert 'resource "aws_secretsmanager_secret" "backend_query_pgvector_dsn"' in content
+    assert 'resource "aws_ssm_parameter" "backend_non_secret"' in content
+    assert "SUPPORTDOC_QUERY_GENERATION_MODEL" in content
+    assert "/healthz" in content
+
+
+def test_root_readme_references_task1_foundation_assets() -> None:
+    content = ROOT_README.read_text(encoding="utf-8")
+
+    assert "infra/aws/task1-foundation/" in content
+    assert "docs/ops/aws_task1_foundation.md" in content


### PR DESCRIPTION
Closes #122
---

This PR implements the repo-side deliverables for **EPIC 12 / Task 1** by adding the minimum AWS foundation required for the SupportDoc RAG Chatbot MVP to move onto its locked AWS path.

The change adds a Terraform foundation stack plus operator documentation and validation helpers for:

- a shared VPC with public and private subnet tiers
- security groups that enforce `ALB -> ECS -> RDS / inference`
- a private ECR repository for the backend image
- an S3 artifacts bucket with seeded prefixes
- CloudWatch log groups for backend and inference
- a stable SSM Parameter Store prefix for non-secret runtime config
- a stable Secrets Manager naming scheme for secret runtime config
- a public ALB with HTTP-to-HTTPS redirect
- ACM certificate wiring and Route 53 alias DNS for the backend API domain

This PR is intentionally limited to the **foundation + HTTPS entry-point** slice. It does **not** deploy ECS, RDS, the inference host, or Amplify yet.

The revised EPIC locks the MVP onto a single AWS path built around **Amplify + ECS/Fargate + ALB + RDS PostgreSQL/pgvector + a private OpenAI-compatible inference endpoint**, and Task 1 specifically requires the shared AWS foundation plus HTTPS backend entry points before the later deployment tasks can proceed.

This PR turns the earlier documentation-only AWS plan into commit-tracked infrastructure assets, operator notes, and verification steps.

- `infra/aws/task1-foundation/README.md`
- `infra/aws/task1-foundation/main.tf`
- `infra/aws/task1-foundation/outputs.tf`
- `infra/aws/task1-foundation/terraform.tfvars.example`
- `infra/aws/task1-foundation/variables.tf`
- `infra/aws/task1-foundation/versions.tf`
- `docs/ops/aws_task1_foundation.md`
- `scripts/verify-aws-task1.sh`
- `tests/test_aws_task1_foundation_assets.py`
- `PR_EPIC12_TASK1_AWS_FOUNDATION.md`

- `README.md`
- `docs/architecture/aws_deployment.md`
- `docs/ops/cost_and_ops.md` ---
Changes to be committed:
	modified:   README.md
	modified:   docs/architecture/aws_deployment.md
	new file:   docs/ops/aws_task1_foundation.md
	modified:   docs/ops/cost_and_ops.md
	new file:   infra/aws/task1-foundation/README.md
	new file:   infra/aws/task1-foundation/main.tf
	new file:   infra/aws/task1-foundation/outputs.tf
	new file:   infra/aws/task1-foundation/terraform.tfvars.example
	new file:   infra/aws/task1-foundation/variables.tf
	new file:   infra/aws/task1-foundation/versions.tf
	new file:   scripts/verify-aws-task1.sh
	new file:   tests/test_aws_task1_foundation_assets.py