### PR TITLE
On branch infra/129-Bootstrap-Terraform-remote-state-GitHub-Actions-O…

### DIFF
--- a/.github/workflows/terraform-task1-foundation.yml
+++ b/.github/workflows/terraform-task1-foundation.yml
@@ -1,0 +1,186 @@
+name: terraform-task1-foundation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/terraform-task1-foundation.yml'
+      - 'infra/aws/task1-foundation/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/terraform-task1-foundation.yml'
+      - 'infra/aws/task1-foundation/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: terraform-task1-foundation-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TF_ROOT: infra/aws/task1-foundation
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  TF_IN_AUTOMATION: 'true'
+  TF_INPUT: 'false'
+  TF_VAR_aws_region: ${{ vars.AWS_REGION }}
+  TF_VAR_project: ${{ vars.TF_VAR_PROJECT }}
+  TF_VAR_environment: ${{ vars.TF_VAR_ENVIRONMENT }}
+  TF_VAR_root_domain_name: ${{ vars.TF_VAR_ROOT_DOMAIN_NAME }}
+  TF_VAR_backend_api_subdomain: ${{ vars.TF_VAR_BACKEND_API_SUBDOMAIN }}
+  TF_VAR_route53_zone_id: ${{ vars.TF_VAR_ROUTE53_ZONE_ID }}
+
+jobs:
+  plan:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.14.8
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: gha-task1-foundation-plan
+          allowed-account-ids: '675450865367'
+
+      - name: Terraform fmt
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_ROOT }}
+        run: |
+          terraform init \
+            -input=false \
+            -backend-config="bucket=${{ vars.TF_BACKEND_BUCKET }}" \
+            -backend-config="key=${{ vars.TF_BACKEND_KEY }}" \
+            -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform validate
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform validate
+
+      - name: Terraform plan
+        working-directory: ${{ env.TF_ROOT }}
+        run: |
+          terraform plan -input=false -no-color -out=tfplan
+          terraform show -no-color tfplan > plan.txt
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-task1-foundation-plan
+          path: ${{ env.TF_ROOT }}/plan.txt
+
+      - name: Comment PR with plan summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          PLAN_PATH: ${{ env.TF_ROOT }}/plan.txt
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- terraform-task1-foundation-plan -->';
+            let plan = fs.readFileSync(process.env.PLAN_PATH, 'utf8');
+            if (plan.length > 60000) {
+              plan = plan.slice(0, 60000) + '\n\n... truncated ...';
+            }
+            const body = [
+              marker,
+              '## Terraform plan — task1-foundation',
+              '',
+              '<details><summary>Show plan</summary>',
+              '',
+              '```terraform',
+              plan,
+              '```',
+              '',
+              '</details>'
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }
+
+  apply:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.14.8
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: gha-task1-foundation-apply
+          allowed-account-ids: '675450865367'
+
+      - name: Terraform fmt
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_ROOT }}
+        run: |
+          terraform init \
+            -input=false \
+            -backend-config="bucket=${{ vars.TF_BACKEND_BUCKET }}" \
+            -backend-config="key=${{ vars.TF_BACKEND_KEY }}" \
+            -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform validate
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform validate
+
+      - name: Terraform plan
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform plan -input=false -no-color -out=tfplan
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform apply -input=false -auto-approve tfplan

--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,19 @@ data/processed/indexes/
 data/evaluation/runs/
 tmp/eval/
 data/processed/chunks.jsonl
+
+# Terraform local state / overrides
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+terraform.tfvars
+terraform.tfvars.json
+*.auto.tfvars
+*.auto.tfvars.json

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ The deploy-now AWS slice is still the backend shell on ECS/ALB in fixture mode. 
 
 The canonical AWS deployment baseline for that path now lives in `docs/architecture/aws_deployment.md`, with the rendered diagram in `docs/diagrams/aws_deployment.md` and the versioned Mermaid source in `docs/diagrams/aws_deployment.mmd`.
 
-The concrete EPIC 12 / Task 1 implementation now lives under `infra/aws/task1-foundation/`, with the repo-aligned operator contract in `docs/ops/aws_task1_foundation.md` and the verification helper in `scripts/verify-aws-task1.sh`.
+The concrete EPIC 12 / Task 1 implementation now lives under `infra/aws/task1-foundation/`, with the repo-aligned operator contract in `docs/ops/aws_task1_foundation.md`, the one-time AWS bootstrap JSON artifacts under `infra/aws/task1-foundation/bootstrap/`, the GitHub OIDC workflow in `.github/workflows/terraform-task1-foundation.yml`, and the verification helper in `scripts/verify-aws-task1.sh`.
 
 For copy-ready report wording on the baseline no-fine-tuning answer, the snapshot -> parse -> chunk -> embed -> index preparation flow, and the UI/AWS handoff boundary, use `docs/validation/report_and_aws_handoff_notes.md`.
 
@@ -697,7 +697,9 @@ For copy-ready report wording on the baseline no-fine-tuning answer, the snapsho
 - `docs/validation/README.md` — validation entry point for fixture smoke, artifact smoke, container runtime smoke, cloud runtime smoke, and reviewed trust artifacts
 - `docs/architecture/aws_deployment.md` — canonical AWS deployment baseline, deploy-now scope, and deferred options
 - `infra/aws/task1-foundation/` — Terraform stack for the EPIC 12 / Task 1 AWS foundation and HTTPS entry point
-- `docs/ops/aws_task1_foundation.md` — repo-aligned Task 1 env/secret contract and naming decisions
+- `infra/aws/task1-foundation/bootstrap/` — one-time AWS bootstrap JSON artifacts for the Task 1.1 OIDC role and state-bucket policies
+- `docs/ops/aws_task1_foundation.md` — repo-aligned Task 1 env/secret contract and Task 1.1 deploy-control-plane notes
+- `.github/workflows/terraform-task1-foundation.yml` — GitHub Actions OIDC workflow for PR plan / main apply on the Task 1 foundation stack
 - `docs/diagrams/aws_deployment.md` — AWS deployment diagram
 - `docs/adr/` — architecture decisions and project rationale
 - `docs/process/hybrid_retrieval_baseline.md` — default hybrid baseline config and run command

--- a/docs/ops/aws_task1_foundation.md
+++ b/docs/ops/aws_task1_foundation.md
@@ -2,22 +2,28 @@
 
 This note is the operator-facing companion to `infra/aws/task1-foundation/`.
 
-It translates the repo's actual backend/frontend config surface into the exact AWS foundation choices needed for **EPIC 12 / Task 1**.
+It translates the repo's actual backend/frontend config surface into the exact AWS foundation choices needed for **EPIC 12 / Task 1**, plus the Task 1.1 control-plane wiring needed to deploy that stack safely with Terraform remote state and GitHub Actions OIDC.
 
 ## Selected MVP defaults
 
-The Task 1 implementation locks these defaults unless a later task proves they must change:
+The Task 1 foundation plus Task 1.1 deploy path lock these defaults unless a later task proves they must change:
 
-- **AWS region:** `us-east-1`
+- **AWS region default:** `us-west-2`
 - **environment name:** `mvp`
 - **resource naming prefix:** `supportdoc-rag-chatbot-mvp`
-- **backend API domain pattern:** `api.supportdoc-mvp.<root_domain_name>`
+- **backend API hostname pattern:** `api.<root_domain_name>`
 - **ECR repository:** `supportdoc-rag-chatbot/mvp/backend`
-- **S3 bucket pattern:** `supportdoc-rag-chatbot-mvp-<account-id>-us-east-1-artifacts`
+- **S3 bucket pattern:** `supportdoc-rag-chatbot-mvp-<account-id>-us-west-2-artifacts`
 - **SSM path prefix:** `/supportdoc-rag-chatbot/mvp`
 - **Secrets Manager name prefix:** `supportdoc-rag-chatbot/mvp`
 - **backend log group:** `/aws/supportdoc-rag-chatbot/mvp/backend`
 - **inference log group:** `/aws/supportdoc-rag-chatbot/mvp/inference`
+
+When the deploy path is wired with the real GitHub repository variables from Task 1.1, those committed defaults resolve to:
+
+- **root domain:** `supportdochq.com`
+- **exact hosted zone ID:** `Z04948001WRDOJY1UUZYV`
+- **public backend hostname:** `api.supportdochq.com`
 
 ## Network layout
 
@@ -43,6 +49,32 @@ Task 1 pins the inbound traffic chain to:
 - **ECS SG** — backend port `9001` from the ALB SG only
 - **RDS SG** — PostgreSQL `5432` from the ECS SG only
 - **inference SG** — inference port `8000` from the ECS SG only
+
+## Task 1.1 deploy-control plane
+
+Task 1.1 does not change the runtime topology. It adds the safe deployment path around the Task 1 stack:
+
+- Terraform S3 backend with `use_lockfile = true`
+- optional exact hosted-zone targeting through `route53_zone_id`
+- one GitHub OIDC-trusted IAM role for PR `plan` and `main` `apply`
+- one workflow file: `.github/workflows/terraform-task1-foundation.yml`
+- one-time AWS bootstrap JSON artifacts kept under `infra/aws/task1-foundation/bootstrap/`
+
+### GitHub repository variables expected by the workflow
+
+Set these repository **Variables** before enabling the workflow:
+
+- `AWS_REGION`
+- `AWS_ROLE_ARN`
+- `TF_BACKEND_BUCKET`
+- `TF_BACKEND_KEY`
+- `TF_VAR_PROJECT`
+- `TF_VAR_ENVIRONMENT`
+- `TF_VAR_ROOT_DOMAIN_NAME`
+- `TF_VAR_BACKEND_API_SUBDOMAIN`
+- `TF_VAR_ROUTE53_ZONE_ID`
+
+Keep long-lived AWS access keys out of GitHub for this path.
 
 ## Repo-aligned runtime contract
 
@@ -108,7 +140,14 @@ Carry these outputs into the later deployment tasks:
 The repo previously carried AWS guidance as documentation only. Task 1 now adds:
 
 - a real Terraform foundation stack under `infra/aws/task1-foundation/`
-- a concrete region default of `us-east-1`
+- a concrete region default of `us-west-2`
 - real reserved names for SSM parameters and Secrets Manager secrets
 - a concrete HTTPS ALB + ACM + Route 53 entry point
 - a verification script that checks the accepted public/private and exposure boundaries
+
+Task 1.1 layers on top of that with:
+
+- a partial S3 backend block under `infra/aws/task1-foundation/versions.tf`
+- exact hosted-zone targeting through `route53_zone_id`
+- bootstrap IAM JSON artifacts for the one-time AWS setup
+- a GitHub Actions OIDC workflow for PR `plan` and `main` `apply`

--- a/docs/ops/cost_and_ops.md
+++ b/docs/ops/cost_and_ops.md
@@ -22,7 +22,7 @@ The concrete Task 1 implementation and its exact env/secret naming contract live
 - **Secrets / config:** Secrets Manager plus SSM Parameter Store
 - **Browser hosting:** Amplify Hosting for the checked-in SPA when the separate browser-hosting slice is enabled
 
-The working assumption for planning is one U.S. commercial AWS region, now pinned to **`us-east-1` for the MVP foundation** so the networking, HTTPS edge, and runtime config naming stay consistent across later tasks.
+The working assumption for planning is one U.S. commercial AWS region, now pinned to **`us-west-2` for the MVP foundation** so the networking, HTTPS edge, and runtime config naming stay consistent across later tasks.
 
 ## Operating modes
 

--- a/infra/aws/task1-foundation/README.md
+++ b/infra/aws/task1-foundation/README.md
@@ -2,9 +2,16 @@
 
 This Terraform stack implements the **Task 1** baseline for the SupportDoc RAG Chatbot MVP using the actual runtime contract present in the repo.
 
+Task 1.1 adds the deploy-control-plane overlay around the same stack:
+
+- a partial S3 backend with native lockfile locking
+- exact hosted-zone targeting through an optional `route53_zone_id` input
+- bootstrap IAM policy JSONs for the one-time AWS setup you will do manually
+- a GitHub Actions workflow for PR `plan` and `main` `apply` via OIDC
+
 ## What it creates
 
-- one target region: `us-east-1` by default
+- one target region: `us-west-2` by default
 - one environment name: `mvp` by default
 - one shared naming convention based on `supportdoc-rag-chatbot-mvp`
 - one VPC with:
@@ -41,31 +48,67 @@ This Terraform stack implements the **Task 1** baseline for the SupportDoc RAG C
 
 These defaults are baked into this stack to keep the MVP path opinionated and fast:
 
-- **region:** `us-east-1`
+- **region:** `us-west-2`
 - **environment:** `mvp`
-- **backend API subdomain pattern:** `api.supportdoc-mvp.<root_domain_name>`
+- **backend API hostname pattern:** `api.<root_domain_name>`
 - **pgvector schema name:** `supportdoc_rag`
 - **pgvector runtime id:** `default`
 - **generation mode target:** OpenAI-compatible
 - **default model identifier:** `mistralai/Mistral-7B-Instruct-v0.3`
 
+With the Task 1.1 GitHub repository variables set to `root_domain_name=supportdochq.com` and `backend_api_subdomain=api`, the deployed hostname becomes `api.supportdochq.com`.
+
 ## Prerequisites
 
-- Terraform `>= 1.6`
+- Terraform `>= 1.10`
 - AWS credentials with permission to create the listed resources
 - an existing **public Route 53 hosted zone**
 - a real root domain name you control, for example `example.com`
+- a pre-created S3 bucket for Terraform remote state
+- a GitHub OIDC-trusted IAM role for the workflow if you want PR `plan` and `main` `apply`
 
-## Deploy
+## One-time AWS bootstrap artifacts
+
+The JSON documents you will apply manually in AWS for Task 1.1 live under:
+
+- `infra/aws/task1-foundation/bootstrap/oidc-trust-pr-and-main.json`
+- `infra/aws/task1-foundation/bootstrap/supportdoc-tfstate-s3-rw.json`
+- `infra/aws/task1-foundation/bootstrap/supportdoc-task1-foundation-apply.json`
+
+## Local deploy flow
 
 ```bash
 cd infra/aws/task1-foundation
 cp terraform.tfvars.example terraform.tfvars
 # edit terraform.tfvars so root_domain_name points to a real Route 53 zone you own
-terraform init
+# optionally set route53_zone_id to pin the exact hosted zone instead of discovering by name
+terraform init \
+  -backend-config="bucket=<terraform-state-bucket>" \
+  -backend-config="key=supportdoc-rag-chatbot/mvp/task1-foundation.tfstate" \
+  -backend-config="region=us-west-2"
 terraform plan
 terraform apply
 ```
+
+## GitHub Actions deploy flow
+
+The repo-level workflow is:
+
+- `.github/workflows/terraform-task1-foundation.yml`
+
+Set these GitHub repository **Variables** before enabling the workflow:
+
+- `AWS_REGION`
+- `AWS_ROLE_ARN`
+- `TF_BACKEND_BUCKET`
+- `TF_BACKEND_KEY`
+- `TF_VAR_PROJECT`
+- `TF_VAR_ENVIRONMENT`
+- `TF_VAR_ROOT_DOMAIN_NAME`
+- `TF_VAR_BACKEND_API_SUBDOMAIN`
+- `TF_VAR_ROUTE53_ZONE_ID`
+
+The workflow uses OIDC only. Do not add long-lived AWS access keys for this path.
 
 ## What this stack intentionally does *not* create yet
 

--- a/infra/aws/task1-foundation/bootstrap/oidc-trust-pr-and-main.json
+++ b/infra/aws/task1-foundation/bootstrap/oidc-trust-pr-and-main.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GitHubActionsPrAndMain",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::675450865367:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:pylabview/supportdoc-rag-chatbot:pull_request",
+            "repo:pylabview/supportdoc-rag-chatbot:ref:refs/heads/main"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/infra/aws/task1-foundation/bootstrap/supportdoc-task1-foundation-apply.json
+++ b/infra/aws/task1-foundation/bootstrap/supportdoc-task1-foundation-apply.json
@@ -1,0 +1,76 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VpcAlbAndSecurityGroups",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:*",
+        "elasticloadbalancing:*",
+        "acm:*",
+        "logs:*",
+        "ecr:*",
+        "ssm:*",
+        "secretsmanager:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "HostedZoneLookupAndChanges",
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetHostedZone",
+        "route53:ListHostedZonesByName",
+        "route53:ListResourceRecordSets",
+        "route53:GetChange",
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": [
+        "arn:aws:route53:::hostedzone/Z04948001WRDOJY1UUZYV",
+        "arn:aws:route53:::change/*"
+      ]
+    },
+    {
+      "Sid": "ArtifactBuckets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:GetBucketLocation",
+        "s3:GetBucketVersioning",
+        "s3:PutBucketVersioning",
+        "s3:GetEncryptionConfiguration",
+        "s3:PutEncryptionConfiguration",
+        "s3:GetBucketTagging",
+        "s3:PutBucketTagging",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::supportdoc-rag-chatbot-*",
+        "arn:aws:s3:::supportdoc-rag-chatbot-*/*"
+      ]
+    },
+    {
+      "Sid": "ListAllBucketsForProviderCalls",
+      "Effect": "Allow",
+      "Action": "s3:ListAllMyBuckets",
+      "Resource": "*"
+    },
+    {
+      "Sid": "AllowElbServiceLinkedRole",
+      "Effect": "Allow",
+      "Action": "iam:CreateServiceLinkedRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/infra/aws/task1-foundation/bootstrap/supportdoc-tfstate-s3-rw.json
+++ b/infra/aws/task1-foundation/bootstrap/supportdoc-tfstate-s3-rw.json
@@ -1,0 +1,35 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListStatePrefix",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::supportdoc-tfstate-675450865367-us-west-2",
+      "Condition": {
+        "StringEquals": {
+          "s3:prefix": "supportdoc-rag-chatbot/mvp/task1-foundation.tfstate"
+        }
+      }
+    },
+    {
+      "Sid": "ReadWriteStateFile",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::supportdoc-tfstate-675450865367-us-west-2/supportdoc-rag-chatbot/mvp/task1-foundation.tfstate"
+    },
+    {
+      "Sid": "ManageStateLockFile",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::supportdoc-tfstate-675450865367-us-west-2/supportdoc-rag-chatbot/mvp/task1-foundation.tfstate.tflock"
+    }
+  ]
+}

--- a/infra/aws/task1-foundation/main.tf
+++ b/infra/aws/task1-foundation/main.tf
@@ -9,15 +9,17 @@ data "aws_availability_zones" "available" {
 }
 
 locals {
-  root_domain_name         = trimsuffix(var.root_domain_name, ".")
-  backend_api_domain       = "${var.backend_api_subdomain}.${local.root_domain_name}"
-  name_prefix              = "${var.project}-${var.environment}"
-  ecr_repository_name      = "${var.project}/${var.environment}/backend"
-  s3_bucket_name           = lower("${var.project}-${var.environment}-${data.aws_caller_identity.current.account_id}-${var.aws_region}-artifacts")
-  ssm_parameter_prefix     = "/${var.project}/${var.environment}"
-  secrets_prefix           = "${var.project}/${var.environment}"
-  backend_log_group_name   = "/aws/${var.project}/${var.environment}/backend"
-  inference_log_group_name = "/aws/${var.project}/${var.environment}/inference"
+  root_domain_name             = trimsuffix(var.root_domain_name, ".")
+  route53_zone_id              = try(trimspace(var.route53_zone_id), "")
+  use_explicit_route53_zone_id = local.route53_zone_id != ""
+  backend_api_domain           = "${var.backend_api_subdomain}.${local.root_domain_name}"
+  name_prefix                  = "${var.project}-${var.environment}"
+  ecr_repository_name          = "${var.project}/${var.environment}/backend"
+  s3_bucket_name               = lower("${var.project}-${var.environment}-${data.aws_caller_identity.current.account_id}-${var.aws_region}-artifacts")
+  ssm_parameter_prefix         = "/${var.project}/${var.environment}"
+  secrets_prefix               = "${var.project}/${var.environment}"
+  backend_log_group_name       = "/aws/${var.project}/${var.environment}/backend"
+  inference_log_group_name     = "/aws/${var.project}/${var.environment}/inference"
 
   public_subnet_map = {
     for index, cidr in var.public_subnet_cidrs :
@@ -66,9 +68,14 @@ locals {
   )
 }
 
-data "aws_route53_zone" "public" {
+data "aws_route53_zone" "public_by_name" {
+  count        = local.use_explicit_route53_zone_id ? 0 : 1
   name         = "${local.root_domain_name}."
   private_zone = false
+}
+
+locals {
+  public_route53_zone_id = local.use_explicit_route53_zone_id ? local.route53_zone_id : data.aws_route53_zone.public_by_name[0].zone_id
 }
 
 resource "aws_vpc" "this" {
@@ -518,7 +525,7 @@ resource "aws_route53_record" "backend_validation" {
   }
 
   allow_overwrite = true
-  zone_id         = data.aws_route53_zone.public.zone_id
+  zone_id         = local.public_route53_zone_id
   name            = each.value.name
   type            = each.value.type
   ttl             = 60
@@ -544,7 +551,7 @@ resource "aws_lb_listener" "https" {
 }
 
 resource "aws_route53_record" "backend_alias_a" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = local.public_route53_zone_id
   name    = local.backend_api_domain
   type    = "A"
 
@@ -556,7 +563,7 @@ resource "aws_route53_record" "backend_alias_a" {
 }
 
 resource "aws_route53_record" "backend_alias_aaaa" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = local.public_route53_zone_id
   name    = local.backend_api_domain
   type    = "AAAA"
 

--- a/infra/aws/task1-foundation/outputs.tf
+++ b/infra/aws/task1-foundation/outputs.tf
@@ -23,6 +23,11 @@ output "backend_base_url" {
   value       = "https://${local.backend_api_domain}"
 }
 
+output "public_route53_zone_id" {
+  description = "Public Route 53 hosted zone ID used for ACM validation and ALB alias records."
+  value       = local.public_route53_zone_id
+}
+
 output "vpc_id" {
   description = "Shared MVP VPC identifier."
   value       = aws_vpc.this.id

--- a/infra/aws/task1-foundation/terraform.tfvars.example
+++ b/infra/aws/task1-foundation/terraform.tfvars.example
@@ -1,10 +1,12 @@
-aws_region            = "us-east-1"
+aws_region            = "us-west-2"
 project               = "supportdoc-rag-chatbot"
 environment           = "mvp"
 root_domain_name      = "example.com"
-backend_api_subdomain = "api.supportdoc-mvp"
+backend_api_subdomain = "api"
 
-# Keep the repo-aligned runtime defaults unless later tasks intentionally change them.
+# Optional hardening: pin the exact public hosted zone instead of discovering by name.
+route53_zone_id = null
+
 inference_model_id     = "mistralai/Mistral-7B-Instruct-v0.3"
 pgvector_schema_name   = "supportdoc_rag"
 pgvector_runtime_id    = "default"

--- a/infra/aws/task1-foundation/variables.tf
+++ b/infra/aws/task1-foundation/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "Target AWS region for the single MVP environment."
   type        = string
-  default     = "us-east-1"
+  default     = "us-west-2"
 }
 
 variable "project" {
@@ -21,10 +21,21 @@ variable "root_domain_name" {
   type        = string
 }
 
-variable "backend_api_subdomain" {
-  description = "Subdomain label prefix used to derive the public backend API FQDN."
+variable "route53_zone_id" {
+  description = "Optional exact public Route 53 hosted zone ID. Set this to pin the stack to one hosted zone instead of discovering by name."
   type        = string
-  default     = "api.supportdoc-mvp"
+  default     = null
+
+  validation {
+    condition     = try(trimspace(var.route53_zone_id), "") == "" || can(regex("^Z[A-Z0-9]+$", trimspace(var.route53_zone_id)))
+    error_message = "route53_zone_id must be null, empty, or a valid Route 53 hosted zone ID like Z123ABC456DEF."
+  }
+}
+
+variable "backend_api_subdomain" {
+  description = "Subdomain label or prefix used to derive the public backend API FQDN."
+  type        = string
+  default     = "api"
 }
 
 variable "vpc_cidr" {

--- a/infra/aws/task1-foundation/versions.tf
+++ b/infra/aws/task1-foundation/versions.tf
@@ -1,5 +1,9 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    use_lockfile = true
+  }
 
   required_providers {
     aws = {

--- a/tests/test_aws_task1_1_oidc_workflow.py
+++ b/tests/test_aws_task1_1_oidc_workflow.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/terraform-task1-foundation.yml")
+OPS_DOC = Path("docs/ops/aws_task1_foundation.md")
+INFRA_README = Path("infra/aws/task1-foundation/README.md")
+TFVARS_EXAMPLE = Path("infra/aws/task1-foundation/terraform.tfvars.example")
+
+
+def test_task1_1_workflow_uses_oidc_and_remote_state_backend_config() -> None:
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "id-token: write" in content
+    assert "issues: write" in content
+    assert "pull-requests: write" in content
+    assert "aws-actions/configure-aws-credentials@v6.1.0" in content
+    assert "role-to-assume: ${{ vars.AWS_ROLE_ARN }}" in content
+    assert '-backend-config="bucket=${{ vars.TF_BACKEND_BUCKET }}"' in content
+    assert '-backend-config="key=${{ vars.TF_BACKEND_KEY }}"' in content
+    assert "repo.full_name == github.repository" in content
+    assert "workflow_dispatch" in content
+    assert "github.event_name == 'pull_request'" in content
+
+
+def test_task1_1_docs_pin_remote_state_and_api_hostname() -> None:
+    ops_content = OPS_DOC.read_text(encoding="utf-8")
+    infra_content = INFRA_README.read_text(encoding="utf-8")
+    tfvars_content = TFVARS_EXAMPLE.read_text(encoding="utf-8")
+
+    assert "api.<root_domain_name>" in ops_content
+    assert "api.supportdochq.com" in ops_content
+    assert "route53_zone_id" in ops_content
+    assert "use_lockfile = true" in ops_content
+    assert "terraform-task1-foundation.yml" in ops_content
+    assert "bootstrap/oidc-trust-pr-and-main.json" in infra_content
+    assert "terraform init" in infra_content
+    assert 'aws_region            = "us-west-2"' in tfvars_content
+    assert 'backend_api_subdomain = "api"' in tfvars_content
+    assert "route53_zone_id = null" in tfvars_content

--- a/tests/test_aws_task1_foundation_assets.py
+++ b/tests/test_aws_task1_foundation_assets.py
@@ -10,6 +10,8 @@ TASK1_VARIABLES_TF = Path("infra/aws/task1-foundation/variables.tf")
 TASK1_OUTPUTS_TF = Path("infra/aws/task1-foundation/outputs.tf")
 TASK1_TFVARS = Path("infra/aws/task1-foundation/terraform.tfvars.example")
 TASK1_VERIFY = Path("scripts/verify-aws-task1.sh")
+TASK1_BOOTSTRAP_DIR = Path("infra/aws/task1-foundation/bootstrap")
+TASK1_WORKFLOW = Path(".github/workflows/terraform-task1-foundation.yml")
 
 
 def test_task1_foundation_assets_exist() -> None:
@@ -21,6 +23,10 @@ def test_task1_foundation_assets_exist() -> None:
         TASK1_OUTPUTS_TF,
         TASK1_TFVARS,
         TASK1_VERIFY,
+        TASK1_WORKFLOW,
+        TASK1_BOOTSTRAP_DIR / "oidc-trust-pr-and-main.json",
+        TASK1_BOOTSTRAP_DIR / "supportdoc-tfstate-s3-rw.json",
+        TASK1_BOOTSTRAP_DIR / "supportdoc-task1-foundation-apply.json",
     ]:
         assert path.exists(), f"Missing Task 1 foundation asset: {path}"
 
@@ -40,6 +46,8 @@ def test_task1_docs_pin_repo_runtime_contract() -> None:
 
 def test_task1_terraform_covers_https_foundation_requirements() -> None:
     content = TASK1_MAIN_TF.read_text(encoding="utf-8")
+    variables = TASK1_VARIABLES_TF.read_text(encoding="utf-8")
+    versions = Path("infra/aws/task1-foundation/versions.tf").read_text(encoding="utf-8")
 
     assert 'resource "aws_lb" "public"' in content
     assert 'resource "aws_acm_certificate" "backend"' in content
@@ -51,10 +59,23 @@ def test_task1_terraform_covers_https_foundation_requirements() -> None:
     assert 'resource "aws_ssm_parameter" "backend_non_secret"' in content
     assert "SUPPORTDOC_QUERY_GENERATION_MODEL" in content
     assert "/healthz" in content
+    assert 'data "aws_route53_zone" "public_by_id"' not in content
+    assert 'data "aws_route53_zone" "public_by_name"' in content
+    assert (
+        "public_route53_zone_id = local.use_explicit_route53_zone_id ? local.route53_zone_id : data.aws_route53_zone.public_by_name[0].zone_id"
+        in content
+    )
+    assert 'default     = "us-west-2"' in variables
+    assert 'default     = "api"' in variables
+    assert 'variable "route53_zone_id"' in variables
+    assert 'backend "s3"' in versions
+    assert "use_lockfile = true" in versions
 
 
 def test_root_readme_references_task1_foundation_assets() -> None:
     content = ROOT_README.read_text(encoding="utf-8")
 
     assert "infra/aws/task1-foundation/" in content
+    assert "infra/aws/task1-foundation/bootstrap/" in content
     assert "docs/ops/aws_task1_foundation.md" in content
+    assert ".github/workflows/terraform-task1-foundation.yml" in content


### PR DESCRIPTION
…IDC-deploy-path-Task1-foundation

Closes #129
---

This PR carries the local repo changes needed to make the EPIC 12 Task 1 foundation stack deployable through Terraform remote state and GitHub Actions OIDC.

Because the attached current repo zip does not yet include the Task 1 foundation assets, this overlay carries both:

- the Task 1 AWS foundation files under `infra/aws/task1-foundation/`, and
- the Task 1.1 deploy-control-plane additions around that stack.

- added a partial S3 backend block with `use_lockfile = true`
- raised the Terraform requirement to `>= 1.10.0`
- changed the default AWS region from `us-east-1` to `us-west-2`
- simplified the default backend hostname pattern from `api.supportdoc-mvp.<root_domain_name>` to `api.<root_domain_name>`
- added optional `route53_zone_id` input so Route 53 can be pinned to an exact hosted zone
- added `public_route53_zone_id` output
- kept real deployment values out of committed examples where practical

- added `.github/workflows/terraform-task1-foundation.yml`
- wired PR `terraform plan` and `main` `terraform apply`
- configured OIDC-based AWS credential usage via `aws-actions/configure-aws-credentials`
- used GitHub repository variables for backend config and Terraform variables
- added sticky PR plan comments through `actions/github-script`

Added ready-to-copy JSON artifacts under `infra/aws/task1-foundation/bootstrap/`:

- `oidc-trust-pr-and-main.json`
- `supportdoc-tfstate-s3-rw.json`
- `supportdoc-task1-foundation-apply.json`

- updated `infra/aws/task1-foundation/README.md` for remote state, OIDC workflow, and bootstrap artifacts
- updated `docs/ops/aws_task1_foundation.md` for the Task 1.1 deploy path
- updated `README.md` discoverability pointers
- updated `docs/ops/cost_and_ops.md` to reflect `us-west-2`
- added Terraform local-state ignores to `.gitignore`

- expanded `tests/test_aws_task1_foundation_assets.py`
- added `tests/test_aws_task1_1_oidc_workflow.py`

Validated locally with:

```bash
pytest --noconftest -q \
  tests/test_aws_task1_foundation_assets.py \
  tests/test_aws_task1_1_oidc_workflow.py \
  tests/test_aws_deployment_docs.py
```

Result:

- **8 passed**

Additional checks:

- GitHub Actions workflow YAML parsed successfully
- bootstrap IAM JSON files parsed successfully

- This PR does **not** create the AWS state bucket, IAM role, or attached policies in a live account. Those are still manual AWS-side changes.
- This PR does **not** deploy ECS, RDS, inference, or Amplify yet.
- The intended real deployment target remains `api.supportdochq.com` through GitHub repository variables and the exact hosted zone ID.

---

Changes to be committed:
	new file:   .github/workflows/terraform-task1-foundation.yml
	modified:   .gitignore
	modified:   README.md
	modified:   docs/ops/aws_task1_foundation.md
	modified:   docs/ops/cost_and_ops.md
	modified:   infra/aws/task1-foundation/README.md
	new file:   infra/aws/task1-foundation/bootstrap/oidc-trust-pr-and-main.json
	new file:   infra/aws/task1-foundation/bootstrap/supportdoc-task1-foundation-apply.json
	new file:   infra/aws/task1-foundation/bootstrap/supportdoc-tfstate-s3-rw.json
	modified:   infra/aws/task1-foundation/main.tf
	modified:   infra/aws/task1-foundation/outputs.tf
	modified:   infra/aws/task1-foundation/terraform.tfvars.example
	modified:   infra/aws/task1-foundation/variables.tf
	modified:   infra/aws/task1-foundation/versions.tf
	new file:   tests/test_aws_task1_1_oidc_workflow.py
	modified:   tests/test_aws_task1_foundation_assets.py